### PR TITLE
Handle negative values in categorical colorize

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -192,6 +192,10 @@ class by(Reduction):
             return lambda shape, array_module: array_module.zeros(
                 shape + (n_cats,), dtype='f8'
             )
+        elif isinstance(self.reduction, count):
+            return lambda shape, array_module: array_module.zeros(
+                shape + (n_cats,), dtype='u4'
+            )
         else:
             return lambda shape, array_module: array_module.zeros(
                 shape + (n_cats,), dtype='i4'
@@ -264,7 +268,7 @@ class count(OptionalFieldReduction):
         If provided, only counts elements in ``column`` that are not ``NaN``.
         Otherwise, counts every element.
     """
-    _dshape = dshape(ct.int32)
+    _dshape = dshape(ct.uint32)
 
     # CPU append functions
     @staticmethod
@@ -293,11 +297,11 @@ class count(OptionalFieldReduction):
 
     @staticmethod
     def _create(shape, array_module):
-        return array_module.zeros(shape, dtype='i4')
+        return array_module.zeros(shape, dtype='u4')
 
     @staticmethod
     def _combine(aggs):
-        return aggs.sum(axis=0, dtype='i4')
+        return aggs.sum(axis=0, dtype='u4')
 
 
 class any(OptionalFieldReduction):

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -264,9 +264,9 @@ def test_shade_mpl_cmap(agg):
 def test_shade_category(array):
     coords = [np.array([0, 1]), np.array([2, 5])]
     cat_agg = tf.Image(array([[(0, 12, 0), (3, 0, 3)],
-                                  [(12, 12, 12), (24, 0, 0)]]),
-                           coords=(coords + [['a', 'b', 'c']]),
-                           dims=(dims + ['cats']))
+                              [(12, 12, 12), (24, 0, 0)]], dtype='u4'),
+                       coords=(coords + [['a', 'b', 'c']]),
+                       dims=(dims + ['cats']))
 
     colors = [(255, 0, 0), '#0000FF', 'orange']
 
@@ -352,7 +352,7 @@ def test_shade_category(array):
     # test that empty coordinates are always fully transparent, even when
     # min_alpha is non-zero
     cat_agg = tf.Image(array([[(0, 0, 0), (3, 0, 3)],
-                                [(12, 12, 12), (24, 0, 0)]]),
+                              [(12, 12, 12), (24, 0, 0)]], dtype='u4'),
                            coords=(coords + [['a', 'b', 'c']]),
                            dims=(dims + ['cats']))
     
@@ -371,7 +371,7 @@ def test_shade_category(array):
 
     # Next test manual-span
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20, span=(6, 36))
-    sol = np.array([[0, 335565567],
+    sol = np.array([[16777215, 335565567],
                     [4283774890, 2701132031]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
@@ -385,35 +385,35 @@ def test_shade_category(array):
     # Categorical aggregations with some reductions (such as sum) can result in negative
     # values in the data
     cat_agg = tf.Image(array([[(0, -30, 0), (-18, 0, -18)],
-                                [(-2, -2, -2), (-18, 0, 0)]]),
-                        coords=(coords + [['a', 'b', 'c']]),
-                        dims=(dims + ['cats']))
+                              [(-2, -2, -2), (-18, 0, 0)]], dtype='i4'),
+                       coords=(coords + [['a', 'b', 'c']]),
+                       dims=(dims + ['cats']))
 
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20)
-    sol = np.array([[16777215, 16777215],
-                    [16777215, 16777215]], dtype='u4')
+    sol = np.array([[1140785152, 335565567],
+                    [4283774890, 2701132031]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
-    assert ((img.data[0,0] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[0,1] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[1,0] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[1,1] >> 24) & 0xFF) == 0 # fully transparent
+    assert ((img.data[0,0] >> 24) & 0xFF) == 67
+    assert ((img.data[0,1] >> 24) & 0xFF) == 20
+    assert ((img.data[1,0] >> 24) & 0xFF) == 255
+    assert ((img.data[1,1] >> 24) & 0xFF) == 161
 
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20, span=(6, 36))
-    sol = np.array([[16711680, 21247],
-                    [5584810, 255]], dtype='u4')
+    sol = np.array([[352256000, 335565567],
+                    [341129130, 335544575]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
-    assert ((img.data[0,0] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[0,1] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[1,0] >> 24) & 0xFF) == 0 # fully transparent
-    assert ((img.data[1,1] >> 24) & 0xFF) == 0 # fully transparent
+    assert ((img.data[0,0] >> 24) & 0xFF) == 20 # min alpha
+    assert ((img.data[0,1] >> 24) & 0xFF) == 20 # min alpha
+    assert ((img.data[1,0] >> 24) & 0xFF) == 20 # min alpha
+    assert ((img.data[1,1] >> 24) & 0xFF) == 20 # min alpha
 
 @pytest.mark.parametrize('array', arrays)
 def test_shade_zeros(array):
     coords = [np.array([0, 1]), np.array([2, 5])]
     cat_agg = tf.Image(array([[(0, 0, 0), (0, 0, 0)],
-                                  [(0, 0, 0), (0, 0, 0)]]),
+                              [(0, 0, 0), (0, 0, 0)]], dtype='u4'),
                            coords=(coords + [['a', 'b', 'c']]),
                            dims=(dims + ['cats']))
 
@@ -424,6 +424,7 @@ def test_shade_zeros(array):
                     [16777215, 16777215]], dtype='u4')
     sol = tf.Image(sol, coords=coords, dims=dims)
     assert_eq_xr(img, sol)
+
 
 coords2 = [np.array([0, 2]), np.array([3, 5])]
 img1 = tf.Image(np.array([[0xff00ffff, 0x00000000],

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -163,7 +163,9 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or np.issubdtype(data2.dtype, np.integer):
-        hist = np.bincount(data2.astype('i8').ravel())
+        if data2.dtype.kind == 'u':
+             data2 = data2.astype('i8')
+        hist = np.bincount(data2.ravel())
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])
         hist, bin_centers = hist[idx:], bin_centers[idx:]

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -334,8 +334,8 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
             # otherwise the offset remains at zero
             if not np.all(mask):
                 offset = total[total > 0].min()
-        masked_total = np.where(~mask, total, np.nan)
-        a_scaled = _normalize_interpolate_how(how)(masked_total - offset, mask)
+            total = np.where(~mask, total, np.nan)
+        a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
         norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
     else:
         if how == 'eq_hist':
@@ -346,9 +346,10 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         # i.e. a 0 will be fully transparent, but any non-zero number will
         # be clipped to the span range and have min-alpha applied
         offset = np.array(span, dtype=data.dtype)[0]
-        if offset == 0  and total.dtype.kind == 'u':
+        if np.nanmin(total) == 0 and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
-        masked_clip_2d(data, mask, *span)
+            total = np.where(~mask, total, np.nan)
+        masked_clip_2d(total, mask, *span)
         a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
         norm_span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
 

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -358,7 +358,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
     if span is None:
         # Currently masks out zero or negative values, but will need fixing         
         offset = np.nanmin(total)
-        if offset <= 0:
+        if offset <= 0 and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
             # If at least one element is not masked, use the minimum as the offset
             # otherwise the offset remains at zero
@@ -375,7 +375,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         # i.e. a 0 will be fully transparent, but any non-zero number will
         # be clipped to the span range and have min-alpha applied
         offset = np.array(span, dtype=data.dtype)[0]
-        if offset <= 0:
+        if offset <= 0  and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
         a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
         norm_span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -190,39 +190,6 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
-@ngjit
-def masked_clip_2d(data, mask, lower, upper):
-    """
-    Clip the elements of an input array between lower and upper bounds,
-    skipping over elements that are masked out.
-
-    Parameters
-    ----------
-    data: np.ndarray
-        Numeric ndarray that will be clipped in-place
-    mask: np.ndarray
-        Boolean ndarray where True values indicate elements that should be
-        skipped
-    lower: int or float
-        Lower bound to clip to
-    upper: int or float
-        Upper bound to clip to
-
-    Returns
-    -------
-    None
-        data array is modified in-place
-    """
-    for i in range(data.shape[0]):
-        for j in range(data.shape[1]):
-            if mask[i, j]:
-                continue
-            val = data[i, j]
-            if val < lower:
-                data[i, j] = lower
-            elif val > upper:
-                data[i, j] = upper
-
 def _interpolate(agg, cmap, how, alpha, span, min_alpha, name):
     if cupy and isinstance(agg.data, cupy.ndarray):
         from ._cuda_utils import masked_clip_2d, interp

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -292,7 +292,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         from ._cuda_utils import interp, masked_clip_2d 
         array = cupy.array
     else:
-        from ._cpu_utils import masked_clip_2delse:
+        from ._cpu_utils import masked_clip_2d
         interp = np.interp
         array = np.array
 
@@ -326,7 +326,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
     if span is None:
         # Currently masks out zero or negative values, but will need fixing         
         offset = np.nanmin(total)
-        if offset <= 0 and total.dtype.kind == 'u':
+        if offset == 0 and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
             # If at least one element is not masked, use the minimum as the offset
             # otherwise the offset remains at zero
@@ -343,7 +343,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         # i.e. a 0 will be fully transparent, but any non-zero number will
         # be clipped to the span range and have min-alpha applied
         offset = np.array(span, dtype=data.dtype)[0]
-        if offset <= 0  and total.dtype.kind == 'u':
+        if offset == 0  and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
         masked_clip_2d(data, mask, *span)
         a_scaled = _normalize_interpolate_how(how)(total - offset, mask)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -289,9 +289,10 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name):
 
 def _colorize(agg, color_key, how, span, min_alpha, name):
     if cupy and isinstance(agg.data, cupy.ndarray):
-        from ._cuda_utils import interp
+        from ._cuda_utils import interp, masked_clip_2d 
         array = cupy.array
     else:
+        from ._cpu_utils import masked_clip_2delse:
         interp = np.interp
         array = np.array
 
@@ -344,6 +345,7 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
         offset = np.array(span, dtype=data.dtype)[0]
         if offset <= 0  and total.dtype.kind == 'u':
             mask = mask | (total <= 0)
+        masked_clip_2d(data, mask, *span)
         a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
         norm_span = _normalize_interpolate_how(how)([0, span[1] - span[0]], 0)
 

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -163,7 +163,7 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or np.issubdtype(data2.dtype, np.integer):
-        hist = np.bincount(data2.ravel())
+        hist = np.bincount(data2.astype('i8').ravel())
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])
         hist, bin_centers = hist[idx:], bin_centers[idx:]
@@ -332,7 +332,8 @@ def _colorize(agg, color_key, how, span, min_alpha, name):
             # otherwise the offset remains at zero
             if not np.all(mask):
                 offset = total[total > 0].min()
-        a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
+        masked_total = np.where(~mask, total, np.nan)
+        a_scaled = _normalize_interpolate_how(how)(masked_total - offset, mask)
         norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
     else:
         if how == 'eq_hist':


### PR DESCRIPTION
I've been testing with the following code:

```python
import numpy as np
import datashader.transfer_functions as tf
import holoviews as hv
hv.extension('bokeh')
coords = [np.array([0, 1]), np.array([2, 5])]
dims = ['y_axis', 'x_axis']
cat_agg = tf.Image(np.array([[(0, -30, 0), (-18, 0, -18)],
                                [(-2, -2, -2), (-18, 0, 0)]]),
                        coords=(coords + [['a', 'b', 'c']]),
                        dims=(dims + ['cats']))
colors = [(255, 0, 0), '#0000FF', 'orange']
img = tf.shade(cat_agg, color_key=colors, how='linear', span=(-36, 0), min_alpha=20)
img2 = tf.shade(cat_agg, color_key=colors, how='linear')
hv.RGB(img.data.view('uint8').reshape((2, 2, 4))[::-1, :]) +\
hv.RGB(img2.data.view('uint8').reshape((2, 2, 4))[::-1, :])
```