### PR TITLE
Performance improvement for TMS tileset generation

### DIFF
--- a/datashader/tests/test_tiles.py
+++ b/datashader/tests/test_tiles.py
@@ -5,6 +5,7 @@ import datashader.transfer_functions as tf
 from datashader.colors import viridis
 
 from datashader.tiles import render_tiles
+from datashader.tiles import gen_super_tiles
 from datashader.tiles import _get_super_tile_min_max
 from datashader.tiles import calculate_zoom_level_stats
 from datashader.tiles import MercatorTileDefinition
@@ -97,7 +98,9 @@ def test_get_super_tile_min_max():
                 'tile_size': 256,
                 'span': (0, 1000)}
 
-    result = _get_super_tile_min_max(tile_info, mock_load_data_func, mock_rasterize_func)
+    agg = _get_super_tile_min_max(tile_info, mock_load_data_func, mock_rasterize_func)
+
+    result = [np.nanmin(agg.data), np.nanmax(agg.data)]
 
     assert isinstance(result, list)
     assert len(result) == 2
@@ -109,15 +112,15 @@ def test_calculate_zoom_level_stats_with_fullscan_ranging_strategy():
                    MERCATOR_CONST, MERCATOR_CONST)
     level = 0
     color_ranging_strategy = 'fullscan'
-    result = calculate_zoom_level_stats(full_extent, level,
+    super_tiles, span = calculate_zoom_level_stats(list(gen_super_tiles(full_extent, level)),
                                         mock_load_data_func,
                                         mock_rasterize_func,
                                         color_ranging_strategy=color_ranging_strategy)
 
-    assert isinstance(result, (list, tuple))
-    assert len(result) == 2
-    assert_is_numeric(result[0])
-    assert_is_numeric(result[1])
+    assert isinstance(span, (list, tuple))
+    assert len(span) == 2
+    assert_is_numeric(span[0])
+    assert_is_numeric(span[1])
 
 def test_meters_to_tile():
     # Part of NYC (used in taxi demo)

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -55,7 +55,6 @@ def render_tiles(full_extent, levels, load_data_func,
                  post_render_func, output_path, color_ranging_strategy='fullscan'):
     results = dict()
     for level in levels:
-        print('testing performance fix')
         print('calculating statistics for level {}'.format(level))
         super_tiles, span = calculate_zoom_level_stats(list(gen_super_tiles(full_extent, level)),
                                                        load_data_func, rasterize_func,

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -11,14 +11,11 @@ import numpy as np
 
 from PIL.Image import fromarray
 
-
 __all__ = ['render_tiles', 'MercatorTileDefinition']
-
 
 
 # helpers ---------------------------------------------------------------------
 def _create_dir(path):
-
     import os, errno
 
     try:
@@ -34,16 +31,21 @@ def _get_super_tile_min_max(tile_info, load_data_func, rasterize_func):
     agg = rasterize_func(df, x_range=tile_info['x_range'],
                          y_range=tile_info['y_range'],
                          height=tile_size, width=tile_size)
-    return [np.nanmin(agg.data), np.nanmax(agg.data)]
+    return agg
 
 
-def calculate_zoom_level_stats(full_extent, level, load_data_func,
+def calculate_zoom_level_stats(super_tiles, load_data_func,
                                rasterize_func,
                                color_ranging_strategy='fullscan'):
     if color_ranging_strategy == 'fullscan':
-        b = db.from_sequence(list(gen_super_tiles(full_extent,level)))
-        b = b.map(_get_super_tile_min_max, load_data_func, rasterize_func).flatten()
-        return dask.compute(b.min(), b.max())
+        stats = []
+        for super_tile in super_tiles:
+            agg = _get_super_tile_min_max(super_tile, load_data_func, rasterize_func)
+            super_tile['agg'] = agg
+            stats.append(np.nanmin(agg.data))
+            stats.append(np.nanmax(agg.data))
+        b = db.from_sequence(stats)
+        return super_tiles, dask.compute(b.min(), b.max())
     else:
         raise ValueError('Invalid color_ranging_strategy option')
 
@@ -51,19 +53,16 @@ def calculate_zoom_level_stats(full_extent, level, load_data_func,
 def render_tiles(full_extent, levels, load_data_func,
                  rasterize_func, shader_func,
                  post_render_func, output_path, color_ranging_strategy='fullscan'):
-
-    #TODO: get full extent once at beginning for all levels
     results = dict()
     for level in levels:
+        print('testing performance fix')
         print('calculating statistics for level {}'.format(level))
-        span = calculate_zoom_level_stats(full_extent, level,
-                                          load_data_func, rasterize_func,
-                                          color_ranging_strategy='fullscan')
-
-        super_tiles = list(gen_super_tiles(full_extent, level, span))
+        super_tiles, span = calculate_zoom_level_stats(list(gen_super_tiles(full_extent, level)),
+                                                       load_data_func, rasterize_func,
+                                                       color_ranging_strategy=color_ranging_strategy)
         print('rendering {} supertiles for zoom level {} with span={}'.format(len(super_tiles), level, span))
         b = db.from_sequence(super_tiles)
-        b.map(render_super_tile, output_path, load_data_func, rasterize_func, shader_func, post_render_func).compute()
+        b.map(render_super_tile, span, output_path, shader_func, post_render_func).compute()
         results[level] = dict(success=True, stats=span, supertile_count=len(super_tiles))
 
     return results
@@ -71,8 +70,8 @@ def render_tiles(full_extent, levels, load_data_func,
 
 def gen_super_tiles(extent, zoom_level, span=None):
     xmin, ymin, xmax, ymax = extent
-    super_tile_size = min(2**4 * 256,
-                         (2 ** zoom_level) * 256)
+    super_tile_size = min(2 ** 4 * 256,
+                          (2 ** zoom_level) * 256)
     super_tile_def = MercatorTileDefinition(x_range=(xmin, xmax), y_range=(ymin, ymax), tile_size=super_tile_size)
     super_tiles = super_tile_def.get_tiles_by_extent(extent, zoom_level)
     for s in super_tiles:
@@ -80,25 +79,19 @@ def gen_super_tiles(extent, zoom_level, span=None):
         x_range = (st_extent[0], st_extent[2])
         y_range = (st_extent[1], st_extent[3])
         yield {'level': zoom_level,
-                'x_range': x_range,
-                'y_range': y_range,
-                'tile_size': super_tile_def.tile_size,
-                'span': span}
+               'x_range': x_range,
+               'y_range': y_range,
+               'tile_size': super_tile_def.tile_size,
+               'span': span}
 
 
-def render_super_tile(tile_info, output_path, load_data_func,
-                      rasterize_func, shader_func, post_render_func):
-    tile_size = tile_info['tile_size']
+def render_super_tile(tile_info, span, output_path, shader_func, post_render_func):
     level = tile_info['level']
-    df = load_data_func(tile_info['x_range'], tile_info['y_range'])
-    agg = rasterize_func(df, x_range=tile_info['x_range'],
-                         y_range=tile_info['y_range'], height=tile_size,
-                         width=tile_size)
-    ds_img = shader_func(agg, span=tile_info['span'])
+    ds_img = shader_func(tile_info['agg'], span=span)
     return create_sub_tiles(ds_img, level, tile_info, output_path, post_render_func)
 
-def create_sub_tiles(data_array, level, tile_info, output_path, post_render_func=None):
 
+def create_sub_tiles(data_array, level, tile_info, output_path, post_render_func=None):
     # validate / createoutput_dir
     _create_dir(output_path)
 
@@ -117,9 +110,11 @@ def create_sub_tiles(data_array, level, tile_info, output_path, post_render_func
 
     return renderer.render(data_array, level=level)
 
+
 def invert_y_tile(y, z):
     # Convert from TMS to Google tile y coordinate, and vice versa
-    return (2 ** z) - 1 - y 
+    return (2 ** z) - 1 - y
+
 
 # TODO: change name from source to definition
 class MercatorTileDefinition(object):
@@ -174,7 +169,7 @@ class MercatorTileDefinition(object):
         self.x_origin_offset = x_origin_offset
         self.y_origin_offset = y_origin_offset
         self.initial_resolution = initial_resolution
-        self._resolutions = [self._get_resolution(z) for z in range(self.min_zoom, self.max_zoom+1)]
+        self._resolutions = [self._get_resolution(z) for z in range(self.min_zoom, self.max_zoom + 1)]
 
     def to_ogc_tile_metadata(self, output_file_path):
         '''
@@ -182,13 +177,11 @@ class MercatorTileDefinition(object):
         '''
         pass
 
-
     def to_esri_tile_metadata(self, output_file_path):
         '''
         Create ESRI tile metadata JSON
         '''
         pass
-
 
     def is_valid_tile(self, x, y, z):
 
@@ -200,17 +193,14 @@ class MercatorTileDefinition(object):
 
         return True
 
-
     # TODO ngjit?
     def _get_resolution(self, z):
         return self.initial_resolution / (2 ** z)
-
 
     def get_resolution_by_extent(self, extent, height, width):
         x_rs = (extent[2] - extent[0]) / width
         y_rs = (extent[3] - extent[1]) / height
         return [x_rs, y_rs]
-
 
     def get_level_by_extent(self, extent, height, width):
         x_rs = (extent[2] - extent[0]) / width
@@ -226,8 +216,7 @@ class MercatorTileDefinition(object):
                 if i > 0:
                     return i - 1
             i += 1
-        return (i-1)
-
+        return (i - 1)
 
     def pixels_to_meters(self, px, py, level):
         res = self._get_resolution(level)
@@ -235,13 +224,11 @@ class MercatorTileDefinition(object):
         my = (py * res) - self.y_origin_offset
         return (mx, my)
 
-
     def meters_to_pixels(self, mx, my, level):
         res = self._get_resolution(level)
         px = (mx + self.x_origin_offset) / res
         py = (my + self.y_origin_offset) / res
         return (px, py)
-
 
     def pixels_to_tile(self, px, py, level):
         tx = math.ceil(px / self.tile_size)
@@ -250,16 +237,13 @@ class MercatorTileDefinition(object):
         # convert from TMS y coordinate
         return (int(tx), invert_y_tile(int(ty), level))
 
-
     def pixels_to_raster(self, px, py, level):
         map_size = self.tile_size << level
         return (px, map_size - py)
 
-
     def meters_to_tile(self, mx, my, level):
         px, py = self.meters_to_pixels(mx, my, level)
         return self.pixels_to_tile(px, py, level)
-
 
     def get_tiles_by_extent(self, extent, level):
 
@@ -279,9 +263,8 @@ class MercatorTileDefinition(object):
 
         return tiles
 
-
     def get_tile_meters(self, tx, ty, level):
-        ty = invert_y_tile(ty, level) # convert to TMS for conversion to meters
+        ty = invert_y_tile(ty, level)  # convert to TMS for conversion to meters
         xmin, ymin = self.pixels_to_meters(tx * self.tile_size, ty * self.tile_size, level)
         xmax, ymax = self.pixels_to_meters((tx + 1) * self.tile_size, (ty + 1) * self.tile_size, level)
         return (xmin, ymin, xmax, ymax)
@@ -310,12 +293,12 @@ class TileRenderer(object):
         for t in tiles:
             x, y, z, data_extent = t
             dxmin, dymin, dxmax, dymax = data_extent
-            arr = da.loc[{'x':slice(dxmin, dxmax), 'y':slice(dymin, dymax)}]
+            arr = da.loc[{'x': slice(dxmin, dxmax), 'y': slice(dymin, dymax)}]
 
             if 0 in arr.shape:
                 continue
 
-            img = fromarray(np.flip(arr.data, 0), 'RGBA') # flip since y tiles go down (Google map tiles)
+            img = fromarray(np.flip(arr.data, 0), 'RGBA')  # flip since y tiles go down (Google map tiles)
 
             if self.post_render_func:
                 extras = dict(x=x, y=y, z=z)
@@ -389,6 +372,7 @@ class FileSystemTileRenderer(TileRenderer):
             output_file = os.path.join(tile_directory, tile_file_name)
             _create_dir(tile_directory)
             img.save(output_file, self.tile_format)
+
 
 class S3TileRenderer(TileRenderer):
 


### PR DESCRIPTION
I've been utilizing the TMS tileset rendering feature for a couple weeks, after seeing Tom White's article, using his branch that was recently merged. I'd been attempting to render the OSM 1 billion point dataset to a TMS tileset for demonstration purposes, but repeatedly failing on my machine (Xeon E3-1505M v6, 64 GB Ram). I investigated and identified some performance improvements that I've included in this pull request: 

- Remove duplicate calls to gen_super_tiles
- Cache results of rasterize_func instead of running twice, during both calculate_zoom_level_stats and render_super_tile
- Moved calculate_zoom_level_stats to a serial implementation instead of dask.bag.map to reduce memory overhead that caused large renders to fail

![Performance Comparison of Tileset Rendering (50 Million OSM GPS Points)](https://user-images.githubusercontent.com/36244490/76174660-176d4780-617f-11ea-9155-ba21398bdbb1.png)

Using this branch, I was able to successfully render the OSM 1 billion point dataset. The elapsed times for each level are below. 

|Level|Super Tile Count|Calculating Stats (s)|Rendering (s)| Total Time (s)|
|-----|-------------------|---------------------|---------------|---------------|
|0|1|46.70|16.39|63.08|
|1|1|42.98|9.47|52.45|
|2|1|43.79|8.82|52.61|
|3|1|41.64|9.68|51.32|
|4|1|41.99|11.97|53.97|
|5|4|65.52|25.96|91.48|
|6|16|155.82|81.61|237.43|
|7|64|515.14|314.10|829.25|
|8|256|2130.61|737.57|2868.18|
|9|1024|8646.66|1456.87|10103.54|

