### PR TITLE
GPU Quadmesh support

### DIFF
--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -5,13 +5,18 @@ from datashader.core import bypixel
 import xarray as xr
 from datashader.utils import Dispatcher
 
+try:
+    import cupy
+except ImportError:
+    cupy = None
 
 glyph_dispatch = Dispatcher()
 
 
 @bypixel.pipeline.register(xr.Dataset)
 def xarray_pipeline(df, schema, canvas, glyph, summary):
-    return glyph_dispatch(glyph, df, schema, canvas, summary)
+    cuda = cupy and isinstance(df[glyph.name].data, cupy.ndarray)
+    return glyph_dispatch(glyph, df, schema, canvas, summary, cuda)
 
 
 # Default to default pandas implementation

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -3,15 +3,16 @@ import numpy as np
 
 from datashader.glyphs.glyph import Glyph
 from datashader.resampling import infer_interval_breaks
-from datashader.transfer_functions._cuda_utils import cuda_args
 from datashader.utils import isreal, ngjit
 import numba
 from numba import cuda
 
 try:
     import cupy
+    from datashader.transfer_functions._cuda_utils import cuda_args
 except ImportError:
     cupy = None
+    cuda_args = None
 
 
 def _cuda_mapper(mapper):

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -3,7 +3,31 @@ import numpy as np
 
 from datashader.glyphs.glyph import Glyph
 from datashader.resampling import infer_interval_breaks
+from datashader.transfer_functions._cuda_utils import cuda_args
 from datashader.utils import isreal, ngjit
+import numba
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+
+def _cuda_mapper(mapper):
+    @cuda.jit
+    def kernel(in_array, out_array):
+        i, j = cuda.grid(2)
+        if i < out_array.shape[0] and j < out_array.shape[1]:
+            out_array[i, j] = mapper(in_array[i, j])
+
+    def cuda_map(in_array):
+        out_array = cupy.zeros(in_array.shape, dtype='float64')
+        in_array = cuda.to_device(in_array)
+        kernel[cuda_args(in_array.shape)](in_array, out_array)
+        return out_array
+
+    return cuda_map
 
 
 class _QuadMeshLike(Glyph):
@@ -63,51 +87,80 @@ class QuadMeshRectilinear(_QuadMeshLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         x_name = self.x
         y_name = self.y
+        name = self.name
 
         @ngjit
         @self.expand_aggs_and_cols(append)
-        def _extend(xs, ys, *aggs_and_cols):
+        def perform_extend(i, j, xs, ys, *aggs_and_cols):
+            x0i, x1i = xs[i], xs[i + 1]
+            # Make sure x0 <= x1
+            if x0i > x1i:
+                x0i, x1i = x1i, x0i
+            # Make sure single pixel quads are represented
+            if x0i == x1i:
+                x1i += 1
+            y0i, y1i = ys[j], ys[j + 1]
+            # Make sure  y0 <= y1
+            if y0i > y1i:
+                y0i, y1i = y1i, y0i
+            # Make sure single pixel quads are represented
+            if y0i == y1i:
+                y1i += 1
+            # x1i and y1i are not included in the iteration. this
+            # serves to avoid overlapping quads and it avoids the need
+            # for special handling of quads that end on exactly on the
+            # upper bound.
+            for xi in range(x0i, x1i):
+                for yi in range(y0i, y1i):
+                    append(j, i, xi, yi, *aggs_and_cols)
+
+        @cuda.jit
+        @self.expand_aggs_and_cols(append)
+        def extend_cuda(xs, ys, *aggs_and_cols):
+            i, j = cuda.grid(2)
+            if i < (xs.shape[0] - 1) and j < (ys.shape[0] - 1):
+                perform_extend(i, j, xs, ys, *aggs_and_cols)
+
+        @ngjit
+        @self.expand_aggs_and_cols(append)
+        def extend_cpu(xs, ys, *aggs_and_cols):
             for i in range(len(xs) - 1):
-                x0i, x1i = xs[i], xs[i + 1]
-
-                # Make sure x0 <= x1
-                if x0i > x1i:
-                    x0i, x1i = x1i, x0i
-
-                # Make sure single pixel quads are represented
-                if x0i == x1i:
-                    x1i += 1
-
                 for j in range(len(ys) - 1):
-
-                    y0i, y1i = ys[j], ys[j + 1]
-
-                    # Make sure  y0 <= y1
-                    if y0i > y1i:
-                        y0i, y1i = y1i, y0i
-
-                    # Make sure single pixel quads are represented
-                    if y0i == y1i:
-                        y1i += 1
-
-                    # x1i and y1i are not included in the iteration. this
-                    # serves to avoid overlapping quads and it avoids the need
-                    # for special handling of quads that end on exactly on the
-                    # upper bound.
-                    for xi in range(x0i, x1i):
-                        for yi in range(y0i, y1i):
-                            append(j, i, xi, yi, *aggs_and_cols)
+                    perform_extend(i, j, xs, ys, *aggs_and_cols)
 
         def extend(aggs, xr_ds, vt, bounds):
+            from datashader.core import LinearAxis
+            use_cuda = cupy and isinstance(xr_ds[name].data, cupy.ndarray)
+
+            xs = xr_ds[x_name].values
+            ys = xr_ds[y_name].values
+            if use_cuda:
+                xs = cupy.array(xs)
+                ys = cupy.array(ys)
+
+                x_mapper2 = _cuda_mapper(x_mapper)
+                y_mapper2 = _cuda_mapper(y_mapper)
+            else:
+                x_mapper2 = x_mapper
+                y_mapper2 = y_mapper
+
             # Convert from bin centers to interval edges
-            x_breaks = infer_interval_breaks(xr_ds[x_name].values)
-            y_breaks = infer_interval_breaks(xr_ds[y_name].values)
+            x_breaks = infer_interval_breaks(xs)
+            y_breaks = infer_interval_breaks(ys)
 
             x0, x1, y0, y1 = bounds
             xspan = x1 - x0
             yspan = y1 - y0
-            xscaled = (x_mapper(x_breaks) - x0) / xspan
-            yscaled = (y_mapper(y_breaks) - y0) / yspan
+
+            if x_mapper is LinearAxis.mapper:
+                xscaled = (x_breaks - x0) / xspan
+            else:
+                xscaled = (x_mapper2(x_breaks) - x0) / xspan
+
+            if y_mapper is LinearAxis.mapper:
+                yscaled = (y_breaks - y0) / yspan
+            else:
+                yscaled = (y_mapper2(y_breaks) - y0) / yspan
 
             xmask = np.where((xscaled >= 0) & (xscaled <= 1))
             ymask = np.where((yscaled >= 0) & (yscaled <= 1))
@@ -126,7 +179,12 @@ class QuadMeshRectilinear(_QuadMeshLike):
 
             aggs_and_cols = aggs + cols
 
-            _extend(xs, ys, *aggs_and_cols)
+            if use_cuda:
+                do_extend = extend_cuda[cuda_args(xr_ds[name].shape)]
+            else:
+                do_extend = extend_cpu
+
+            do_extend(xs, ys, *aggs_and_cols)
 
         return extend
 
@@ -150,12 +208,159 @@ class QuadMeshCurvialinear(_QuadMeshLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         x_name = self.x
         y_name = self.y
+        name = self.name
 
         @ngjit
         @self.expand_aggs_and_cols(append)
-        def _extend(plot_height, plot_width, xs, ys, *aggs_and_cols):
-            y_len, x_len, = xs.shape
+        def perform_extend(
+                i, j,
+                plot_height, plot_width, xs, ys, xverts, yverts,
+                yincreasing, eligible, intersect, *aggs_and_cols
+        ):
 
+            # make array of quad x any vertices
+            xverts[0] = xs[j, i]
+            xverts[1] = xs[j, i + 1]
+            xverts[2] = xs[j + 1, i + 1]
+            xverts[3] = xs[j + 1, i]
+            xverts[4] = xverts[0]
+
+            yverts[0] = ys[j, i]
+            yverts[1] = ys[j, i + 1]
+            yverts[2] = ys[j + 1, i + 1]
+            yverts[3] = ys[j + 1, i]
+            yverts[4] = yverts[0]
+
+            # Compute the rectilinear bounding box around the quad and
+            # skip quad if there is no chance for it to intersect
+            # viewport
+            xmin = min(min(xverts[0], xverts[1]), min(xverts[2], xverts[3]))
+            if xmin >= plot_width:
+                return
+            xmin = max(xmin, 0)
+
+            xmax = max(max(xverts[0], xverts[1]), max(xverts[2], xverts[3]))
+            if xmax < 0:
+                return
+            xmax = min(xmax, plot_width)
+
+            ymin = min(min(yverts[0], yverts[1]), min(yverts[2], yverts[3]))
+            if ymin >= plot_height:
+                return
+            ymin = max(ymin, 0)
+
+            ymax = max(max(yverts[0], yverts[1]), max(yverts[2], yverts[3]))
+            if ymax < 0:
+                return
+            ymax = min(ymax, plot_height)
+
+            # Handle subpixel quads
+            if xmin == xmax or ymin == ymax:
+                # If either dimension is a single pixel, then render it
+                if xmin == xmax and xmax < plot_width:
+                    xmax += 1
+                if ymin == ymax and ymax < plot_height:
+                    ymax += 1
+
+                for yi in range(ymin, ymax):
+                    for xi in range(xmin, xmax):
+                        append(j, i, xi, yi, *aggs_and_cols)
+
+                return
+
+            # make yincreasing an array holding whether each edge is
+            # increasing vertically (+1), decreasing vertically (-1),
+            # or horizontal (0).
+            yincreasing[:] = 0
+            for k in range(4):
+                if yverts[k + 1] > yverts[k]:
+                    yincreasing[k] = 1
+                elif yverts[k + 1] < yverts[k]:
+                    yincreasing[k] = -1
+
+            for yi in range(ymin, ymax):
+                eligible[:] = 1
+                for xi in range(xmin, xmax):
+                    intersect[:] = 0
+                    # Test edges
+                    for edge_i in range(4):
+                        # Skip if we already know edge is ineligible
+                        if not eligible[edge_i]:
+                            continue
+
+                        # Check if edge is fully to left of point. If
+                        # so, we don't need to consider it again for
+                        # this row.
+                        if ((xverts[edge_i] < xi) and
+                                (xverts[edge_i + 1] < xi)):
+                            eligible[edge_i] = 0
+                            continue
+
+                        # Check if edge is fully above or below point.
+                        # If so, we don't need to consider it again
+                        # for this  row.
+                        if ((yverts[edge_i] > yi) ==
+                                (yverts[edge_i + 1] > yi)):
+                            eligible[edge_i] = 0
+                            continue
+
+                        # Now check if edge is to the right of point.
+                        # A is vector from point to first vertex
+                        ax = xverts[edge_i] - xi
+                        ay = yverts[edge_i] - yi
+
+                        # B is vector from point to second vertex
+                        bx = xverts[edge_i + 1] - xi
+                        by = yverts[edge_i + 1] - yi
+
+                        # Compute cross product of B and A
+                        bxa = (bx * ay - by * ax)
+
+                        # If cross product has same sign as yincreasing
+                        # then edge intersects to the right
+                        intersect[edge_i] = (
+                                bxa * yincreasing[edge_i] < 0
+                        )
+                    intersections = (
+                            intersect[0] + intersect[1] + intersect[2] + intersect[3]
+                    )
+                    if intersections % 2 == 1:
+                        # If odd number of intersections, point
+                        # is inside quad
+                        append(j, i, xi, yi, *aggs_and_cols)
+
+        @cuda.jit
+        @self.expand_aggs_and_cols(append)
+        def extend_cuda(plot_height, plot_width, xs, ys, *aggs_and_cols):
+            # # For consistency with CPU path, we initialize all arrays here
+            # # xverts/yverts arrays
+            xverts = cuda.local.array(5, dtype=numba.types.int32)
+            yverts = cuda.local.array(5, dtype=numba.types.int32)
+            #
+            # # Array holding whether each edge is increasing
+            # # vertically (+1), decreasing vertically (-1),
+            # # or horizontal (0).
+            yincreasing = cuda.local.array(4, dtype=numba.types.int8)
+
+            # # Array that will hold mask of whether edges are
+            # # eligible for intersection tests
+            eligible = cuda.local.array(4, dtype=numba.types.int8)
+
+            # # Array that will hold a mask of whether edges
+            # # intersect the ray to the right of test point
+            intersect = cuda.local.array(4, dtype=numba.types.int8)
+
+            i, j = cuda.grid(2)
+            if i < (xs.shape[0] - 1) and j < (ys.shape[0] - 1):
+                perform_extend(
+                    i, j, plot_height, plot_width, xs, ys,
+                    xverts, yverts, yincreasing, eligible, intersect,
+                    *aggs_and_cols
+                )
+
+        @ngjit
+        @self.expand_aggs_and_cols(append)
+        def extend_cpu(plot_height, plot_width, xs, ys, *aggs_and_cols):
             # For performance, we initialize all arrays once before the loop
 
             # xverts/yverts arrays
@@ -175,123 +380,34 @@ class QuadMeshCurvialinear(_QuadMeshLike):
             # intersect the ray to the right of test point
             intersect = np.zeros(4, dtype=np.int8)
 
+            y_len, x_len, = xs.shape
             for i in range(x_len - 1):
                 for j in range(y_len - 1):
-
-                    # make array of quad x any vertices
-                    xverts[0] = xs[j, i]
-                    xverts[1] = xs[j, i + 1]
-                    xverts[2] = xs[j + 1, i + 1]
-                    xverts[3] = xs[j + 1, i]
-                    xverts[4] = xs[j, i]
-
-                    yverts[0] = ys[j, i]
-                    yverts[1] = ys[j, i + 1]
-                    yverts[2] = ys[j + 1, i + 1]
-                    yverts[3] = ys[j + 1, i]
-                    yverts[4] = ys[j, i]
-
-                    # Compute the rectilinear bounding box around the quad and
-                    # skip quad if there is no chance for it to intersect
-                    # viewport
-                    xmin = min(xverts)
-                    if xmin >= plot_width:
-                        continue
-                    xmin = max(xmin, 0)
-
-                    xmax = max(xverts)
-                    if xmax < 0:
-                        continue
-                    xmax = min(xmax, plot_width)
-
-                    ymin = min(yverts)
-                    if ymin >= plot_height:
-                        continue
-                    ymin = max(ymin, 0)
-
-                    ymax = max(yverts)
-                    if ymax < 0:
-                        continue
-                    ymax = min(ymax, plot_height)
-
-                    # Handle subpixel quads
-                    if xmin == xmax or ymin == ymax:
-                        # If either dimension is a single pixel, then render it
-                        if xmin == xmax and xmax < plot_width:
-                            xmax += 1
-                        if ymin == ymax and ymax < plot_height:
-                            ymax += 1
-
-                        for yi in range(ymin, ymax):
-                            for xi in range(xmin, xmax):
-                                append(j, i, xi, yi, *aggs_and_cols)
-
-                        continue
-
-                    # make yincreasing an array holding whether each edge is
-                    # increasing vertically (+1), decreasing vertically (-1),
-                    # or horizontal (0).
-                    yincreasing.fill(0)
-                    yincreasing[yverts[1:] > yverts[:-1]] = 1
-                    yincreasing[yverts[1:] < yverts[:-1]] = -1
-
-                    for yi in range(ymin, ymax):
-                        eligible.fill(1)
-                        for xi in range(xmin, xmax):
-                            intersect.fill(0)
-                            # Test edges
-                            for edge_i in range(4):
-                                # Skip if we already know edge is ineligible
-                                if not eligible[edge_i]:
-                                    continue
-
-                                # Check if edge is fully to left of point. If
-                                # so, we don't need to consider it again for
-                                # this row.
-                                if ((xverts[edge_i] < xi) and
-                                        (xverts[edge_i + 1] < xi)):
-                                    eligible[edge_i] = 0
-                                    continue
-
-                                # Check if edge is fully above or below point.
-                                # If so, we don't need to consider it again
-                                # for this  row.
-                                if ((yverts[edge_i] > yi) ==
-                                        (yverts[edge_i + 1] > yi)):
-
-                                    eligible[edge_i] = 0
-                                    continue
-
-                                # Now check if edge is to the right of point.
-                                # A is vector from point to first vertex
-                                ax = xverts[edge_i] - xi
-                                ay = yverts[edge_i] - yi
-
-                                # B is vector from point to second vertex
-                                bx = xverts[edge_i + 1] - xi
-                                by = yverts[edge_i + 1] - yi
-
-                                # Compute cross product of B and A
-                                bxa = (bx*ay - by*ax)
-
-                                # If cross product has same sign as yincreasing
-                                # then edge intersects to the right
-                                intersect[edge_i] = (
-                                        bxa * yincreasing[edge_i] < 0
-                                )
-
-                            if intersect.sum() % 2 == 1:
-                                # If odd number of intersections, point
-                                # is inside quad
-                                append(j, i, xi, yi, *aggs_and_cols)
+                    perform_extend(
+                        i, j, plot_height, plot_width, xs, ys,
+                        xverts, yverts, yincreasing, eligible, intersect, *aggs_and_cols
+                    )
 
         def extend(aggs, xr_ds, vt, bounds):
-            # Convert from bin centers to interval edges
+            from datashader.core import LinearAxis
+            use_cuda = cupy and isinstance(xr_ds[name].data, cupy.ndarray)
+
             x_breaks = xr_ds[x_name].values
+            y_breaks = xr_ds[y_name].values
+            if use_cuda:
+                x_breaks = cupy.array(x_breaks)
+                y_breaks = cupy.array(y_breaks)
+
+                x_mapper2 = _cuda_mapper(x_mapper)
+                y_mapper2 = _cuda_mapper(y_mapper)
+            else:
+                x_mapper2 = _cuda_mapper(x_mapper)
+                y_mapper2 = _cuda_mapper(y_mapper)
+
+            # Convert from bin centers to interval edges
             x_breaks = infer_interval_breaks(x_breaks, axis=1)
             x_breaks = infer_interval_breaks(x_breaks, axis=0)
 
-            y_breaks = xr_ds[y_name].values
             y_breaks = infer_interval_breaks(y_breaks, axis=1)
             y_breaks = infer_interval_breaks(y_breaks, axis=0)
 
@@ -299,8 +415,16 @@ class QuadMeshCurvialinear(_QuadMeshLike):
             x0, x1, y0, y1 = bounds
             xspan = x1 - x0
             yspan = y1 - y0
-            xscaled = (x_mapper(x_breaks) - x0) / xspan
-            yscaled = (y_mapper(y_breaks) - y0) / yspan
+
+            if x_mapper is LinearAxis.mapper:
+                xscaled = (x_breaks - x0) / xspan
+            else:
+                xscaled = (x_mapper2(x_breaks) - x0) / xspan
+
+            if y_mapper is LinearAxis.mapper:
+                yscaled = (y_breaks - y0) / yspan
+            else:
+                yscaled = (y_mapper2(y_breaks) - y0) / yspan
 
             plot_height, plot_width = aggs[0].shape[:2]
 
@@ -309,6 +433,13 @@ class QuadMeshCurvialinear(_QuadMeshLike):
 
             coord_dims = xr_ds.coords[x_name].dims
             aggs_and_cols = aggs + info(xr_ds.transpose(*coord_dims))
-            _extend(plot_height, plot_width, xs, ys, *aggs_and_cols)
+            if use_cuda:
+                do_extend = extend_cuda[cuda_args(xr_ds[name].shape)]
+            else:
+                do_extend = extend_cpu
+
+            do_extend(
+                plot_height, plot_width, xs, ys, *aggs_and_cols
+            )
 
         return extend

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -36,6 +36,9 @@ class extract(Preprocess):
             else:
                 nullval = 0
             return cupy.array(df[self.column].to_gpu_array(fillna=nullval))
+        elif isinstance(df, xr.Dataset):
+            # DataArray could be backed by numpy or cupy array
+            return df[self.column].data
         else:
             return df[self.column].values
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -40,6 +40,11 @@ from numba import prange
 from .utils import ngjit
 
 try:
+    import cupy
+except ImportError:
+    cupy = None
+
+try:
     # Try to create numba JIT with 'parallel' target
     ngjit_parallel = nb.jit(nopython=True, nogil=True, parallel=True)
 except:
@@ -964,7 +969,11 @@ def infer_interval_breaks(coord, axis=0):
     array([[-0.5,  0.5,  1.5],
            [ 2.5,  3.5,  4.5]])
     """
-    coord = np.asarray(coord)
+    if cupy and isinstance(coord, cupy.ndarray):
+        # leave cupy array as-is
+        pass
+    else:
+        coord = np.asarray(coord)
     if sys.version_info.major == 2 and len(coord) and isinstance(coord[0], (dt.datetime, dt.date)):
         # np.diff does not work on datetimes in python 2
         coord = coord.astype('datetime64')

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -3,114 +3,136 @@ import numpy as np
 from numpy import nan
 import xarray as xr
 import datashader as ds
+import pytest
 from collections import OrderedDict
 
+from datashader.tests.test_pandas import assert_eq_xr
 
-def test_rect_quadmesh_autorange():
+array_modules = [np]
+try:
+    import cupy
+    array_modules.append(cupy)
+except ImportError:
+    cupy = None
+
+
+@pytest.mark.parametrize('array_module', array_modules)
+def test_rect_quadmesh_autorange(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4)
     da = xr.DataArray(
-        [[1, 2, 3, 4],
-         [5, 6, 7, 8]],
+        array_module.array(
+            [[1, 2, 3, 4],
+             [5, 6, 7, 8]]
+        ),
         coords=[('b', [1, 2]),
                 ('a', [1, 2, 3, 4])],
         name='Z')
 
     y_coords = np.linspace(0.75, 2.25, 4)
     x_coords = np.linspace(0.75, 4.25, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[1., 1., 2., 2., 3., 3., 4., 4.],
          [1., 1., 2., 2., 3., 3., 4., 4.],
          [5., 5., 6., 6., 7., 7., 8., 8.],
          [5., 5., 6., 6., 7., 7., 8., 8.]],
-        dtype='i4'),
+        dtype='f8'),
         coords=[('b', y_coords),
                 ('a', x_coords)]
     )
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_rect_quadmesh_autorange_reversed():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_rect_quadmesh_autorange_reversed(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4)
     da = xr.DataArray(
-        [[1, 2, 3, 4],
-         [5, 6, 7, 8]],
+        array_module.array(
+            [[1, 2, 3, 4],
+             [5, 6, 7, 8]]
+        ),
         coords=[('b', [-1, -2]),
                 ('a', [-1, -2, -3, -4])],
         name='Z')
 
     y_coords = np.linspace(-2.25, -0.75, 4)
     x_coords = np.linspace(-4.25, -0.75, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[8., 8., 7., 7., 6., 6., 5., 5.],
          [8., 8., 7., 7., 6., 6., 5., 5.],
          [4., 4., 3., 3., 2., 2., 1., 1.],
          [4., 4., 3., 3., 2., 2., 1., 1.]],
-        dtype='i4'),
+        dtype='f8'),
         coords=[('b', y_coords),
                 ('a', x_coords)]
     )
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_rect_quadmesh_manual_range():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_rect_quadmesh_manual_range(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4,
                   x_range=[1, 3],
                   y_range=[-1, 3])
 
     da = xr.DataArray(
-        [[1, 2, 3, 4],
-         [5, 6, 7, 8]],
+        array_module.array(
+            [[1, 2, 3, 4],
+             [5, 6, 7, 8]]
+        ),
         coords=[('b', [1, 2]),
                 ('a', [1, 2, 3, 4])],
         name='Z')
 
     y_coords = np.linspace(-0.5, 2.5, 4)
     x_coords = np.linspace(1.125, 2.875, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[nan, nan, nan, nan, nan, nan, nan, nan],
          [1., 1., 2., 2., 2., 2., 3., 3.],
          [5., 5., 6., 6., 6., 6., 7., 7.],
          [nan, nan, nan, nan, nan, nan, nan, nan]],
-        dtype='f4'),
+        dtype='f8'),
         coords=[('b', y_coords),
                 ('a', x_coords)]
     )
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_subpixel_quads_represented():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_subpixel_quads_represented(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4,
                   x_range=[0, 16],
                   y_range=[0, 8])
 
     da = xr.DataArray(
-        [[1, 2, 3, 4],
-         [5, 6, 7, 8]],
+        array_module.array(
+            [[1, 2, 3, 4],
+             [5, 6, 7, 8]]
+        ),
         coords=[('b', [1, 2]),
                 ('a', [1, 2, 3, 4])],
         name='Z')
 
     y_coords = np.linspace(1, 7, 4)
     x_coords = np.linspace(1, 15, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[14., 22., nan, nan, nan, nan, nan, nan],
          [nan, nan, nan, nan, nan, nan, nan, nan],
          [nan, nan, nan, nan, nan, nan, nan, nan],
@@ -121,14 +143,15 @@ def test_subpixel_quads_represented():
     )
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_curve_quadmesh_rect_autorange():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_curve_quadmesh_rect_autorange(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4)
     Qx = np.array(
         [[1, 2],
@@ -140,7 +163,7 @@ def test_curve_quadmesh_rect_autorange():
     )
     Z = np.arange(4, dtype='int32').reshape(2, 2)
     da = xr.DataArray(
-        Z,
+        array_module.array(Z),
         coords={'Qx': (['Y', 'X'], Qx),
                 'Qy': (['Y', 'X'], Qy)},
         dims=['Y', 'X'],
@@ -149,24 +172,26 @@ def test_curve_quadmesh_rect_autorange():
 
     y_coords = np.linspace(0.75, 2.25, 4)
     x_coords = np.linspace(0.625, 2.375, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[0., 0., 0., 0., 1., 1., 1., 1.],
          [0., 0., 0., 0., 1., 1., 1., 1.],
          [2., 2., 2., 2., 3., 3., 3., 3.],
          [2., 2., 2., 2., 3., 3., 3., 3.]],
+        dtype='f8'
         ),
         coords=[('Qy', y_coords),
                 ('Qx', x_coords)]
     )
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     res = c.quadmesh(da.transpose('X', 'Y'), x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_curve_quadmesh_autorange():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_curve_quadmesh_autorange(array_module):
     c = ds.Canvas(plot_width=4, plot_height=8)
     Qx = np.array(
         [[1, 2],
@@ -178,7 +203,7 @@ def test_curve_quadmesh_autorange():
     )
     Z = np.arange(4, dtype='int32').reshape(2, 2)
     da = xr.DataArray(
-        Z,
+        array_module.array(Z),
         coords={'Qx': (['Y', 'X'], Qx),
                 'Qy': (['Y', 'X'], Qy)},
         dims=['Y', 'X'],
@@ -187,7 +212,7 @@ def test_curve_quadmesh_autorange():
 
     x_coords = np.linspace(0.75, 2.25, 4)
     y_coords = np.linspace(-0.5, 6.5, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[nan, nan, nan, nan],
          [0.,  0.,  nan, nan],
          [0.,  0.,  1.,  1.],
@@ -204,13 +229,14 @@ def test_curve_quadmesh_autorange():
     )
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     res = c.quadmesh(da.transpose('X', 'Y'), x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_curve_quadmesh_manual_range():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_curve_quadmesh_manual_range(array_module):
     c = ds.Canvas(plot_width=4, plot_height=8, x_range=[1, 2], y_range=[1, 3])
     Qx = np.array(
         [[1, 2],
@@ -222,7 +248,7 @@ def test_curve_quadmesh_manual_range():
     )
     Z = np.arange(4, dtype='int32').reshape(2, 2)
     da = xr.DataArray(
-        Z,
+        array_module.array(Z),
         coords={'Qx': (['Y', 'X'], Qx),
                 'Qy': (['Y', 'X'], Qy)},
         dims=['Y', 'X'],
@@ -231,7 +257,7 @@ def test_curve_quadmesh_manual_range():
 
     x_coords = np.linspace(1.125, 1.875, 4)
     y_coords = np.linspace(1.125, 2.875, 8)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[0., 0., 1., 1.],
          [0., 0., 1., 1.],
          [0., 0., 1., 1.],
@@ -248,13 +274,14 @@ def test_curve_quadmesh_manual_range():
     )
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     res = c.quadmesh(da.transpose('X', 'Y'), x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
 
-def test_curve_quadmesh_manual_range_subpixel():
+@pytest.mark.parametrize('array_module', array_modules)
+def test_curve_quadmesh_manual_range_subpixel(array_module):
     c = ds.Canvas(plot_width=3, plot_height=5,
                   x_range=[-150, 150], y_range=[-250, 250])
     Qx = np.array(
@@ -267,7 +294,7 @@ def test_curve_quadmesh_manual_range_subpixel():
     )
     Z = np.arange(4, dtype='int32').reshape(2, 2)
     da = xr.DataArray(
-        Z,
+        array_module.array(Z),
         coords={'Qx': (['Y', 'X'], Qx),
                 'Qy': (['Y', 'X'], Qy)},
         dims=['Y', 'X'],
@@ -276,7 +303,7 @@ def test_curve_quadmesh_manual_range_subpixel():
 
     x_coords = np.linspace(-100, 100, 3)
     y_coords = np.linspace(-200, 200, 5)
-    out = xr.DataArray(np.array(
+    out = xr.DataArray(array_module.array(
         [[nan, nan, nan],
          [nan, nan, nan],
          [nan, 6.,  nan],
@@ -290,7 +317,7 @@ def test_curve_quadmesh_manual_range_subpixel():
     )
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)
 
     res = c.quadmesh(da.transpose('X', 'Y'), x='Qx', y='Qy', agg=ds.sum('Z'))
-    assert res.equals(out)
+    assert_eq_xr(res, out)


### PR DESCRIPTION
This PR adds support for aggregating `quadmesh` glyphs using cuda.  The cuda codepath is invoked when the data backing the provided `xarray.DataArray` is a `cupy.ndarray`.

I'm seeing 20-50x speedups in both the rectilinear and curvilinear cases.

Here are some examples: https://anaconda.org/jonmmease/gpu_quadmesh_pr/notebook