### PR TITLE
Fix _colorize alpha for case of no provided span

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -359,7 +359,7 @@ def test_shade_category(array):
     # First test auto-span
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20)
     sol = np.array([[16777215, 335565567],
-                    [3612686250, 2298478847]], dtype='u4')
+                    [4283774890, 2701132031]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
 
@@ -371,7 +371,7 @@ def test_shade_category(array):
 
     # Next test manual-span
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20, span=(6, 36))
-    sol = np.array([[16777215, 335565567],
+    sol = np.array([[0, 335565567],
                     [4283774890, 2701132031]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
@@ -400,8 +400,8 @@ def test_shade_category(array):
     assert ((img.data[1,1] >> 24) & 0xFF) == 0 # fully transparent
 
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20, span=(6, 36))
-    sol = np.array([[16777215, 16777215],
-                    [16777215, 16777215]], dtype='u4')
+    sol = np.array([[16711680, 21247],
+                    [5584810, 255]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
     assert ((img.data[0,0] >> 24) & 0xFF) == 0 # fully transparent

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -357,7 +357,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
     # min/max of the data
     if span is None:
         # Currently masks out zero or negative values, but will need fixing         
-        offset = total.min()
+        offset = np.nanmin(total)
         if offset <= 0:
             mask = mask | (total <= 0)
             # If at least one element is not masked, use the minimum as the offset
@@ -377,9 +377,8 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         offset = np.array(span, dtype=data.dtype)[0]
         if offset <= 0:
             mask = mask | (total <= 0)
-            offset = total[total > 0].min()
-        a_ = _normalize_interpolate_how(how)(total - offset, mask)
         span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
+        a_ = _normalize_interpolate_how(how)(total - offset, mask)
 
     # Interpolate the alpha values
     a = interp(a_, array(span),

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -364,8 +364,8 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
             # otherwise the offset remains at zero
             if not np.all(mask):
                 offset = total[total > 0].min()
-        a_ = _normalize_interpolate_how(how)(total - offset, mask)
-        span = [np.nanmin(a_).item(), np.nanmax(a_).item()]
+        a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
+        norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
     else:
         if how == 'eq_hist':
             # For eq_hist to work with span, we'll need to store the histogram
@@ -377,11 +377,11 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         offset = np.array(span, dtype=data.dtype)[0]
         if offset <= 0:
             mask = mask | (total <= 0)
-        span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
-        a_ = _normalize_interpolate_how(how)(total - offset, mask)
+        a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
+        norm_span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
 
     # Interpolate the alpha values
-    a = interp(a_, array(span),
+    a = interp(a_scaled, array(norm_span),
                array([min_alpha, 255]), left=0, right=255).astype(np.uint8)
     r[mask] = g[mask] = b[mask] = 255
     values = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -356,18 +356,16 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
     # if span is provided, use it, otherwise produce it a span based off the
     # min/max of the data
     if span is None:
-        span = [np.nanmin(total).item(), np.nanmax(total).item()]
-        offset = span[0]
-        if how != 'eq_hist':
-            span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
-        # If there are elements that are zero or lower, they should be fully
-        # transparent and masked out
+        # Currently masks out zero or negative values, but will need fixing         
+        offset = total.min()
         if offset <= 0:
             mask = mask | (total <= 0)
             # If at least one element is not masked, use the minimum as the offset
             # otherwise the offset remains at zero
             if not np.all(mask):
                 offset = total[total > 0].min()
+        a_ = _normalize_interpolate_how(how)(total - offset, mask)
+        span = [np.nanmin(a_).item(), np.nanmax(a_).item()]
     else:
         if how == 'eq_hist':
             # For eq_hist to work with span, we'll need to store the histogram
@@ -376,15 +374,15 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         # even in fixed-span mode cells with 0 should remain fully transparent
         # i.e. a 0 will be fully transparent, but any non-zero number will
         # be clipped to the span range and have min-alpha applied
-        mask = mask | (total <= 0)
-        # clip all other values to the fixed span
-        masked_clip_2d(total, mask, *span)
-        offset = span[0]
+        offset = np.array(span, dtype=data.dtype)[0]
+        if offset <= 0:
+            mask = mask | (total <= 0)
+            offset = total[total > 0].min()
+        a_ = _normalize_interpolate_how(how)(total - offset, mask)
         span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
 
-    a = _normalize_interpolate_how(how)(total - offset, mask)
     # Interpolate the alpha values
-    a = interp(a, array(span),
+    a = interp(a_, array(span),
                array([min_alpha, 255]), left=0, right=255).astype(np.uint8)
     r[mask] = g[mask] = b[mask] = 255
     values = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)


### PR DESCRIPTION
PR #875 introduced a regression, with categorical colormapping computing an incorrect alpha range. Specifically, in the previous release the output in the "Original Image" cell below used the full range of alpha values, resulting in bright colors:

![image](https://user-images.githubusercontent.com/1695496/80847273-a5d8d500-8bd4-11ea-95b0-005db748693b.png)

while with current Datashader master the alpha range is very small:

![image](https://user-images.githubusercontent.com/1695496/80847255-99ed1300-8bd4-11ea-9ec5-69947bc9e1c9.png)

With git bisect it was clear that these changes were from the changes to _colorize() in #875 to allow specifying a span.  On investigation, the issue was that previously when no span was set, the range of alpha values was set based on the interpolated (scaled) data, while after #875 the range was set using unscaled data (which in this example is a much smaller range than the 0 to 255 scaled range).

Because there have been changes to this code since #875 (and specifically in #896), it was difficult to see how to restore the original behavior, but I've done my best.  The results look appropriate to me with and without a specified span on these examples now.

![image](https://user-images.githubusercontent.com/1695496/80847663-1af8da00-8bd6-11ea-84ed-c26c9fb7bce9.png)

But some part of the changes in #896 may have been lost, e.g. whatever `masked_clip_2d(total, mask, *span)` was doing here. Plus I have not yet tried to address the clearly inappropriate behavior for negative values, which should _not_  be masked off as they are now.
