### PR TITLE
Fixed categorical var/std reductions in dask

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -240,9 +240,9 @@ class by(Reduction):
         return aggs.sum(axis=0, dtype='i4')
 
     def _combine_m2(self, Ms, sums, ns):
-        Ms = Ms.sum(axis=0, dtype='f8')
-        sums = sums.sum(axis=0, dtype='f8')
-        ns = ns.sum(axis=0, dtype='i4')
+        Ms   = self._combine_float(Ms)
+        sums = self._combine_float(sums)
+        ns   = self._combine_int(ns)
         return self.reduction._combine(Ms, sums, ns)
 
     def _build_finalize(self, dshape):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -224,7 +224,9 @@ class by(Reduction):
         return ngjit(_categorical_append)
 
     def _build_combine(self, dshape):
-        if isinstance(self.reduction, FloatingReduction):
+        if isinstance(self.reduction, m2):
+            return self._combine_m2
+        elif isinstance(self.reduction, FloatingReduction):
             return self._combine_float
         else:
             return self._combine_int
@@ -236,6 +238,12 @@ class by(Reduction):
     @staticmethod
     def _combine_int(aggs):
         return aggs.sum(axis=0, dtype='i4')
+
+    def _combine_m2(self, Ms, sums, ns):
+        Ms = Ms.sum(axis=0, dtype='f8')
+        sums = sums.sum(axis=0, dtype='f8')
+        ns = ns.sum(axis=0, dtype='i4')
+        return self.reduction._combine(Ms, sums, ns)
 
     def _build_finalize(self, dshape):
         cats = list(dshape[self.cat_column].categories)

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1,12 +1,14 @@
 from __future__ import division, absolute_import
+
 import os
 
-from dask.context import config
 import dask.dataframe as dd
 import numpy as np
-from numpy import nan
 import pandas as pd
 import xarray as xr
+
+from dask.context import config
+from numpy import nan
 
 import datashader as ds
 import datashader.utils as du
@@ -261,6 +263,57 @@ def test_categorical_sum(ddf):
 
     agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.sum('f64')))
     assert_eq_xr(agg, out)
+
+@pytest.mark.parametrize('ddf', ddfs)
+def test_categorical_mean(ddf):
+    sol = np.array([[[  2, nan, nan, nan],
+                     [nan, nan,  12, nan]],
+                    [[nan,   7, nan, nan],
+                     [nan, nan, nan,  17]]])
+    out = xr.DataArray(
+        sol,
+        coords=(coords + [['a', 'b', 'c', 'd']]),
+        dims=(dims + ['cat']))
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.mean('f32')))
+    assert_eq_xr(agg, out)
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.mean('f64')))
+    assert_eq_xr(agg, out)
+
+@pytest.mark.parametrize('ddf', ddfs)
+def test_categorical_var(ddf):
+    sol = np.array([[[1.3625,  nan,  nan,  nan],
+                     [   nan,  nan, 1.21,  nan]],
+                    [[   nan, 1.21,  nan,  nan],
+                     [   nan,  nan,  nan, 1.21]]])
+    out = xr.DataArray(
+        sol,
+        coords=(coords + [['a', 'b', 'c', 'd']]),
+        dims=(dims + ['cat']))
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.var('f32')))
+    assert_eq_xr(agg, out, True)
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.var('f64')))
+    assert_eq_xr(agg, out, True)
+
+@pytest.mark.parametrize('ddf', ddfs)
+def test_categorical_std(ddf):
+    sol = np.array([[[1.16726175, nan, nan, nan],
+                     [       nan, nan, 1.1, nan]],
+                    [[       nan, 1.1, nan, nan],
+                     [       nan, nan, nan, 1.1]]])
+    out = xr.DataArray(
+        sol,
+        coords=(coords + [['a', 'b', 'c', 'd']]),
+        dims=(dims + ['cat']))
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.std('f32')))
+    assert_eq_xr(agg, out, True)
+
+    agg = c.points(ddf, 'x', 'y', ds.by('cat', ds.std('f64')))
+    assert_eq_xr(agg, out, True)
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_multiple_aggregates(ddf):

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -293,8 +293,6 @@ def test_categorical_max(df):
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.max('i32')))
     assert_eq_xr(agg, out)
 
-
-
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_mean(df):
     sol = np.array([[[  2, nan, nan, nan],
@@ -305,6 +303,10 @@ def test_categorical_mean(df):
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
         dims=(dims + ['cat']))
+
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.mean('f32')))
+    assert_eq_xr(agg, out)
+
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.mean('f64')))
     assert_eq_xr(agg, out)
 
@@ -318,6 +320,10 @@ def test_categorical_var(df):
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
         dims=(dims + ['cat']))
+
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.var('f32')))
+    assert_eq_xr(agg, out, True)
+
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.var('f64')))
     assert_eq_xr(agg, out, True)
 
@@ -331,6 +337,10 @@ def test_categorical_std(df):
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
         dims=(dims + ['cat']))
+    
+    agg = c.points(df, 'x', 'y', ds.by('cat', ds.std('f32')))
+    assert_eq_xr(agg, out, True)
+
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.std('f64')))
     assert_eq_xr(agg, out, True)
 


### PR DESCRIPTION
In my previous PR I had only tested pandas but for var/std reductions the combine implementation also needs to be handled for `m2` reductions (needed for `var` and `std`).

Fixes https://github.com/holoviz/datashader/issues/900