### PR TITLE
Supporting cuDF 0.14+

### DIFF
--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -75,18 +75,18 @@ def masked_clip_2d(data, mask, lower, upper):
 # Behaviour of numba.cuda.atomic.max/min changed in 0.50 so as to behave as per
 # np.nanmax/np.nanmin
 if LooseVersion(numba.__version__) >= LooseVersion("0.51.0"):
-    @cuda.jit
+    @numba.jit
     def cuda_atomic_nanmin(ary, idx, val)
         return cuda.atomic.nanmin(ary, idx, val)
-    @cuda.jit
+    @numba.jit
     def cuda_atomic_nanmax(ary, idx, val)
         return cuda.atomic.nanmax(ary, idx, val)
-elif LooseVersion(numba.__version__) <= LooseVersion("0.49.0"):
-    @cuda.jit
+elif LooseVersion(numba.__version__) <= LooseVersion("0.49.1"):
+    @numba.jit
     def cuda_atomic_nanmin(ary, idx, val)
         return cuda.atomic.min(ary, idx, val)
 
-    @cuda.jit
+    @numba.jit
     def cuda_atomic_nanmax(ary, idx, val)
         return cuda.atomic.max(ary, idx, val)
 else:
@@ -99,8 +99,8 @@ def masked_clip_2d_kernel(data, mask, lower, upper):
     i, j = cuda.grid(2)
     maxi, maxj = data.shape
     if i >= 0 and i < maxi and j >= 0 and j < maxj and not mask[i, j]:
-        cuda_atomic_max(data, (i, j), lower)
-        cuda_atomic_min(data, (i, j), upper)
+        cuda_atomic_nanmax(data, (i, j), lower)
+        cuda_atomic_nanmax(data, (i, j), upper)
 
 
 # interp

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -76,22 +76,21 @@ def masked_clip_2d(data, mask, lower, upper):
 # np.nanmax/np.nanmin
 if LooseVersion(numba.__version__) >= LooseVersion("0.51.0"):
     @numba.jit
-    def cuda_atomic_nanmin(ary, idx, val)
+    def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.nanmin(ary, idx, val)
     @numba.jit
-    def cuda_atomic_nanmax(ary, idx, val)
+    def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.nanmax(ary, idx, val)
 elif LooseVersion(numba.__version__) <= LooseVersion("0.49.1"):
     @numba.jit
-    def cuda_atomic_nanmin(ary, idx, val)
+    def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.min(ary, idx, val)
 
     @numba.jit
-    def cuda_atomic_nanmax(ary, idx, val)
+    def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.max(ary, idx, val)
 else:
-    # WHAT DO YOU WANT TO DO HERE?
-    pass
+    raise ImportError("Datashader's CUDA support requires numba!=0.50.0")
 
 
 @cuda.jit

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -75,18 +75,17 @@ def masked_clip_2d(data, mask, lower, upper):
 # Behaviour of numba.cuda.atomic.max/min changed in 0.50 so as to behave as per
 # np.nanmax/np.nanmin
 if LooseVersion(numba.__version__) >= LooseVersion("0.51.0"):
-    @numba.jit
+    @cuda.jit(device=True)
     def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.nanmin(ary, idx, val)
-    @numba.jit
+    @cuda.jit(device=True)
     def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.nanmax(ary, idx, val)
 elif LooseVersion(numba.__version__) <= LooseVersion("0.49.1"):
-    @numba.jit
+    @cuda.jit(device=True)
     def cuda_atomic_nanmin(ary, idx, val):
         return cuda.atomic.min(ary, idx, val)
-
-    @numba.jit
+    @cuda.jit(device=True)
     def cuda_atomic_nanmax(ary, idx, val):
         return cuda.atomic.max(ary, idx, val)
 else:
@@ -99,7 +98,7 @@ def masked_clip_2d_kernel(data, mask, lower, upper):
     maxi, maxj = data.shape
     if i >= 0 and i < maxi and j >= 0 and j < maxj and not mask[i, j]:
         cuda_atomic_nanmax(data, (i, j), lower)
-        cuda_atomic_nanmax(data, (i, j), upper)
+        cuda_atomic_nanmin(data, (i, j), upper)
 
 
 # interp

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0',
+    'numba <=0.49.1,>=0.51.0',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba >=0.37.0,<0.49',
+    'numba >=0.37.0',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba <0.49.0,>=0.51.0',
+    'numba >=0.37.0, !=0.49.*, !=0.50.*',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dask[complete] >=0.18.0',
     'toolz >=0.7.4',  # ? for some dask issue (dasks does only >=0.7.3)
     'datashape >=0.5.1',
-    'numba <=0.49.1,>=0.51.0',
+    'numba <0.49.0,>=0.51.0',
     'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',


### PR DESCRIPTION
- removing numba pinning which prevented datashader 0.11 working with cuDF 0.14+
- fixed a couple of issues raised with the PR #934 

I have tested this with `cuDF 0.14 + numba 0.49`  & `cuDF 0.15(nightlies) + numba 0.51.0rc1`

cc @philippjfr @jonmmease 