### PR TITLE
Correctly combine multi-chunk categorical reductions

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -224,26 +224,7 @@ class by(Reduction):
         return ngjit(_categorical_append)
 
     def _build_combine(self, dshape):
-        if isinstance(self.reduction, m2):
-            return self._combine_m2
-        elif isinstance(self.reduction, FloatingReduction):
-            return self._combine_float
-        else:
-            return self._combine_int
-
-    @staticmethod
-    def _combine_float(aggs):
-        return aggs.sum(axis=0, dtype='f8')
-
-    @staticmethod
-    def _combine_int(aggs):
-        return aggs.sum(axis=0, dtype='i4')
-
-    def _combine_m2(self, Ms, sums, ns):
-        Ms   = self._combine_float(Ms)
-        sums = self._combine_float(sums)
-        ns   = self._combine_int(ns)
-        return self.reduction._combine(Ms, sums, ns)
+        return self.reduction._combine
 
     def _build_finalize(self, dshape):
         cats = list(dshape[self.cat_column].categories)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -204,24 +204,7 @@ class by(Reduction):
         return tuple(by(self.cat_column, base) for base in bases)
 
     def _build_append(self, dshape, schema, cuda=False):
-        f = self.reduction._build_append(dshape, schema, cuda)
-        # because we transposed, we also need to flip the
-        # order of the x/y arguments
-        if isinstance(self.reduction, m2):
-            def _categorical_append(x, y, agg, cols, tmp1, tmp2):
-                _agg = agg.transpose()
-                _ind = int(cols[0])
-                f(y, x, _agg[_ind], cols[1], tmp1[_ind], tmp2[_ind])
-        elif self.val_column is not None:
-            def _categorical_append(x, y, agg, field):
-                _agg = agg.transpose()
-                f(y, x, _agg[int(field[0])], field[1])
-        else:
-            def _categorical_append(x, y, agg, field):
-                _agg = agg.transpose()
-                f(y, x, _agg[int(field)])
-
-        return ngjit(_categorical_append)
+        return self.reduction._build_append(dshape, schema, cuda)
 
     def _build_combine(self, dshape):
         return self.reduction._combine

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -283,10 +283,10 @@ def test_categorical_mean(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_var(ddf):
-    sol = np.array([[[1.3625,  nan,  nan,  nan],
-                     [   nan,  nan, 1.21,  nan]],
-                    [[   nan, 1.21,  nan,  nan],
-                     [   nan,  nan,  nan, 1.21]]])
+    sol = np.array([[[ 2.5,  nan,  nan,  nan],
+                     [ nan,  nan,   2.,  nan]],
+                    [[ nan,   2.,  nan,  nan],
+                     [ nan,  nan,  nan,   2.]]])
     out = xr.DataArray(
         sol,
         coords=(coords + [['a', 'b', 'c', 'd']]),
@@ -300,10 +300,12 @@ def test_categorical_var(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_std(ddf):
-    sol = np.array([[[1.16726175, nan, nan, nan],
-                     [       nan, nan, 1.1, nan]],
-                    [[       nan, 1.1, nan, nan],
-                     [       nan, nan, nan, 1.1]]])
+    sol = np.sqrt(np.array([
+        [[ 2.5,  nan,  nan,  nan],
+         [ nan,  nan,   2.,  nan]],
+        [[ nan,   2.,  nan,  nan],
+         [ nan,  nan,  nan,   2.]]])
+    )
     out = xr.DataArray(
         sol,
         coords=(coords + [['a', 'b', 'c', 'd']]),

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -312,10 +312,10 @@ def test_categorical_mean(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_var(df):
-    sol = np.array([[[1.3625,  nan,  nan,  nan],
-                     [   nan,  nan, 1.21,  nan]],
-                    [[   nan, 1.21,  nan,  nan],
-                     [   nan,  nan,  nan, 1.21]]])
+    sol = np.array([[[ 2.5,  nan,  nan,  nan],
+                     [ nan,  nan,   2.,  nan]],
+                    [[ nan,   2.,  nan,  nan],
+                     [ nan,  nan,  nan,   2.]]])
     out = xr.DataArray(
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
@@ -329,10 +329,12 @@ def test_categorical_var(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_std(df):
-    sol = np.array([[[1.16726175, nan, nan, nan],
-                     [       nan, nan, 1.1, nan]],
-                    [[       nan, 1.1, nan, nan],
-                     [       nan, nan, nan, 1.1]]])
+    sol = np.sqrt(np.array([
+        [[ 2.5,  nan,  nan,  nan],
+         [ nan,  nan,   2.,  nan]],
+        [[ nan,   2.,  nan,  nan],
+         [ nan,  nan,  nan,   2.]]])
+    )
     out = xr.DataArray(
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),


### PR DESCRIPTION
This PR moves some of the logic used for handling categorical aggregates in `by` into the compiler code. This was the only way I could make temporary arrays (needed for the `m2` reduction) respect the correct indexing when the array had a categorical dimension.

This should be safe because in the non-categorical case the compiler is untouched.

Fixes https://github.com/holoviz/datashader/issues/900