### PR TITLE
ImportError -> Exception for guards around cupy/cudf import

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -20,12 +20,12 @@ from . import reductions as rd
 
 try:
     import cudf
-except ImportError:
+except Exception:
     cudf = None
 
 try:
     import dask_cudf
-except ImportError:
+except Exception:
     dask_cudf = None
 
 class Axis(object):
@@ -201,7 +201,7 @@ class Canvas(object):
                         source.spatial is not None and
                         source.spatial.x == x and source.spatial.y == y and
                         self.x_range is not None and self.y_range is not None):
-            
+
                     source = source.spatial_query(
                         x_range=self.x_range, y_range=self.y_range)
             glyph = Point(x, y)

--- a/datashader/data_libraries/__init__.py
+++ b/datashader/data_libraries/__init__.py
@@ -14,5 +14,5 @@ try:
     import dask_cudf as _dask_cudf  # noqa (Test dask_cudf installed)
     from . import dask_cudf         # noqa (API import)
 
-except ImportError:
+except Exception:
     pass

--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -7,7 +7,7 @@ from datashader.utils import Dispatcher
 
 try:
     import cupy
-except ImportError:
+except Exception:
     cupy = None
 
 glyph_dispatch = Dispatcher()

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -11,7 +11,7 @@ from numba import cuda
 try:
     import cudf
     from ..transfer_functions._cuda_utils import cuda_args
-except ImportError:
+except Exception:
     cudf = None
     cuda_args = None
 

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -12,7 +12,7 @@ from datashader.macros import expand_varargs
 
 try:
     import cudf
-except ImportError:
+except Exception:
     cudf = None
 
 

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -10,7 +10,7 @@ from numba import cuda
 try:
     import cudf
     from ..transfer_functions._cuda_utils import cuda_args
-except ImportError:
+except Exception:
     cudf = None
     cuda_args = None
 

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -10,7 +10,7 @@ from numba import cuda
 try:
     import cudf
     from ..transfer_functions._cuda_utils import cuda_args
-except ImportError:
+except Exception:
     cudf = None
     cuda_args = None
 

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -10,7 +10,7 @@ from numba import cuda
 try:
     import cupy
     from datashader.transfer_functions._cuda_utils import cuda_args
-except ImportError:
+except Exception:
     cupy = None
     cuda_args = None
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -12,7 +12,7 @@ from numba import cuda as nb_cuda
 
 try:
     import cudf
-except ImportError:
+except Exception:
     cudf = None
 
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -41,7 +41,7 @@ from .utils import ngjit
 
 try:
     import cupy
-except ImportError:
+except Exception:
     cupy = None
 
 try:

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -20,7 +20,7 @@ from datashader.utils import ngjit, orient_array
 
 try:
     import cupy
-except ImportError:
+except Exception:
     cupy = None
 
 __all__ = ['Image', 'stack', 'shade', 'set_background', 'spread', 'dynspread']

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -21,7 +21,7 @@ except ImportError:
 
 try:
     import cudf
-except ImportError:
+except Exception:
     cudf = None
 
 try:


### PR DESCRIPTION
Currently, datashader imports `cupy` and `cudf` inside `try`/`except` blocks, and proceeds gracefully when an `ImportError` is raised.

I ran into a situation today where I was using a conda environment that had cupy installed, but without an NVIDIA GPU. When attemping to import cupy, an `AttributeError` was raised inside cupy.  since it was not an `ImportError`, this exception propagates all the way up and makes Datashader unusable in that environment.

With these changes, if any exception is raised while attempting to import `cupy` or `cudf`, Datashader will continue on without GPU support.