### PR TITLE
recast glyph.x and glyph.y as strings when checking if real

### DIFF
--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -23,9 +23,9 @@ class _PointLike(Glyph):
         return (self.x, self.y)
 
     def validate(self, in_dshape):
-        if not isreal(in_dshape.measure[self.x]):
+        if not isreal(in_dshape.measure[str(self.x)]):
             raise ValueError('x must be real')
-        elif not isreal(in_dshape.measure[self.y]):
+        elif not isreal(in_dshape.measure[str(self.y)]):
             raise ValueError('y must be real')
 
     def _compute_x_bounds(self, df):


### PR DESCRIPTION
This change allowed for using numeric column names in a Pandas DataFrame, the goal of #284.  It was not the change I thought would be required, changing `df.col_label` to `df['col_label']`.  I am not sure if and where the DataFrame indexing change would benefit the code but changing the two lines I did made Datashader one step easier to use for NumPy arrays.

This is essentially what I used now to plot data from an NumPy array where the first row is the x-values and all other rows are set of y-values:
```
n_data = len(data)
df = pd.DataFrame(data=data.T)
data_cols = range(1, n_data)
x_range = data[0, 0], data[0, -1]
y_range = data[1:].min(), data[1:].max()
canvas = datashader.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=300)
aggs = collections.OrderedDict((c, canvas.line(df, 0, c)) for c in data_cols)
merged = xarray.concat(aggs.values(), dim=pd.Index(data_cols, name='cols'))
img = datashader.transfer_functions.shade(merged.sum(dim='cols'), how='eq_hist')
``` 