### PR TITLE
GPU testing improvements

### DIFF
--- a/datashader/tests/benchmarks/test_canvas.py
+++ b/datashader/tests/benchmarks/test_canvas.py
@@ -1,14 +1,19 @@
 import pytest
-
+import os
 import numpy as np
 import pandas as pd
 
 import datashader as ds
 
+if "DATASHADER_TEST_GPU" in os.environ:
+    test_gpu = bool(int(os.environ["DATASHADER_TEST_GPU"]))
+else:
+    test_gpu = None
+
 
 @pytest.fixture
 def time_series():
-    n = 10**6
+    n = 10**7
     signal = np.random.normal(0, 0.3, size=n).cumsum() + 50
     noise = lambda var, bias, n: np.random.normal(bias, var, n)
     ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
@@ -26,5 +31,23 @@ def test_line(benchmark, time_series):
 
 @pytest.mark.benchmark(group="canvas")
 def test_points(benchmark, time_series):
+    cvs = ds.Canvas(plot_height=300, plot_width=900)
+    benchmark(cvs.points, time_series, 'x', 'y')
+
+
+@pytest.mark.skipif(test_gpu is not True, reason="DATASHADER_TEST_GPU not set")
+@pytest.mark.benchmark(group="canvas")
+def test_line_gpu(benchmark, time_series):
+    from cudf import from_pandas
+    time_series = from_pandas(time_series)
+    cvs = ds.Canvas(plot_height=300, plot_width=900)
+    benchmark(cvs.line, time_series, 'x', 'y')
+
+
+@pytest.mark.skipif(test_gpu is not True, reason="DATASHADER_TEST_GPU not set")
+@pytest.mark.benchmark(group="canvas")
+def test_points_gpu(benchmark, time_series):
+    from cudf import from_pandas
+    time_series = from_pandas(time_series)
     cvs = ds.Canvas(plot_height=300, plot_width=900)
     benchmark(cvs.points, time_series, 'x', 'y')


### PR DESCRIPTION
## Overview
The test suite now checks for the presence of a `DATASHADER_TEST_GPU` environment variable. When this is set to `1`, the test suite will fail if GPU tests are not run. When set to `0`, GPU tests will not run even if a GPU is available. When not set, GPU tests will run if `cudf` and `cupy` are installed.

Additionally, two new benchmark tests are added to `datashader/tests/benchmarks/test_canvas.py`. These are GPU versions of the existing `test_points` and `test_line` benchmarks.  The new `test_points_gpu` and `test_line_gpu` tests will only run if `DATASHADER_TEST_GPU` is set to `1`.

## Example
Here are the steps to run the GPU tests from a CUDA compatible machine. Note that these libraries are moving fast, so it's a good idea to explicitly pin dependency versions.  The combination below is the newest stable versions of everything except `numba` (numba is currently at 0.46).  Numba 0.46 made a change to the cuda array interface (https://github.com/numba/numba/pull/4609) that's not supported in the lastest stable version of cupy (which is 6.5.0 at the moment).  `cupy` accommodates this change on `master`, so when the next version of `cupy` is released, I expect it will be fine to update to the lastest version of numba as well.

```
conda create -n datashader_gpu_tests -c defaults -c conda-forge -c rapidsai cupy=6.5.0 cudf=0.10 dask-cudf=0.10.0 numba=0.45 pytest pytest-benchmark
conda activate datashader_gpu_tests
conda install -c pyviz/label/dev --only-deps datashader
export DATASHADER_TEST_GPU=1
pytest datashader/tests/
```

To check that the GPU tests were executed and to spot-check the GPU performance, look for the `benchmark 'canvas'` results table toward the end of the pytest output. Here's what it looks like on my machine:

```
------------------------------------------------------------------------------ benchmark 'canvas': 4 tests -------------------------------------------------------------------------------
Name (time in ms)          Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_points_gpu         4.4676 (1.0)        5.0742 (1.0)        4.6613 (1.0)      0.1932 (2.03)       4.6151 (1.0)      0.0870 (1.0)           2;1  214.5327 (1.0)           7           1
test_line_gpu           8.0951 (1.81)       8.2877 (1.63)       8.2002 (1.76)     0.0952 (1.0)        8.2416 (1.79)     0.1805 (2.08)          2;0  121.9479 (0.57)          5           1
test_points            57.2529 (12.82)     58.1536 (11.46)     57.7428 (12.39)    0.3414 (3.59)      57.7395 (12.51)    0.4716 (5.42)          2;0   17.3182 (0.08)          5           1
test_line             333.6861 (74.69)    341.3802 (67.28)    336.2218 (72.13)    2.9798 (31.29)    335.4188 (72.68)    2.3706 (27.26)         1;1    2.9742 (0.01)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

As you can see, for my hardware `test_points_gpu` is about 12x faster than `test_points` and `test_line_gpu` is about 42x faster than `test_line`.

cc @jbednar