### PR TITLE
Fix AttributeError: module 'pandas.compat' has no attribute 'string_types'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     # `conda install dask[complete]` happily gives you dask...which is
     # happily like pip's dask[complete]. (conda's dask-core is more
     # like pip's dask.)
-    'dask[complete] >=0.18.0',
+    'dask[complete] >=2.0.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
     'numba >=0.37.0,<0.49',


### PR DESCRIPTION
Resolves #945 for Python 3 (making those pass as seen in this Travis build), but not for Python 2.