### PR TITLE
GPU fixes

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -68,8 +68,8 @@ class category_values(Preprocess):
                 nullval = np.nan
             else:
                 nullval = 0
-            a = df[self.columns[0]].cat.codes.to_gpu_array()
-            b = df[self.columns[1]].to_gpu_array(fillna=nullval)
+            a = cupy.asarray(df[self.columns[0]].cat.codes.to_gpu_array())
+            b = cupy.asarray(df[self.columns[1]].to_gpu_array(fillna=nullval))
             return cupy.stack((a, b), axis=-1)
         else:
             a = df[self.columns[0]].cat.codes.values
@@ -153,7 +153,7 @@ class by(Reduction):
         self.columns = (cat_column, getattr(reduction, 'column', None))
         self.reduction = reduction
         self.column = cat_column # for backwards compatibility with count_cat
-        
+
     def __hash__(self):
         return hash((type(self), self._hashable_inputs(), self.reduction))
 

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -283,6 +283,11 @@ def test_categorical_mean(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_var(ddf):
+    if cudf and isinstance(ddf.meta, cudf.DataFrame):
+        pytest.skip(
+            "The 'var' reduction is yet supported on the GPU"
+        )
+
     sol = np.array([[[ 2.5,  nan,  nan,  nan],
                      [ nan,  nan,   2.,  nan]],
                     [[ nan,   2.,  nan,  nan],
@@ -300,6 +305,11 @@ def test_categorical_var(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_std(ddf):
+    if cudf and isinstance(ddf.meta, cudf.DataFrame):
+        pytest.skip(
+            "The 'std' reduction is yet supported on the GPU"
+        )
+
     sol = np.sqrt(np.array([
         [[ 2.5,  nan,  nan,  nan],
          [ nan,  nan,   2.,  nan]],

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -283,7 +283,7 @@ def test_categorical_mean(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_var(ddf):
-    if cudf and isinstance(ddf.meta, cudf.DataFrame):
+    if cudf and isinstance(ddf._meta, cudf.DataFrame):
         pytest.skip(
             "The 'var' reduction is yet supported on the GPU"
         )
@@ -305,7 +305,7 @@ def test_categorical_var(ddf):
 
 @pytest.mark.parametrize('ddf', ddfs)
 def test_categorical_std(ddf):
-    if cudf and isinstance(ddf.meta, cudf.DataFrame):
+    if cudf and isinstance(ddf._meta, cudf.DataFrame):
         pytest.skip(
             "The 'std' reduction is yet supported on the GPU"
         )

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -312,6 +312,11 @@ def test_categorical_mean(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_var(df):
+    if cudf and isinstance(df, cudf.DataFrame):
+        pytest.skip(
+            "The 'var' reduction is yet supported on the GPU"
+        )
+
     sol = np.array([[[ 2.5,  nan,  nan,  nan],
                      [ nan,  nan,   2.,  nan]],
                     [[ nan,   2.,  nan,  nan],
@@ -329,6 +334,11 @@ def test_categorical_var(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_std(df):
+    if cudf and isinstance(df, cudf.DataFrame):
+        pytest.skip(
+            "The 'std' reduction is yet supported on the GPU"
+        )
+
     sol = np.sqrt(np.array([
         [[ 2.5,  nan,  nan,  nan],
          [ nan,  nan,   2.,  nan]],
@@ -339,7 +349,7 @@ def test_categorical_std(df):
         sol,
         coords=OrderedDict(coords, cat=['a', 'b', 'c', 'd']),
         dims=(dims + ['cat']))
-    
+
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.std('f32')))
     assert_eq_xr(agg, out, True)
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -103,13 +103,13 @@ def check_span(x, cmap, how, sol):
 
     # zero out smallest. If span is working properly the zeroed out pixel
     # will be masked out and all other pixels will remain unchanged
-    x[0, 1] = 0 if x.dtype.kind == 'i' else np.nan
+    x[0, 1] = 0 if x.dtype.kind in ('i', 'u') else np.nan
     img = tf.shade(x, cmap=cmap, how=how, span=float_span)
     sol[0, 1] = sol[0, 0]
     assert_eq_xr(img, sol)
 
     # zero out the largest value
-    x[2, 1] = 0 if x.dtype.kind == 'i' else np.nan
+    x[2, 1] = 0 if x.dtype.kind in ('i', 'u') else np.nan
     img = tf.shade(x, cmap=cmap, how=how, span=float_span)
     sol[2, 1] = sol[0, 0]
     assert_eq_xr(img, sol)
@@ -355,7 +355,7 @@ def test_shade_category(array):
                               [(12, 12, 12), (24, 0, 0)]], dtype='u4'),
                            coords=(coords + [['a', 'b', 'c']]),
                            dims=(dims + ['cats']))
-    
+
     # First test auto-span
     img = tf.shade(cat_agg, color_key=colors, how='linear', min_alpha=20)
     sol = np.array([[5584810, 335565567],

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -159,9 +159,9 @@ def nansum_missing(array, axis):
     T = list(range(array.ndim))
     T.remove(axis)
     T.insert(0, axis)
-    array = np.asarray(array).transpose(T)
+    array = array.transpose(T)
     missing_vals = np.isnan(array)
-    all_empty = np.bitwise_and.reduce(missing_vals, axis=0)
+    all_empty = np.all(missing_vals, axis=0)
     set_to_zero = missing_vals & ~all_empty
     return np.where(set_to_zero, 0, array).sum(axis=0)
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -430,7 +430,12 @@ def dshape_from_pandas_helper(col):
             isinstance(col.dtype, pd.api.types.CategoricalDtype) or
             cudf and isinstance(col.dtype, cudf.core.dtypes.CategoricalDtype)):
         # Compute category dtype
-        categories = np.array(col.cat.categories)
+        pd_categories = col.cat.categories
+        if cudf and not isinstance(pd_categories, pd.Index):
+            pd_categories = pd_categories.to_pandas()
+
+        categories = np.array(pd_categories)
+
         if categories.dtype.kind == 'U':
             categories = categories.astype('object')
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -431,7 +431,9 @@ def dshape_from_pandas_helper(col):
             cudf and isinstance(col.dtype, cudf.core.dtypes.CategoricalDtype)):
         # Compute category dtype
         pd_categories = col.cat.categories
-        if cudf and not isinstance(pd_categories, pd.Index):
+        if isinstance(pd_categories, dd.Index):
+            pd_categories = pd_categories.compute()
+        if cudf and isinstance(pd_categories, cudf.Index):
             pd_categories = pd_categories.to_pandas()
 
         categories = np.array(pd_categories)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     'xarray >=0.9.6',
     'colorcet >=0.9.0',
     'param >=1.6.0',
-    'pyct[cmd]',
+    'pyct[cmd] ==0.4.6',
     'bokeh',
     'scipy',
 ]


### PR DESCRIPTION
This PR contains an assortment of fixes for GPU support. Tested with:
 - `cudf=0.13` and `numba=0.48`
 - `cudf=0.14`, and `numba=0.49` (This numba version isn't supported by Datashader for performance reasons, but I wanted to make sure things worked for cudf 0.14 when we can unpin).

