### PR TITLE
Print cupy version in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ jobs:
         - pip install rasterio
         - doit env_capture
       script:
+        - conda list --full-name cupy --json
+        - python -c "import cupy; print(cupy.__version__)"
         - doit test_all
         - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
       after_success: codecov


### PR DESCRIPTION
The testing is sensitive to the cupy version; with the wrong version, we can get `AttributeError: type object 'cupy.core.core.Indexer' has no attribute '__reduce_cython__'`. The cupy version does not appear to be pinned and we might not want to pin it, but this records the cupy version in the Travis build so that if we later have problems we can look at the last working build and know what version worked before.