### PR TITLE
Fix render_tiles to use Google Map tile coordinates

### DIFF
--- a/datashader/tests/test_tiles.py
+++ b/datashader/tests/test_tiles.py
@@ -7,6 +7,7 @@ from datashader.colors import viridis
 from datashader.tiles import render_tiles
 from datashader.tiles import _get_super_tile_min_max
 from datashader.tiles import calculate_zoom_level_stats
+from datashader.tiles import MercatorTileDefinition
 
 import numpy as np
 import pandas as pd
@@ -117,3 +118,12 @@ def test_calculate_zoom_level_stats_with_fullscan_ranging_strategy():
     assert len(result) == 2
     assert_is_numeric(result[0])
     assert_is_numeric(result[1])
+
+def test_meters_to_tile():
+    # Part of NYC (used in taxi demo)
+    full_extent_of_data = (-8243206.93436, 4968192.04221, -8226510.539480001, 4982886.20438)
+    xmin, ymin, xmax, ymax = full_extent_of_data
+    zoom = 12
+    tile_def = MercatorTileDefinition((xmin, xmax), (ymin, ymax), tile_size=256)
+    tile = tile_def.meters_to_tile(xmin, ymin, zoom)
+    assert tile == (1205, 1540) # using Google tile coordinates, not TMS


### PR DESCRIPTION
I think there is a bug in the MercatorTileDefinition code. The intent behind the code seems to be that Google Map tile coordinates are returned (y increasing downwards), since the code refers to Bokeh’s WMTSTileSource (https://docs.bokeh.org/en/latest/_modules/bokeh/models/tiles.html#WMTSTileSource). However, the code currently returns TMS tile coordinates, but even if you try using TMSTileSource that doesn’t work since the tiles are upside down.

The example at https://github.com/holoviz/datashader/blob/master/examples/tiling.ipynb happens to work fine since the figure is symmetrical about the origin, so the bug is not exhibited in this case.

Recreating the NYC taxi example with tile rendering (source below) results in a blank figure. With the fix in this PR, the taxi example works correctly.

```python
import datashader as ds
import pandas as pd
from colorcet import fire
from datashader import transfer_functions as tf
from datashader.tiles import render_tiles, tile_previewer
import os
from bokeh.io import show

df = pd.read_csv('./datashader-examples/data/nyc_taxi.csv', usecols=['dropoff_x', 'dropoff_y'])
df = df.rename(columns={"dropoff_x": "x", "dropoff_y": "y"})

def get_extents(df, x, y):
    return df[x].min(), df[y].min(), df[x].max(), df[y].max()

def load_data_func(x_range, y_range):
    return df.loc[df['x'].between(*x_range) & df['y'].between(*y_range)]

def rasterize_func(df, x_range, y_range, height, width):
    cvs = ds.Canvas(x_range=x_range, y_range=y_range,
                    plot_height=height, plot_width=width)
    agg = cvs.points(df, 'x', 'y')
    return agg

def shader_func(agg, span=None):
    img = tf.shade(agg, cmap=fire)
    return img

def post_render_func(img, **kwargs):
    return img

full_extent_of_data = get_extents(df, 'x', 'y')
output_path = 'tiles/nyc_taxi_tiles_repro'
if not os.path.isdir(output_path):
    results = render_tiles(full_extent_of_data,
                        range(12, 14),
                        load_data_func=load_data_func,
                        rasterize_func=rasterize_func,
                        shader_func=shader_func,
                        post_render_func=post_render_func,
                        output_path=output_path)

p = tile_previewer(full_extent_of_data, 'tiles/nyc_taxi_tiles_repro/{z}/{x}/{y}.png')
show(p)
```