### PR TITLE
Remove apparently redundant specifications of pandas in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ examples = [
     'distributed', # dask
     'holoviews >=1.10.0',
     'matplotlib',
-    'pandas >=0.24.1',
 ]
 
 extras_require = {
@@ -44,7 +43,6 @@ extras_require = {
         'flake8',
         'nbsmoke[all] >=0.4.0',
         'fastparquet >=0.1.6',  # optional dependency
-        'pandas >=0.24.1,<1.0',  # optional ragged array support
         'holoviews >=1.10.0',
     ],
     'examples': examples,


### PR DESCRIPTION
Anything in install_requires will always be present, so doesn't need to be specified elsewhere.

Maybe there have been (or will be) times when the pandas dependency must be specified differently in some particular situation (e.g. building the website), but looks like not at the moment.

Unless there's some problem I don't know about...?