### PR TITLE
Add support for by with multiple base reductions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,11 @@ stages:
   - name: docs
     if: tag =~ ^v(\d+|\.)*[^a-z]\d*$ OR tag = website
   - name: docs_dev
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$ OR tag = website_dev OR commit_message =~ /^.*(website_dev).*$/
+    if: tag =~ ^v(\d+|\.)+([a-z]|rc)\d+$ OR tag = website_dev OR commit_message =~ /^.*(website_dev).*$/
   - name: conda_dev_package
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
+    if: tag =~ ^v(\d+|\.)+([a-z]|rc)\d+$
   - name: pip_dev_package
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
+    if: tag =~ ^v(\d+|\.)+([a-z]|rc)\d+$
   - name: conda_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: pip_package

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -194,6 +194,12 @@ class by(Reduction):
                 shape + (n_cats,), dtype='i4'
             )
 
+    def _build_bases(self, cuda=False):
+        bases = self.reduction._build_bases(cuda)
+        if bases[0] is self:
+            return bases
+        return tuple(by(self.cat_column, base) for base in bases)
+
     def _build_append(self, dshape, schema, cuda=False):
         f = self.reduction._build_append(dshape, schema, cuda)
         # because we transposed, we also need to flip the

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -310,10 +310,10 @@ def test_categorical_mean(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_var(df):
-    sol = np.array([[[4.808333,       nan,        nan,        nan],
-                     [     nan,       nan, 131.965575,        nan]],
-                    [[     nan, 43.693333,        nan,        nan],
-                     [     nan,       nan,        nan, 202.769717]]])
+    sol = np.array([[[1.3625,  nan,  nan,  nan],
+                     [   nan,  nan, 1.21,  nan]],
+                    [[   nan, 1.21,  nan,  nan],
+                     [   nan,  nan,  nan, 1.21]]])
     out = xr.DataArray(
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
@@ -323,10 +323,10 @@ def test_categorical_var(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_std(df):
-    sol = np.array([[[2.192791,      nan,       nan,       nan],
-                     [     nan,      nan, 11.487627,       nan]],
-                    [[     nan, 6.610093,       nan,       nan],
-                     [     nan,      nan,       nan, 14.239723]]])
+    sol = np.array([[[1.16726175, nan, nan, nan],
+                     [       nan, nan, 1.1, nan]],
+                    [[       nan, 1.1, nan, nan],
+                     [       nan, nan, nan, 1.1]]])
     out = xr.DataArray(
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -24,8 +24,8 @@ df_pd = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                       'empty_bin': np.array([0.] * 15 + [np.nan] * 5),
                       'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
 df_pd.cat = df_pd.cat.astype('category')
-df_pd.at[2,'f32'] = np.nan
-df_pd.at[2,'f64'] = np.nan
+df_pd.at[2,'f32'] = nan
+df_pd.at[2,'f64'] = nan
 dfs_pd = [df_pd]
 
 if "DATASHADER_TEST_GPU" in os.environ:
@@ -292,6 +292,47 @@ def test_categorical_max(df):
         dims=(dims + ['cat']))
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.max('i32')))
     assert_eq_xr(agg, out)
+
+
+
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_mean(df):
+    sol = np.array([[[  2, nan, nan, nan],
+                     [nan, nan,  12, nan]],
+                    [[nan,   7, nan, nan],
+                     [nan, nan, nan,  17]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.mean('f64')))
+    assert_eq_xr(agg, out)
+
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_var(df):
+    sol = np.array([[[4.808333,       nan,        nan,        nan],
+                     [     nan,       nan, 131.965575,        nan]],
+                    [[     nan, 43.693333,        nan,        nan],
+                     [     nan,       nan,        nan, 202.769717]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.var('f64')))
+    assert_eq_xr(agg, out, True)
+
+@pytest.mark.parametrize('df', dfs)
+def test_categorical_std(df):
+    sol = np.array([[[2.192791,      nan,       nan,       nan],
+                     [     nan,      nan, 11.487627,       nan]],
+                    [[     nan, 6.610093,       nan,       nan],
+                     [     nan,      nan,       nan, 14.239723]]])
+    out = xr.DataArray(
+        sol,
+        coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
+        dims=(dims + ['cat']))
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.std('f64')))
+    assert_eq_xr(agg, out, True)
 
 @pytest.mark.parametrize('df', dfs)
 def test_multiple_aggregates(df):

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ extras_require = {
         'nbsmoke[all] >=0.4.0',
         'fastparquet >=0.1.6',  # optional dependency
         'holoviews >=1.10.0',
+        'numba <0.49.0',
     ],
     'examples': examples,
     'examples_extra': examples + [


### PR DESCRIPTION
This allows for reductions like `mean`, `var` and `std` to be used with `by`. This is achieved through three steps:

1. If a reduction has multiple bases (e.g. `mean` has `sum` and `count`) then create bases like `by('cat', base_reduction)`
2. Ensure that the `_append` method correctly handles the additional categorical dimension by wrapping the function
3. Ensure that during finalization the bases are combined e.g. `sum`/`count`, while also handling the categorical dimension

There are a few assumption made here:

* Any reduction with multiple bases that is to be supported with `by` must define a `_finalize` method
* Any reduction with an `append` that requires more than one value will need special handling (e.g. see handling of `m2` here)

Fixes https://github.com/holoviz/datashader/issues/900