### PR TITLE
Fix zonal stat example in the docs

### DIFF
--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -118,7 +118,7 @@ def stack(*imgs, **kwargs):
     """
     if not imgs:
         raise ValueError("No images passed in")
-    shapes = ()
+    shapes = []
     for i in imgs:
         if not isinstance(i, Image):
             raise TypeError("Expected `Image`, got: `{0}`".format(type(i)))

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -118,9 +118,14 @@ def stack(*imgs, **kwargs):
     """
     if not imgs:
         raise ValueError("No images passed in")
+    shapes = ()
     for i in imgs:
         if not isinstance(i, Image):
             raise TypeError("Expected `Image`, got: `{0}`".format(type(i)))
+        elif not shapes:
+            shapes.append(i.shape)
+        elif shapes and i.shape not in shapes:
+            raise ValueError("The stacked images must have the same shape.")
 
     name = kwargs.get('name', None)
     op = composite_op_lookup[kwargs.get('how', 'over')]

--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -675,7 +675,6 @@
     "})\n",
     "\n",
     "zones_agg = cvs.line(zone_df, 'x', 'y', ds.sum('trail_segement_id'))\n",
-    "zones_agg.values = np.nan_to_num(zones_agg.values, copy=False).astype(np.int)\n",
     "zones_shaded = dynspread(shade(zones_agg, cmap=Set1), max_px=5)\n",
     "\n",
     "stack(illuminated_shaded, terrain_shaded, zones_shaded)"


### PR DESCRIPTION
Since we added special handling for zeros in a uint array but not an int array the zonal stats example that casts to int types does not mask out the zero values and we get a red background:

Before:

![download (1)](https://user-images.githubusercontent.com/1550771/82809478-7a23d480-9e8c-11ea-91c2-1347d3d3d029.png)

After:

![download (2)](https://user-images.githubusercontent.com/1550771/82809588-b9eabc00-9e8c-11ea-8a22-babac61a1d28.png)

I've also taken the opportunity to add an explicit error for mismatching shapes on stack because I just came across a user who got caught out by this.