### PR TITLE
Pin numba<0.49

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0',
+    'numba >=0.37.0,<0.49',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',


### PR DESCRIPTION
Numba versions >=0.49 exhibit a serious performance regression, for more detail see: https://github.com/numba/numba/issues/5746