### PR TITLE
Generalize categorical aggregation and support span in _colorize

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1170,6 +1170,10 @@ def _cols_to_keep(columns, glyph, agg):
         for subagg in agg.values:
             if subagg.column is not None:
                 cols_to_keep[subagg.column] = True
+    elif hasattr(agg, 'columns'):
+        for column in agg.columns:
+            if column is not None:
+                cols_to_keep[column] = True
     elif agg.column is not None:
         cols_to_keep[agg.column] = True
     return [col for col, keepit in cols_to_keep.items() if keepit]

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -143,7 +143,7 @@ class by(Reduction):
     ----------
     column : str
         Name of the column to aggregate over. Column data type must be
-        categorical. Resulting aggregate has a outer dimension axis along the
+        categorical. Resulting aggregate has an outer dimension axis along the
         categories present.
     reduction : Reduction
         Per-category reduction function.
@@ -502,6 +502,7 @@ class max(FloatingReduction):
 
 class count_cat(by):
     """Count of all elements in ``column``, grouped by category.
+    Alias for `by(...,count())`, for backwards compatibility.
 
     Parameters
     ----------
@@ -725,4 +726,3 @@ __all__ = list(set([_k for _k,_v in locals().items()
                     if isinstance(_v,type) and (issubclass(_v,Reduction) or _v is summary)
                     and _v not in [Reduction, OptionalFieldReduction,
                                    FloatingReduction, m2]]))
-

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -51,6 +51,29 @@ class category_codes(Preprocess):
         else:
             return df[self.column].cat.codes.values
 
+class category_values(Preprocess):
+    """Extract multiple columns from a dataframe as a numpy array of values."""
+    def __init__(self, columns):
+        self.columns = list(columns)
+
+    @property
+    def inputs(self):
+        return self.columns
+
+    def apply(self, df):
+        if cudf and isinstance(df, cudf.DataFrame):
+            import cupy
+            if df[self.columns[1]].dtype.kind == 'f':
+                nullval = np.nan
+            else:
+                nullval = 0
+            a = df[self.columns[0]].cat.codes.to_gpu_array()
+            b = df[self.columns[1]].to_gpu_array(fillna=nullval)
+            return cupy.stack((a, b), axis=-1)
+        else:
+            a = df[self.columns[0]].cat.codes.values
+            b = df[self.columns[1]].values
+            return np.stack((a, b), axis=-1)
 
 class Reduction(Expr):
     """Base class for per-bin reductions."""
@@ -114,6 +137,103 @@ class OptionalFieldReduction(Reduction):
     def _finalize(bases, cuda=False, **kwargs):
         return xr.DataArray(bases[0], **kwargs)
 
+class by(Reduction):
+    """Apply the provided reduction separately per categorical ``column`` value.
+    Parameters
+    ----------
+    column : str
+        Name of the column to aggregate over. Column data type must be
+        categorical. Resulting aggregate has a outer dimension axis along the
+        categories present.
+    reduction : Reduction
+        Per-category reduction function.
+    """
+    def __init__(self, cat_column, reduction):
+        self.columns = (cat_column, getattr(reduction, 'column', None))
+        self.reduction = reduction
+
+    def __hash__(self):
+        return hash((type(self), self._hashable_inputs(), self.reduction))
+
+    @property
+    def cat_column(self):
+        return self.columns[0]
+
+    @property
+    def val_column(self):
+        return self.columns[1]
+
+    def validate(self, in_dshape):
+        if not self.cat_column in in_dshape.dict:
+            raise ValueError("specified column not found")
+        if not isinstance(in_dshape.measure[self.cat_column], ct.Categorical):
+            raise ValueError("input must be categorical")
+
+        self.reduction.validate(in_dshape)
+
+    def out_dshape(self, input_dshape):
+        cats = input_dshape.measure[self.cat_column].categories
+        red_shape = self.reduction.out_dshape(input_dshape)
+        return dshape(Record([(c, red_shape) for c in cats]))
+
+    @property
+    def inputs(self):
+        if self.val_column is not None:
+            return (category_values(self.columns),)
+        else:
+            return (category_codes(self.columns[0]),)
+
+    def _build_create(self, out_dshape):
+        n_cats = len(out_dshape.measure.fields)
+        if isinstance(self.reduction, FloatingReduction):
+            return lambda shape, array_module: array_module.zeros(
+                shape + (n_cats,), dtype='f8'
+            )
+        else:
+            return lambda shape, array_module: array_module.zeros(
+                shape + (n_cats,), dtype='i4'
+            )
+
+    def _build_append(self, dshape, schema, cuda=False):
+        f = self.reduction._build_append(dshape, schema, cuda)
+        # because we transposed, we also need to flip the
+        # order of the x/y arguments
+        if self.val_column is not None:
+            def _categorical_append(x, y, agg, field):
+                _agg = agg.transpose()
+                f(y, x, _agg[int(field[0])], field[1])
+        else:
+            def _categorical_append(x, y, agg, field):
+                _agg = agg.transpose()
+                f(y, x, _agg[int(field)])
+
+        return ngjit(_categorical_append)
+
+
+    def _build_combine(self, dshape):
+        if isinstance(self.reduction, FloatingReduction):
+            return self._combine_float
+        else:
+            return self._combine_int
+
+    @staticmethod
+    def _combine_float(aggs):
+        return aggs.sum(axis=0, dtype='f8')
+
+    @staticmethod
+    def _combine_int(aggs):
+        return aggs.sum(axis=0, dtype='i4')
+
+    def _build_finalize(self, dshape):
+        cats = list(dshape[self.cat_column].categories)
+
+        def finalize(bases, cuda=False, **kwargs):
+            dims = kwargs['dims'] + [self.cat_column]
+
+            coords = kwargs['coords']
+            coords[self.cat_column] = cats
+            return xr.DataArray(bases[0], dims=dims, coords=coords)
+        return finalize
 
 class count(OptionalFieldReduction):
     """Count elements in each bin.
@@ -380,7 +500,7 @@ class max(FloatingReduction):
         return np.nanmax(aggs, axis=0)
 
 
-class count_cat(Reduction):
+class count_cat(by):
     """Count of all elements in ``column``, grouped by category.
 
     Parameters
@@ -390,49 +510,9 @@ class count_cat(Reduction):
         categorical. Resulting aggregate has a outer dimension axis along the
         categories present.
     """
-    def validate(self, in_dshape):
-        if not isinstance(in_dshape.measure[self.column], ct.Categorical):
-            raise ValueError("input must be categorical")
-
-    def out_dshape(self, input_dshape):
-        cats = input_dshape.measure[self.column].categories
-        return dshape(Record([(c, ct.int32) for c in cats]))
-
-    @property
-    def inputs(self):
-        return (category_codes(self.column),)
-
-    def _build_create(self, out_dshape):
-        n_cats = len(out_dshape.measure.fields)
-        return lambda shape, array_module: array_module.zeros(
-            shape + (n_cats,), dtype='i4'
-        )
-
-    @staticmethod
-    @ngjit
-    def _append(x, y, agg, field):
-        agg[y, x, field] += 1
-
-    @staticmethod
-    @ngjit
-    def _append_cuda(x, y, agg, field):
-        nb_cuda.atomic.add(agg, (y, x, field), 1)
-
-    @staticmethod
-    def _combine(aggs):
-        return aggs.sum(axis=0, dtype='i4')
-
-    def _build_finalize(self, dshape):
-        cats = list(dshape[self.column].categories)
-
-        def finalize(bases, cuda=False, **kwargs):
-            dims = kwargs['dims'] + [self.column]
-
-            coords = kwargs['coords']
-            coords[self.column] = cats
-            return xr.DataArray(bases[0], dims=dims, coords=coords)
-        return finalize
-
+    def __init__(self, column):
+        super(count_cat, self).__init__(column, count())
+        self.column = column
 
 class mean(Reduction):
     """Mean of all elements in ``column``.

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -234,6 +234,33 @@ def test_count_cat(ddf):
     agg = c.points(ddf, 'x', 'y', ds.count_cat('cat'))
     assert_eq_xr(agg, out)
 
+@pytest.mark.parametrize('ddf', ddfs)
+def test_categorical_sum(ddf):
+    sol = np.array([[[10, 0, 0, 0],
+                     [0, 0, 60, 0]],
+                    [[0, 35, 0, 0],
+                     [0, 0, 0, 85]]])
+    out = xr.DataArray(
+        sol, coords=(coords + [['a', 'b', 'c', 'd']]), dims=(dims + ['cat'])
+    )
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.sum('i32')))
+    assert_eq_xr(agg, out)
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.sum('i64')))
+    assert_eq_xr(agg, out)
+
+    sol = np.array([[[8.0, 0, 0, 0],
+                     [0, 0, 60.0, 0]],
+                    [[0, 35.0, 0, 0],
+                     [0, 0, 0, 85.0]]])
+    out = xr.DataArray(
+        sol, coords=(coords + [['a', 'b', 'c', 'd']]), dims=(dims + ['cat'])
+    )
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.sum('f32')))
+    assert_eq_xr(agg, out)
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.sum('f64')))
+    assert_eq_xr(agg, out)
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_multiple_aggregates(ddf):

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -230,6 +230,61 @@ def test_count_cat(df):
     agg = c.points(df, 'x', 'y', ds.count_cat('cat'))
     assert_eq_xr(agg, out)
 
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_count(df):
+    sol = np.array([[[5, 0, 0, 0],
+                     [0, 0, 5, 0]],
+                    [[0, 5, 0, 0],
+                     [0, 0, 0, 5]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.count('i32')))
+    assert_eq_xr(agg, out)
+
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_sum(df):
+    sol = np.array([[[10, 0, 0, 0],
+                     [0, 0, 60, 0]],
+                    [[0, 35, 0, 0],
+                     [0, 0, 0, 85]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.sum('i32')))
+    assert_eq_xr(agg, out)
+
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.sum('i64')))
+    assert_eq_xr(agg, out)
+
+    sol = np.array([[[8.0, 0, 0, 0],
+                     [0, 0, 60.0, 0]],
+                    [[0, 35.0, 0, 0],
+                     [0, 0, 0, 85.0]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.sum('f32')))
+    assert_eq_xr(agg, out)
+
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.sum('f64')))
+    assert_eq_xr(agg, out)
+
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_max(df):
+    sol = np.array([[[4, 0, 0, 0],
+                     [0, 0, 14, 0]],
+                    [[0, 9, 0, 0],
+                     [0, 0, 0, 19]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.max('i32')))
+    assert_eq_xr(agg, out)
 
 @pytest.mark.parametrize('df', dfs)
 def test_multiple_aggregates(df):

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -293,6 +293,12 @@ def test_shade_category(array):
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
 
+    img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20, span=(0, 100))
+    sol = np.array([[587137024, 335565567],
+                    [1515534250, 1040187647]], dtype='u4')
+    sol = tf.Image(sol, coords=coords, dims=dims)
+    assert_eq_xr(img, sol)
+
     img = tf.shade(cat_agg, color_key=colors,
                    how=lambda x, m: np.where(m, np.nan, x) ** 2,
                    min_alpha=20)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -66,6 +66,7 @@ Reductions
    any
    count
    count_cat
+   sum_cat
    first
    last
    m2

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -66,7 +66,7 @@ Reductions
    any
    count
    count_cat
-   sum_cat
+   by
    first
    last
    m2

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -20,7 +20,7 @@ dependencies:
  - networkx>=2.0
  - numba
  - numpy
- - pandas >=0.24.1,<1.0
+ - pandas >=0.24.1
  - param
  - python-snappy
  - python

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -20,7 +20,7 @@ dependencies:
  - networkx>=2.0
  - numba
  - numpy
- - pandas
+ - pandas >=0.24.1,<1.0
  - param
  - python-snappy
  - python


### PR DESCRIPTION
I have categorical data where I want to sum a column, but grouped by category.  The `count_cat` functionality simply counts the number of rows of each category.  This PR creates a new aggregation called `sum_cat`.

In addition, I often need to produce multiple datashader visualizations that are colorized where the alpha range is distributed across a fixed span.  This PR enables support for using `span` on categorical data.

Please provide comments or suggestions on how to improve the PR if necessary.

Practical examples can be found here:
https://github.com/spectriclabs/jupyter-notebooks/blob/master/Datashader-Improvements.ipynb