### PR TITLE
Do not automatically trigger the creation of a spatialpandas spatial index

### DIFF
--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -985,9 +985,13 @@ def _build_extend_line_axis1_geometry(
             offsets1 = offsets[0]
             offsets0 = np.arange(len(offsets1))
 
-        # Compute indices of potentially intersecting polygons using
-        # geometry's R-tree
-        eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+        if geometry._sindex is not None:
+            # Compute indices of potentially intersecting polygons using
+            # geometry's R-tree if there is one
+            eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+        else:
+            # Otherwise, process all indices
+            eligible_inds = np.arange(0, len(geometry), dtype='uint32')
 
         extend_cpu_numba(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax,

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -266,9 +266,14 @@ class MultiPointGeometry(_GeometryLike):
 
             geometry = df[geometry_name].array
 
-            # Compute indices of potentially intersecting polygons using
-            # geometry's R-tree
-            eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+            if geometry._sindex is not None:
+                # Compute indices of potentially intersecting polygons using
+                # geometry's R-tree if there is one
+                eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+            else:
+                # Otherwise, process all indices
+                eligible_inds = np.arange(0, len(geometry), dtype='uint32')
+
             missing = geometry.isna()
 
             if isinstance(geometry, PointArray):

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -204,9 +204,13 @@ def _build_extend_polygon_geometry(
         missing = geometry.isna()
         offsets = geometry.buffer_offsets
 
-        # Compute indices of potentially intersecting polygons using
-        # geometry's R-tree
-        eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+        if geometry._sindex is not None:
+            # Compute indices of potentially intersecting polygons using
+            # geometry's R-tree if there is one
+            eligible_inds = geometry.sindex.intersects((xmin, ymin, xmax, ymax))
+        else:
+            # Otherwise, process all indices
+            eligible_inds = np.arange(0, len(geometry), dtype='uint32')
 
         if len(offsets) == 3:
             # MultiPolygonArray

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -363,6 +363,14 @@ def test_points_geometry_point():
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
 
+    # Aggregation should not have triggered calculation of spatial index
+    assert df.geom.array._sindex is None
+
+    # Generate spatial index and check that we get the same result
+    df.geom.array.sindex
+    agg = cvs.points(df, geometry='geom', agg=ds.sum('v'))
+    assert_eq_xr(agg, out)
+
 
 @pytest.mark.skipif(not sp, reason="spatialpandas not installed")
 def test_points_geometry_multipoint():
@@ -382,6 +390,14 @@ def test_points_geometry_multipoint():
                     [3, 3,   3]], dtype='float64')
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
+    assert_eq_xr(agg, out)
+
+    # Aggregation should not have triggered calculation of spatial index
+    assert df.geom.array._sindex is None
+
+    # Generate spatial index and check that we get the same result
+    df.geom.array.sindex
+    agg = cvs.points(df, geometry='geom', agg=ds.sum('v'))
     assert_eq_xr(agg, out)
 
 


### PR DESCRIPTION
Slight change in Datashader's use of `spatialpandas` that I made in order to match the legacy performance of https://examples.pyviz.org/osm/osm-1billion.html#osm-gallery-osm-1billion.

With this change, Datashader will use the per-partition spatial index if one is present but it will not trigger the creation of a new spatial index.  Datashader will still always use/create a spatialindex across all of the partitions in order to judge which partitions are needed.