### PR TITLE
WIP: Spread support for aggregate arrays

### DIFF
--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -114,13 +114,25 @@ def saturate(src, dst):
 
 
 def arr_operator(f):
-    """Define and register a new array composite operator"""
-    ## Should be using jit as for operator(f), but will need
-    ## to deal with different agg types (uint32, float32 at least)
-    f2 = np.vectorize(f)
+    """Define and register a new image composite operator"""
+
+    if jit_enabled:
+        f2 = nb.vectorize(f)
+        f2._compile_for_argtys(
+           (nb.types.int32, nb.types.int32))
+        f2._compile_for_argtys(
+           (nb.types.int64, nb.types.int64))
+        f2._compile_for_argtys(
+            (nb.types.float32, nb.types.float32))
+        f2._compile_for_argtys(
+            (nb.types.float64, nb.types.float64))
+        f2._frozen = True
+    else:
+        f2 = np.vectorize(f)
 
     composite_op_lookup[f.__name__] = f2
     return f2
+
 
 @arr_operator
 def source_arr(src, dst):

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -137,36 +137,40 @@ def arr_operator(f):
 
 @arr_operator
 def source_arr(src, dst):
-    if src:
-        return src
-    else:
-        return dst
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
 
-@arr_operator
-def over_arr(src, dst):
-    return src + dst
+    if src:  return src
+    else:    return dst
 
 @arr_operator
 def add_arr(src, dst):
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
     return src + dst
 
 @arr_operator
 def saturate_arr(src, dst):
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
     return src + dst
 
 @arr_operator
 def max_arr(src, dst):
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
     return max([src,  dst])
 
 @arr_operator
-def maxabs_arr(src, dst):
-    if abs(src) > abs(dst):
-        return src
-    else:
-        return dst
+def over_arr(src, dst):
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
+    return src + dst
 
 @arr_operator
 def min_arr(src, dst):
+    if np.isnan(src): return dst
+    if np.isnan(dst): return src
     return min([src,  dst])
 
 

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -11,7 +11,8 @@ import numpy as np
 import os
 
 __all__ = ('composite_op_lookup', 'over', 'add', 'saturate', 'source',
-           'over_arr', 'add_arr', 'saturate_arr', 'source_arr')
+           'over_arr', 'add_arr', 'saturate_arr', 'source_arr',
+           'max_arr', 'min_arr', 'maxabs_arr')
 
 
 @nb.jit('(uint32,)', nopython=True, nogil=True, cache=True)
@@ -152,3 +153,20 @@ def add_arr(src, dst):
 @arr_operator
 def saturate_arr(src, dst):
     return src + dst
+
+@arr_operator
+def max_arr(src, dst):
+    return max([src,  dst])
+
+@arr_operator
+def maxabs_arr(src, dst):
+    if abs(src) > abs(dst):
+        return src
+    else:
+        return dst
+
+@arr_operator
+def min_arr(src, dst):
+    return min([src,  dst])
+
+

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -137,40 +137,27 @@ def arr_operator(f):
 
 @arr_operator
 def source_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
-
     if src:  return src
     else:    return dst
 
 @arr_operator
 def add_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
     return src + dst
 
 @arr_operator
 def saturate_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
     return src + dst
 
 @arr_operator
 def max_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
     return max([src,  dst])
 
 @arr_operator
 def over_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
     return src + dst
 
 @arr_operator
 def min_arr(src, dst):
-    if np.isnan(src): return dst
-    if np.isnan(dst): return src
     return min([src,  dst])
 
 

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -11,8 +11,7 @@ import numpy as np
 import os
 
 __all__ = ('composite_op_lookup', 'over', 'add', 'saturate', 'source',
-           'over_arr', 'add_arr', 'saturate_arr', 'source_arr',
-           'max_arr', 'min_arr', 'maxabs_arr')
+           'over_arr', 'add_arr', 'saturate_arr', 'source_arr', 'max_arr', 'min_arr')
 
 
 @nb.jit('(uint32,)', nopython=True, nogil=True, cache=True)

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -114,7 +114,7 @@ def saturate(src, dst):
 
 
 def arr_operator(f):
-    """Define and register a new image composite operator"""
+    """Define and register a new array composite operator"""
 
     if jit_enabled:
         f2 = nb.vectorize(f)
@@ -158,5 +158,4 @@ def over_arr(src, dst):
 @arr_operator
 def min_arr(src, dst):
     return min([src,  dst])
-
 

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -10,8 +10,20 @@ import numba as nb
 import numpy as np
 import os
 
-__all__ = ('composite_op_lookup', 'over', 'add', 'saturate', 'source',
-           'over_arr', 'add_arr', 'saturate_arr', 'source_arr', 'max_arr', 'min_arr')
+image_operators = ('over', 'add', 'saturate', 'source')
+array_operators = ('add_arr', 'max_arr', 'min_arr', 'source_arr')
+__all__ = ('composite_op_lookup', 'validate_operator') + image_operators + array_operators
+
+
+def validate_operator(how, is_image):
+    name = how if is_image else how + '_arr'
+    if is_image:
+        if name not in image_operators:
+            raise ValueError('Operator %r not one of the supported image operators: %s'
+                            % (how, ', '.join(repr(el) for el in image_operators)))
+    elif name not in array_operators:
+        raise ValueError('Operator %r not one of the supported array operators: %s'
+                        % (how, ', '.join(repr(el[:-4]) for el in array_operators)))
 
 
 @nb.jit('(uint32,)', nopython=True, nogil=True, cache=True)
@@ -144,16 +156,8 @@ def add_arr(src, dst):
     return src + dst
 
 @arr_operator
-def saturate_arr(src, dst):
-    return src + dst
-
-@arr_operator
 def max_arr(src, dst):
     return max([src,  dst])
-
-@arr_operator
-def over_arr(src, dst):
-    return src + dst
 
 @arr_operator
 def min_arr(src, dst):

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -958,6 +958,36 @@ def test_array_dynspread():
     pytest.raises(ValueError, lambda: tf.dynspread(arr, max_px=-1))
 
 
+def test_categorical_dynspread():
+    a_data = np.array([[0, 1, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    b_data = np.array([[0, 0, 0, 0, 0],
+                       [0, 1, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    c_data = np.array([[1, 0, 0, 0, 0],
+                       [1, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 1, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    data = np.dstack([a_data, b_data, c_data])
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords + [['a', 'b', 'c']],
+                       dims=dims + ['cat'])
+    assert tf.dynspread(arr).equals(tf.spread(arr, 1))
+    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 2))
+    assert tf.dynspread(arr, threshold=0).equals(arr)
+    assert tf.dynspread(arr, max_px=0).equals(arr)
+
+
+
 def check_eq_hist_cdf_slope(eq):
     # Check that the slope of the cdf is ~1
     # Adapted from scikit-image's test for the same function

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -527,7 +527,7 @@ def test_masks():
     np.testing.assert_equal(tf._circle_mask(3), out)
 
 
-def test_spread():
+def test_rgb_spread():
     p = 0x7d00007d
     g = 0x7d00FF00
     b = 0x7dFF0000
@@ -593,6 +593,258 @@ def test_spread():
     pytest.raises(ValueError, lambda: tf.spread(img, mask=np.ones((2, 2))))
 
 
+def test_uint32_spread():
+    data = np.array([[1, 1, 0, 0, 0],
+                     [1, 2, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+
+    s = tf.spread(arr)
+    o = np.array([[5, 5, 3, 0, 0],
+                  [5, 5, 3, 0, 0],
+                  [3, 3, 5, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+    assert (s.x_axis == arr.x_axis).all()
+    assert (s.y_axis == arr.y_axis).all()
+    assert s.dims == arr.dims
+
+    s = tf.spread(arr, px=2)
+    o = np.array([[5, 5, 5, 3, 0],
+                  [5, 5, 8, 6, 3],
+                  [5, 8, 7, 5, 3],
+                  [3, 6, 5, 3, 3],
+                  [0, 3, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, shape='square')
+    o = np.array([[5, 5, 3, 0, 0],
+                  [5, 5, 3, 0, 0],
+                  [3, 3, 5, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='min')
+    o = np.array([[1, 1, 1, 0, 0],
+                  [1, 1, 1, 0, 0],
+                  [1, 1, 2, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='max')
+
+    o = np.array([[2, 2, 2, 0, 0],
+                  [2, 2, 2, 0, 0],
+                  [2, 2, 3, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+
+    mask = np.array([[1, 0, 1],
+                     [0, 1, 0],
+                     [1, 0, 1]])
+
+    data = np.array([[0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+    s = tf.spread(arr, mask=mask)
+
+    o = np.array([[0, 0, 0, 1, 0],
+                  [1, 0, 2, 0, 1],
+                  [0, 1, 0, 0, 0],
+                  [1, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, px=0)
+    np.testing.assert_equal(s.data, arr.data)
+
+    pytest.raises(ValueError, lambda: tf.spread(arr, px=-1))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones(2)))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones((2, 2))))
+
+
+def test_int32_spread():
+    data = np.array([[1, 1, 0, 0, 0],
+                     [1, 2, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='int32')
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+
+    s = tf.spread(arr)
+    o = np.array([[5, 5, 3, 0, 0],
+                  [5, 5, 3, 0, 0],
+                  [3, 3, 5, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+    assert (s.x_axis == arr.x_axis).all()
+    assert (s.y_axis == arr.y_axis).all()
+    assert s.dims == arr.dims
+
+    s = tf.spread(arr, px=2)
+    o = np.array([[5, 5, 5, 3, 0],
+                  [5, 5, 8, 6, 3],
+                  [5, 8, 7, 5, 3],
+                  [3, 6, 5, 3, 3],
+                  [0, 3, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, shape='square')
+    o = np.array([[5, 5, 3, 0, 0],
+                  [5, 5, 3, 0, 0],
+                  [3, 3, 5, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='min')
+    o = np.array([[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='max')
+
+    o = np.array([[2, 2, 2, 0, 0],
+                  [2, 2, 2, 0, 0],
+                  [2, 2, 3, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+
+    mask = np.array([[1, 0, 1],
+                     [0, 1, 0],
+                     [1, 0, 1]])
+
+    data = np.array([[0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]], dtype='int32')
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+    s = tf.spread(arr, mask=mask)
+
+    o = np.array([[0, 0, 0, 1, 0],
+                  [1, 0, 2, 0, 1],
+                  [0, 1, 0, 0, 0],
+                  [1, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, px=0)
+    np.testing.assert_equal(s.data, arr.data)
+
+    pytest.raises(ValueError, lambda: tf.spread(arr, px=-1))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones(2)))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones((2, 2))))
+
+
+def test_float32_spread():
+    data = np.array([[1, 1, np.nan, np.nan, np.nan],
+                     [1, 2, np.nan, np.nan, np.nan],
+                     [np.nan, np.nan, np.nan, np.nan, np.nan],
+                     [np.nan, np.nan, np.nan, 3, np.nan],
+                     [np.nan, np.nan, np.nan, np.nan, np.nan]], dtype='float32')
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+
+    s = tf.spread(arr)
+    o = np.array([[5, 5, 3, np.nan, np.nan],
+                  [5, 5, 3, np.nan, np.nan],
+                  [3, 3, 5, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+    assert (s.x_axis == arr.x_axis).all()
+    assert (s.y_axis == arr.y_axis).all()
+    assert s.dims == arr.dims
+
+    s = tf.spread(arr, px=2)
+    o = np.array([[5, 5, 5, 3, np.nan],
+                  [5, 5, 8, 6, 3],
+                  [5, 8, 7, 5, 3],
+                  [3, 6, 5, 3, 3],
+                  [np.nan, 3, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, shape='square')
+    o = np.array([[5, 5, 3, np.nan, np.nan],
+                  [5, 5, 3, np.nan, np.nan],
+                  [3, 3, 5, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3]])
+
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='min')
+    o = np.array([[1, 1, 1, np.nan, np.nan],
+                  [1, 1, 1, np.nan, np.nan],
+                  [1, 1, 2, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, how='max')
+
+    o = np.array([[2, 2, 2, np.nan, np.nan],
+                  [2, 2, 2, np.nan, np.nan],
+                  [2, 2, 3, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3],
+                  [np.nan, np.nan, 3, 3, 3]])
+    np.testing.assert_equal(s.data, o)
+
+
+    mask = np.array([[1, 0, 1],
+                     [0, 1, 0],
+                     [1, 0, 1]])
+    data = np.array([[np.nan, np.nan, np.nan, 1, np.nan],
+                     [np.nan, np.nan, np.nan, np.nan, np.nan],
+                     [np.nan, 1, np.nan, np.nan, np.nan],
+                     [np.nan, np.nan, np.nan, np.nan, np.nan],
+                     [np.nan, np.nan, np.nan, np.nan, np.nan]], dtype='float32')
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+    s = tf.spread(arr, mask=mask)
+
+
+    o = np.array([[0, 0, 0, 1, 0],
+                  [1, 0, 2, 0, 1],
+                  [0, 1, 0, 0, 0],
+                  [1, 0, 1, 0, 0],
+                  [0, 0, 0, 0, 0]])
+
+    o = np.array([[np.nan, np.nan, np.nan, 1, np.nan],
+                  [1, np.nan, 2, np.nan, 1],
+                  [np.nan, 1, np.nan, np.nan, np.nan],
+                  [1, np.nan, 1, np.nan, np.nan],
+                  [np.nan, np.nan, np.nan, np.nan, np.nan]])
+    np.testing.assert_equal(s.data, o)
+
+    s = tf.spread(arr, px=0)
+    np.testing.assert_equal(s.data, arr.data)
+
+    pytest.raises(ValueError, lambda: tf.spread(arr, px=-1))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones(2)))
+    pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones((2, 2))))
+
+
 def test_rgb_density():
     b = 0xffff0000
     data = np.full((4, 4), b, dtype='uint32')
@@ -603,6 +855,26 @@ def test_rgb_density():
     assert tf._rgb_density(data) == 0
     data[2, 1] = data[1, 2] = data[1, 1] = b
     assert np.allclose(tf._rgb_density(data), 3./8.)
+
+def test_int_array_density():
+    data = np.ones((4, 4), dtype='uint32')
+    assert tf._array_density(data, float_type=False) == 1.0
+    data = np.zeros((4, 4), dtype='uint32')
+    assert tf._array_density(data, float_type=False) == np.inf
+    data[2, 2] = 1
+    assert tf._array_density(data, float_type=False) == 0
+    data[2, 1] = data[1, 2] = data[1, 1] = 1
+    assert np.allclose(tf._array_density(data, float_type=False), 3./8.)
+
+def test_float_array_density():
+    data = np.ones((4, 4), dtype='float32')
+    assert tf._array_density(data, float_type=True) == 1.0
+    data = np.full((4, 4), np.nan, dtype='float32')
+    assert tf._array_density(data, float_type=True) == np.inf
+    data[2, 2] = 1
+    assert tf._array_density(data, float_type=True) == 0
+    data[2, 1] = data[1, 2] = data[1, 1] = 1
+    assert np.allclose(tf._array_density(data, float_type=True), 3./8.)
 
 
 def test_dynspread():

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -593,16 +593,16 @@ def test_spread():
     pytest.raises(ValueError, lambda: tf.spread(img, mask=np.ones((2, 2))))
 
 
-def test_density():
+def test_rgb_density():
     b = 0xffff0000
     data = np.full((4, 4), b, dtype='uint32')
-    assert tf._density(data) == 1.0
+    assert tf._rgb_density(data) == 1.0
     data = np.zeros((4, 4), dtype='uint32')
-    assert tf._density(data) == np.inf
+    assert tf._rgb_density(data) == np.inf
     data[2, 2] = b
-    assert tf._density(data) == 0
+    assert tf._rgb_density(data) == 0
     data[2, 1] = data[1, 2] = data[1, 1] = b
-    assert np.allclose(tf._density(data), 3./8.)
+    assert np.allclose(tf._rgb_density(data), 3./8.)
 
 
 def test_dynspread():

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -845,6 +845,53 @@ def test_float32_spread():
     pytest.raises(ValueError, lambda: tf.spread(arr, mask=np.ones((2, 2))))
 
 
+def test_categorical_spread():
+    a_data = np.array([[0, 1, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    b_data = np.array([[0, 0, 0, 0, 0],
+                       [0, 2, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    c_data = np.array([[0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0],
+                       [0, 0, 0, 3, 0],
+                       [0, 0, 0, 0, 0]], dtype='int32')
+
+    data = np.dstack([a_data, b_data, c_data])
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords + [['a', 'b', 'c']],
+                       dims=dims + ['cat'])
+
+    s = tf.spread(arr)
+    o = np.array([[1, 1, 1, 0, 0],
+                  [1, 1, 1, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0]])
+    np.testing.assert_equal(s.sel(cat='a').data, o)
+
+    o = np.array([[2, 2, 2, 0, 0],
+                  [2, 2, 2, 0, 0],
+                  [2, 2, 2, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0]])
+    np.testing.assert_equal(s.sel(cat='b').data, o)
+
+    o = np.array([[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3],
+                  [0, 0, 3, 3, 3]])
+    np.testing.assert_equal(s.sel(cat='c').data, o)
+
+
 def test_rgb_density():
     b = 0xffff0000
     data = np.full((4, 4), b, dtype='uint32')

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -877,7 +877,7 @@ def test_float_array_density():
     assert np.allclose(tf._array_density(data, float_type=True), 3./8.)
 
 
-def test_dynspread():
+def test_rgb_dynspread():
     b = 0xffff0000
     data = np.array([[b, b, 0, 0, 0],
                      [b, b, 0, 0, 0],
@@ -893,6 +893,22 @@ def test_dynspread():
 
     pytest.raises(ValueError, lambda: tf.dynspread(img, threshold=1.1))
     pytest.raises(ValueError, lambda: tf.dynspread(img, max_px=-1))
+
+def test_array_dynspread():
+    data = np.array([[1, 1, 0, 0, 0],
+                     [1, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    coords = [np.arange(5), np.arange(5)]
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+    assert tf.dynspread(arr).equals(tf.spread(arr, 1))
+    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 2))
+    assert tf.dynspread(arr, threshold=0).equals(arr)
+    assert tf.dynspread(arr, max_px=0).equals(arr)
+
+    pytest.raises(ValueError, lambda: tf.dynspread(arr, threshold=1.1))
+    pytest.raises(ValueError, lambda: tf.dynspread(arr, max_px=-1))
 
 
 def check_eq_hist_cdf_slope(eq):

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -756,8 +756,8 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how='over', name=Non
         elif len(img.shape) == 2:
             density = _array_density(out.data, float_type)
         else:
-            masked = np.isnan(out) if float_type else (out == 0)
-            flat_mask = np.sum(masked, axis=2, dtype=img.dtype)
+            masked = np.logical_not(np.isnan(out)) if float_type else (out != 0)
+            flat_mask = np.sum(masked, axis=2, dtype='uint32')
             density = _array_density(flat_mask.data, False)
         if density >= threshold:
             break

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -535,7 +535,7 @@ def set_background(img, color=None, name=None):
     return Image(data, coords=img.coords, dims=img.dims, name=name)
 
 
-def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
+def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
     """Spread pixels in an image.
 
     Spreading expands each pixel a certain number of pixels on all sides
@@ -550,7 +550,9 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
     shape : str, optional
         The shape to spread by. Options are 'circle' [default] or 'square'.
     how : str, optional
-        The name of the compositing operator to use when combining pixels.
+        The name of the compositing operator to use when combining
+        pixels. Default of None uses 'over' operator for Image objects
+        and 'add' operator otherwise.
     mask : ndarray, shape (M, M), optional
         The mask to spread over. If provided, this mask is used instead of
         generating one based on `px` and `shape`. Must be a square array
@@ -575,6 +577,8 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
         raise ValueError("mask must be a square 2 dimensional ndarray with "
                          "odd dimensions.")
         mask = mask if mask.dtype == 'bool' else mask.astype('bool')
+    if how is None:
+        how = 'over' if is_image else 'add'
 
     w = mask.shape[0]
     extra = w // 2

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -759,7 +759,7 @@ def _array_density(arr):
                     for j in range(x - 1, x + 2):
                         if not np.isnan(arr[i, j]):
                             total += 1
-        return (total - cnt)/(cnt * 8) if cnt else np.inf
+    return (total - cnt)/(cnt * 8) if cnt else np.inf
 
 
 @nb.jit(nopython=True, nogil=True, cache=True)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -580,18 +580,17 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None, stencil=
     M, N = img.shape
     float_type = img.dtype in [np.float32, np.float64]
     if (not is_image) and stencil:
-        extra = w // 2
         kernel = _build_stencil_kernel(how,  w, float_type, img.dtype == np.uint32)
-        out = np.zeros((M + 2*extra, N + 2*extra)).astype(img.dtype)
+        out = np.zeros((M + 2*w, N + 2*w)).astype(img.dtype)
         if float_type:
-            out = np.full((M + 2*extra, N + 2*extra), np.nan).astype(img.dtype)
-            padded_img = np.full((M + 2*extra, N + 2*extra), np.nan, dtype=img.dtype)
+            out = np.full((M + 2*w, N + 2*w), np.nan).astype(img.dtype)
+            padded_img = np.full((M + 2*w, N + 2*w), np.nan, dtype=img.dtype)
         else:
-            out = np.zeros((M + 2*extra, N + 2*extra)).astype(img.dtype)
-            padded_img = np.zeros((M + 2*extra, N + 2*extra), dtype=img.dtype)
-        padded_img[extra:extra+M, extra:extra+N] = img
+            out = np.zeros((M + 2*w, N + 2*w)).astype(img.dtype)
+            padded_img = np.zeros((M + 2*w, N + 2*w), dtype=img.dtype)
+        padded_img[w:w+M, w:w+N] = img
         kernel(padded_img, mask, out=out)
-        out = out[extra:extra+M, extra:extra+N]
+        out = out[w:w+M, w:w+N]
     else:
         extra = w // 2
         buf = np.zeros((M + 2*extra, N + 2*extra),

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -600,7 +600,9 @@ def _build_spread_kernel(how, is_image):
             for x in range(N):
                 el = arr[y, x]
                 # Skip if data is transparent
-                if (not is_image) or ((el >> 24) & 255):
+                process_image = is_image and ((int(el) >> 24) & 255) # Transparent pixel
+                process_array = (not is_image) and (not np.isnan(el))
+                if process_image or process_array:
                     for i in range(w):
                         for j in range(w):
                             # Skip if mask is False at this value

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -582,6 +582,7 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
 
     w = mask.shape[0]
     extra = w // 2
+    M, N = img.shape[:2]
     padded_shape = (M + 2*extra, N + 2*extra)
     float_type = img.dtype in [np.float32, np.float64]
 
@@ -593,7 +594,6 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
         kernel = _build_int_kernel(how, w, img.dtype == np.uint32)
 
     if is_image:
-        M, N = img.shape
         buf = np.zeros(padded_shape, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
@@ -608,9 +608,8 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     else:
-        M, N, O = img.shape
         layers = []
-        for category in range(O):
+        for category in range(img.shape[2]):
             layer = img[:,:,category]
             if float_type:
                 buf = np.full(padded_shape, np.nan, dtype=img.dtype)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -615,7 +615,7 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
                 buf = np.zeros(padded_shape, dtype=layer.dtype)
             kernel(layer.data, mask, buf)
             layers.append(buf[extra:-extra, extra:-extra].copy())
-            out = np.dstack(layers)
+        out = np.dstack(layers)
 
     return img.__class__(out, dims=img.dims, coords=img.coords, name=name)
 

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -718,7 +718,7 @@ _mask_lookup = {'square': _square_mask,
                 'circle': _circle_mask}
 
 
-def dynspread(img, threshold=0.5, max_px=3, shape='circle', how='over', name=None):
+def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None):
     """Spread pixels in an image dynamically based on the image density.
 
     Spreading expands each pixel a certain number of pixels on all sides
@@ -740,7 +740,9 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how='over', name=Non
     shape : str, optional
         The shape to spread by. Options are 'circle' [default] or 'square'.
     how : str, optional
-        The name of the compositing operator to use when combining pixels.
+        The name of the compositing operator to use when combining
+        pixels. Default of None uses 'over' operator for Image objects
+        and 'add' operator otherwise.
     """
     is_image = isinstance(img, Image)
     if not 0 <= threshold <= 1:

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -616,7 +616,7 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
             layers.append(buf[extra:-extra, extra:-extra].copy())
             out = np.dstack(layers)
 
-   return img.__class__(out, dims=img.dims, coords=img.coords, name=name)
+    return img.__class__(out, dims=img.dims, coords=img.coords, name=name)
 
 
 @tz.memoize

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -544,7 +544,7 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
 
     Parameters
     ----------
-    img : Image
+    img : Image or DataArray
     px : int, optional
         Number of pixels to spread on all sides
     shape : str, optional

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -544,7 +544,7 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
 
     Parameters
     ----------
-    img : Image or DataArray
+    img : Image or other DataArray
     px : int, optional
         Number of pixels to spread on all sides
     shape : str, optional

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -15,7 +15,7 @@ import xarray as xr
 from PIL.Image import fromarray
 
 from datashader.colors import rgb, Sets1to3
-from datashader.composite import composite_op_lookup, over
+from datashader.composite import composite_op_lookup, over, validate_operator
 from datashader.utils import nansum_missing, ngjit, orient_array
 
 try:
@@ -625,8 +625,8 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
 @tz.memoize
 def _build_int_kernel(how, mask_size, ignore_zeros):
     """Build a spreading kernel for a given composite operator"""
-    op_name = how + "_arr"
-    op = composite_op_lookup[op_name]
+    validate_operator(how, is_image=False)
+    op = composite_op_lookup[how + "_arr"]
     @ngjit
     def stencilled(arr, mask, out):
         M, N = arr.shape
@@ -649,8 +649,8 @@ def _build_int_kernel(how, mask_size, ignore_zeros):
 @tz.memoize
 def _build_float_kernel(how, mask_size):
     """Build a spreading kernel for a given composite operator"""
-    op_name = how + "_arr"
-    op = composite_op_lookup[op_name]
+    validate_operator(how, is_image=False)
+    op = composite_op_lookup[how + "_arr"]
     @ngjit
     def stencilled(arr, mask, out):
         M, N = arr.shape
@@ -673,8 +673,8 @@ def _build_float_kernel(how, mask_size):
 @tz.memoize
 def _build_spread_kernel(how, is_image):
     """Build a spreading kernel for a given composite operator"""
-    op_name = how + ("" if is_image else "_arr")
-    op = composite_op_lookup[op_name]
+    validate_operator(how, is_image=True)
+    op = composite_op_lookup[how + ("" if is_image else "_arr")]
 
     @ngjit
     def kernel(arr, mask, out):

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -670,34 +670,6 @@ _mask_lookup = {'square': _square_mask,
                 'circle': _circle_mask}
 
 
-
-# Option to normalize accumulator?
-
- # img.data.astype('uint32')
- 
-# @tz.memoize
-# def _build_stencil_kernel(how, is_image, mask_size):
-#     """Build a spreading kernel for a given composite operator"""
-#     op_name = how + ("" if is_image else "_arr")
-#     op = composite_op_lookup[op_name]
-
-#     @nb.stencil(standard_indexing=("mask",),
-#                 neighborhood =((0, mask_size), (0, mask_size)))
-#     def stencilled(arr, mask):
-#         el = arr[0,0]
-#         process_image = is_image and ((int(el) >> 24) & 255) # Transparent pixel
-#         process_array = (not is_image) and (not np.isnan(el))
-#         weight = 0
-#         for i in range(mask_size):
-#             for j in range(mask_size):
-#                 if mask[i][j] and (process_image or process_array):
-#                     weight += mask[i][j]
-#         normalized_weight = weight / len(mask)
-#         return el * normalized_weight
-
-#     return stencilled
-
-
 def dynspread(img, threshold=0.5, max_px=3, shape='circle', how='over', name=None):
     """Spread pixels in an image dynamically based on the image density.
 

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -616,10 +616,7 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
             layers.append(buf[extra:-extra, extra:-extra].copy())
             out = np.dstack(layers)
 
-    if is_image:
-        return Image(out, dims=img.dims, coords=img.coords, name=name)
-    else:
-        return xr.DataArray(out, dims=img.dims, coords=img.coords, name=name)
+   return img.__class__(out, dims=img.dims, coords=img.coords, name=name)
 
 
 @tz.memoize
@@ -638,7 +635,7 @@ def _build_int_kernel(how, mask_size, ignore_zeros):
                         if mask[i, j]:
                             if ignore_zeros and el==0:
                                 result = out[i + y, j + x]
-                            elif ignore_zeros  and out[i + y, j + x]==0:
+                            elif ignore_zeros and out[i + y, j + x]==0:
                                 result = el
                             else:
                                 result = op(el, out[i + y, j + x])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -616,7 +616,10 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
             layers.append(buf[extra:-extra, extra:-extra].copy())
             out = np.dstack(layers)
 
-    return Image(out, dims=img.dims, coords=img.coords, name=name)
+    if is_image:
+        return Image(out, dims=img.dims, coords=img.coords, name=name)
+    else:
+        return xr.DataArray(out, dims=img.dims, coords=img.coords, name=name)
 
 
 @tz.memoize

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -578,6 +578,7 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
 
     w = mask.shape[0]
     extra = w // 2
+    padded_shape = (M + 2*extra, N + 2*extra)
     float_type = img.dtype in [np.float32, np.float64]
 
     if is_image:
@@ -589,18 +590,17 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
 
     if is_image:
         M, N = img.shape
-        buf = np.zeros((M + 2*extra, N + 2*extra),
-                       dtype='uint32' if is_image else img.dtype)
+        buf = np.zeros(padded_shape, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     elif float_type:
         M, N = img.shape
-        buf = np.full((M + 2*extra, N + 2*extra), np.nan, dtype=img.dtype)
+        buf = np.full(padded_shape, np.nan, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     elif len(img.shape)==2:
         M, N = img.shape
-        buf = np.zeros((M + 2*extra, N + 2*extra), dtype=img.dtype)
+        buf = np.zeros(padded_shape, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     else:
@@ -609,9 +609,9 @@ def spread(img, px=1, shape='circle', how='over', mask=None, name=None):
         for category in range(O):
             layer = img[:,:,category]
             if float_type:
-                buf = np.full((M + 2*extra, N + 2*extra), np.nan, dtype=img.dtype)
+                buf = np.full(padded_shape, np.nan, dtype=img.dtype)
             else:
-                buf = np.zeros((M + 2*extra, N + 2*extra), dtype=layer.dtype)
+                buf = np.zeros(padded_shape, dtype=layer.dtype)
             kernel(layer.data, mask, buf)
             layers.append(buf[extra:-extra, extra:-extra].copy())
             out = np.dstack(layers)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -598,12 +598,10 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     elif float_type:
-        M, N = img.shape
         buf = np.full(padded_shape, np.nan, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()
     elif len(img.shape)==2:
-        M, N = img.shape
         buf = np.zeros(padded_shape, dtype=img.dtype)
         kernel(img.data, mask, buf)
         out = buf[extra:-extra, extra:-extra].copy()


### PR DESCRIPTION
Previously, spreading has been supported only for Image objects, working directly on RGBA pixels.  As a result, it has not been available for use with the HoloViews rasterizing operation, which returns aggregate arrays rather than Images.

As proposed in https://github.com/holoviz/datashader/issues/326, this PR adds a set of array spreading operators and allows spread to accept either an image or an aggregate array.

Remaining issues:

- [x] Special handling will be needed for categorical aggregates, which are stacks of regular aggregates (e.g. `aggc` in 2_Pipeline.ipynb)
- [x] dynspread is not yet supported for aggregate arrays; changes will be needed to `_density()` in transfer_functions.py
- [x] Spreading for aggregates is currently only supported when Numba is disabled, `composite.arr_operator(f)` doesn't currently have the type-specific Numba compilation code from `composite.operator(f)`, and it will need to handle whatever datatypes are supported for aggregations (i32, i64, f32, f64? Not sure.). Spreading is remarkably slow without Numba!
- [x] How to interpret the various spreading operators for the aggregate case is open for discussion. There are four different operators defined for images, but right now all those operators are defined for aggregates as only one of two different behaviors, with source_arr returning src if truthy, and else dest, and the rest all returning src+dst.  Is this correct/useful/the only possibility?
- [ ] Need to update examples/getting_started/2_Pipeline.ipynb to explain agg spreading. Explaining it will be tricky, because spreading is currently explained at the image level, which is in a different section of the pipeline from aggregates; spreading discussion either needs to move to the aggregate stage and then be expanded later when discussed for images (which have different allowable operations), or the other way around (pointing forward to the image section from the aggregates section).
- [x] Presumably need to update the `spread()` operation in HoloViews to allow it to be used with `rasterize()` output (hv.Image) instead of just `spread()` output (hv.RGB).