### PR TITLE
Try #934 with Numba installed from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,6 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION --name=$PYTHON_VERSION
         - source activate $PYTHON_VERSION
         - doit develop_install $CHANS_DEV $OPTS
-        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
-        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
-        # - git clone git://github.com/numba/numba.git
-        # - cd numba && python setup.py install && cd ..
         # Install spatialpandas here because it's python 3 only and requires
         # conda-forge for some dependencies
         - if [[ "$PYTHON_VERSION" != "2.7" ]]; then
@@ -74,6 +70,11 @@ jobs:
         - doit env_capture
         - conda list --full-name cupy --json
       script:
+        - conda install dask>=2.0.0
+        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
+        # - git clone git://github.com/numba/numba.git
+        # - cd numba && python setup.py install && cd ..
         - doit test_all
         - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
       after_success: codecov
@@ -88,6 +89,10 @@ jobs:
     - <<: *default
       env: PYTHON_VERSION=3.7
       script:
+        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
+        # - git clone git://github.com/numba/numba.git
+        # - cd numba && python setup.py install && cd ..
         - doit test_all
         - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
           fi
         # Install rasterio using pip to avoid conda solver errors
         - pip install rasterio
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
         - doit env_capture
       script:
         - doit test_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,6 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION --name=$PYTHON_VERSION
         - source activate $PYTHON_VERSION
         - doit develop_install $CHANS_DEV $OPTS
-        - conda list --full-name cupy --json
-        - python -c "import cupy; print(cupy.__version__)"
-        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
-        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
-        # - git clone git://github.com/numba/numba.git
-        # - cd numba && python setup.py install && cd ..
         # Install spatialpandas here because it's python 3 only and requires
         # conda-forge for some dependencies
         - if [[ "$PYTHON_VERSION" != "2.7" ]]; then
@@ -75,6 +69,12 @@ jobs:
         - pip install rasterio
         - doit env_capture
       script:
+        - conda list --full-name cupy --json
+        - python -c "import cupy; print(cupy.__version__)"
+        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
+        # - git clone git://github.com/numba/numba.git
+        # - cd numba && python setup.py install && cd ..
         - doit test_all
         - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
       after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION --name=$PYTHON_VERSION
         - source activate $PYTHON_VERSION
         - doit develop_install $CHANS_DEV $OPTS
+        - conda list --full-name cupy --json
+        - python -c "import cupy; print(cupy.__version__)"
         # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
         - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
         # - git clone git://github.com/numba/numba.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION --name=$PYTHON_VERSION
         - source activate $PYTHON_VERSION
         - doit develop_install $CHANS_DEV $OPTS
+        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
+        # - git clone git://github.com/numba/numba.git
+        # - cd numba && python setup.py install && cd ..
         # Install spatialpandas here because it's python 3 only and requires
         # conda-forge for some dependencies
         - if [[ "$PYTHON_VERSION" != "2.7" ]]; then
@@ -68,13 +72,8 @@ jobs:
         # Install rasterio using pip to avoid conda solver errors
         - pip install rasterio
         - doit env_capture
-      script:
         - conda list --full-name cupy --json
-        - python -c "import cupy; print(cupy.__version__)"
-        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
-        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
-        # - git clone git://github.com/numba/numba.git
-        # - cd numba && python setup.py install && cd ..
+      script:
         - doit test_all
         - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
       after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION --name=$PYTHON_VERSION
         - source activate $PYTHON_VERSION
         - doit develop_install $CHANS_DEV $OPTS
+        # https://numba.pydata.org/numba-doc/latest/user/installing.html#installing-from-source
+        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
+        # - git clone git://github.com/numba/numba.git
+        # - cd numba && python setup.py install && cd ..
         # Install spatialpandas here because it's python 3 only and requires
         # conda-forge for some dependencies
         - if [[ "$PYTHON_VERSION" != "2.7" ]]; then
@@ -67,7 +71,6 @@ jobs:
           fi
         # Install rasterio using pip to avoid conda solver errors
         - pip install rasterio
-        - pip install git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax
         - doit env_capture
       script:
         - doit test_all

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -8,6 +8,8 @@ import xarray as xr
 
 from datashader.glyphs.glyph import isnull
 from numba import cuda as nb_cuda
+from datashader.transfer_functions._cuda_utils import (cuda_atomic_nanmin,
+                                                       cuda_atomic_nanmax)
 
 try:
     import cudf
@@ -479,7 +481,7 @@ class min(FloatingReduction):
     @staticmethod
     @ngjit
     def _append_cuda(x, y, agg, field):
-        nb_cuda.atomic.min(agg, (y, x), field)
+        cuda_atomic_nanmin(agg, (y, x), field)
 
     @staticmethod
     def _combine(aggs):
@@ -506,7 +508,7 @@ class max(FloatingReduction):
     @staticmethod
     @ngjit
     def _append_cuda(x, y, agg, field):
-        nb_cuda.atomic.max(agg, (y, x), field)
+        cuda_atomic_nanmax(agg, (y, x), field)
 
     @staticmethod
     def _combine(aggs):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -8,8 +8,8 @@ import xarray as xr
 
 from datashader.glyphs.glyph import isnull
 from numba import cuda as nb_cuda
-from datashader.transfer_functions._cuda_utils import (cuda_atomic_nanmin,
-                                                       cuda_atomic_nanmax)
+#from datashader.transfer_functions._cuda_utils import (cuda_atomic_nanmin,
+#                                                       cuda_atomic_nanmax)
 
 try:
     import cudf
@@ -481,7 +481,7 @@ class min(FloatingReduction):
     @staticmethod
     @ngjit
     def _append_cuda(x, y, agg, field):
-        cuda_atomic_nanmin(agg, (y, x), field)
+        nb_cuda.atomic.nanmax(agg, (y, x), field)
 
     @staticmethod
     def _combine(aggs):
@@ -508,7 +508,7 @@ class max(FloatingReduction):
     @staticmethod
     @ngjit
     def _append_cuda(x, y, agg, field):
-        cuda_atomic_nanmax(agg, (y, x), field)
+        nb_cuda.nanmax(agg, (y, x), field)
 
     @staticmethod
     def _combine(aggs):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -508,7 +508,7 @@ class max(FloatingReduction):
     @staticmethod
     @ngjit
     def _append_cuda(x, y, agg, field):
-        nb_cuda.nanmax(agg, (y, x), field)
+        nb_cuda.atomic.nanmax(agg, (y, x), field)
 
     @staticmethod
     def _combine(aggs):

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -76,18 +76,18 @@ def masked_clip_2d(data, mask, lower, upper):
 # np.nanmax/np.nanmin
 if LooseVersion(numba.__version__) >= LooseVersion("0.51.0"):
     @cuda.jit
-    def cuda_atomic_nanmin(ary, idx, val)
+    def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.nanmin(ary, idx, val)
     @cuda.jit
-    def cuda_atomic_nanmax(ary, idx, val)
+    def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.nanmax(ary, idx, val)
 elif LooseVersion(numba.__version__) <= LooseVersion("0.49.0"):
     @cuda.jit
-    def cuda_atomic_nanmin(ary, idx, val)
+    def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.min(ary, idx, val)
 
     @cuda.jit
-    def cuda_atomic_nanmax(ary, idx, val)
+    def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.max(ary, idx, val)
 else:
     # WHAT DO YOU WANT TO DO HERE?
@@ -99,8 +99,8 @@ def masked_clip_2d_kernel(data, mask, lower, upper):
     i, j = cuda.grid(2)
     maxi, maxj = data.shape
     if i >= 0 and i < maxi and j >= 0 and j < maxj and not mask[i, j]:
-        cuda_atomic_max(data, (i, j), lower)
-        cuda_atomic_min(data, (i, j), upper)
+        cuda_atomic_nanmax(data, (i, j), lower)
+        cuda_atomic_nanmin(data, (i, j), upper)
 
 
 # interp

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
+    # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
     # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
+    'cupy',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
+    'numba >=0.37.0,<0.49',
     # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
-    'cupy',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0,<0.49',
+    'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0,<0.49',
+    # 'numba >=0.37.0,<0.49',
     # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
     # 'numba >=0.37.0', # maybe this will install whatever cupy we need, then we can overwrite it with numba from git without llvmlite conflicting because this won't install unremovable llvmlite 0.31.0?
     'numpy >=1.7',

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    # 'numba >=0.37.0,<0.49',
+    'numba >=0.37.0,<0.49',
     # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
-    'numba >=0.37.0', # maybe this will install whatever cupy we need, then we can overwrite it with numba from git without llvmlite conflicting because this won't install unremovable llvmlite 0.31.0?
+    # 'numba >=0.37.0', # maybe this will install whatever cupy we need, then we can overwrite it with numba from git without llvmlite conflicting because this won't install unremovable llvmlite 0.31.0?
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0,<0.49',
+    # 'numba >=0.37.0,<0.49',
     # 'numba @ git+https://github.com/stuartarchibald/numba.git@fix/cuda_atomic_nanminmax',
+    'numba >=0.37.0', # maybe this will install whatever cupy we need, then we can overwrite it with numba from git without llvmlite conflicting because this won't install unremovable llvmlite 0.31.0?
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',


### PR DESCRIPTION
This PR is just an attempt to get some nice green checkmarks attached to @stuartarchibald's excellent https://github.com/holoviz/datashader/pull/934, which will make Datashader compatible with Numba 0.51 (see e.g. https://github.com/numba/numba/issues/5820#issuecomment-651402266).

https://github.com/numba/numba/pull/5941 hasn't even been merged yet, and Numba 0.51 certainly isn't out yet, but we can make sure all the gears mesh right now by installing from the git repository directly.