### PR TITLE
Canvas.raster(): fix floating point error in output coords

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1130,17 +1130,23 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         # Compute DataArray metadata
         if np.isclose(left, self.x_range[0]) and \
                 np.isclose(right, self.x_range[1]) and \
-                np.isclose(bottom, self.y_range[0]) and \
-                np.isclose(top, self.y_range[1]) and \
-                np.size(xvals) == self.plot_width and \
-                np.size(yvals) == self.plot_height:
-            # do not recalculate coords if resampling on same x range, y range,
-            #    and same canvas size as of source input
-            #    to avoid floating point representation error.
-            xs, ys = xvals, yvals
+                np.size(xvals) == self.plot_width:
+            # To avoid floating point representation error,
+            # do not recompute x coords if same x_range and same plot_width
+            xs = xvals
         else:
-            xs, ys = compute_coords(self.plot_width, self.plot_height,
-                                    self.x_range, self.y_range, res)
+            xs, _ = compute_coords(self.plot_width, self.plot_height,
+                                   self.x_range, self.y_range, res)
+
+        if np.isclose(bottom, self.y_range[0]) and \
+                np.isclose(top, self.y_range[1]) and \
+                np.size(yvals) == self.plot_height:
+            # To avoid floating point representation error,
+            # do not recompute y coords if same y_range and same plot_height
+            ys = yvals
+        else:
+            _, ys = compute_coords(self.plot_width, self.plot_height,
+                                   self.x_range, self.y_range, res)
 
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1128,25 +1128,19 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
             data = data.astype(dtype)
 
         # Compute DataArray metadata
-        if np.isclose(left, self.x_range[0]) and \
-                np.isclose(right, self.x_range[1]) and \
-                np.size(xvals) == self.plot_width:
-            # To avoid floating point representation error,
-            # do not recompute x coords if same x_range and same plot_width
-            xs = xvals
-        else:
-            xs, _ = compute_coords(self.plot_width, self.plot_height,
-                                   self.x_range, self.y_range, res)
 
-        if np.isclose(bottom, self.y_range[0]) and \
-                np.isclose(top, self.y_range[1]) and \
-                np.size(yvals) == self.plot_height:
-            # To avoid floating point representation error,
-            # do not recompute y coords if same y_range and same plot_height
-            ys = yvals
+        # To avoid floating point representation error,
+        # do not recompute x coords if same x_range and same plot_width,
+        # do not recompute y coords if same y_range and same plot_height
+        close_x = np.isclose([left, right], self.x_range).all() and np.size(xvals) == self.plot_width
+        close_y = np.isclose([bottom, top], self.y_range).all() and np.size(yvals) == self.plot_height
+        if close_x and close_y:
+            xs, ys = xvals, yvals
         else:
-            _, ys = compute_coords(self.plot_width, self.plot_height,
-                                   self.x_range, self.y_range, res)
+            xs, ys = compute_coords(self.plot_width, self.plot_height,
+                                    self.x_range, self.y_range, res)
+            xs = xvals if close_x else xs
+            ys = yvals if close_y else ys
 
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1041,7 +1041,9 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         height_ratio = min((ymax - ymin) / (self.y_range[1] - self.y_range[0]), 1)
 
         if np.isclose(width_ratio, 0) or np.isclose(height_ratio, 0):
-            raise ValueError('Canvas x_range or y_range values do not match closely enough with the data source to be able to accurately rasterize. Please provide ranges that are more accurate.')
+            raise ValueError('Canvas x_range or y_range values do not match closely enough '
+                             'with the data source to be able to accurately rasterize. '
+                             'Please provide ranges that are more accurate.')
 
         w = max(int(round(self.plot_width * width_ratio)), 1)
         h = max(int(round(self.plot_height * height_ratio)), 1)
@@ -1126,7 +1128,20 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
             data = data.astype(dtype)
 
         # Compute DataArray metadata
-        xs, ys = compute_coords(self.plot_width, self.plot_height, self.x_range, self.y_range, res)
+        if np.isclose(left, self.x_range[0]) and \
+                np.isclose(right, self.x_range[1]) and \
+                np.isclose(bottom, self.y_range[0]) and \
+                np.isclose(top, self.y_range[1]) and \
+                np.size(xvals) == self.plot_width and \
+                np.size(yvals) == self.plot_height:
+            # do not recalculate coords if resampling on same x range, y range,
+            #    and same canvas size as of source input
+            #    to avoid floating point representation error.
+            xs, ys = xvals, yvals
+        else:
+            xs, ys = compute_coords(self.plot_width, self.plot_height,
+                                    self.x_range, self.y_range, res)
+
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]
         attrs = dict(res=res[0])

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -111,6 +111,22 @@ def test_partial_extent_with_layer_returns_correct_size(cvs):
 
 
 @rasterio_available
+def test_full_extent_returns_correct_coords():
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        res = ds.utils.calc_res(src)
+        left, bottom, right, top = ds.utils.calc_bbox(src.x.values, src.y.values, res)
+        cvs = ds.Canvas(plot_width=512,
+                        plot_height=256,
+                        x_range=[left, right],
+                        y_range=[bottom, top])
+        agg = cvs.raster(src)
+        assert agg.shape == (3, 256, 512)
+        assert agg is not None
+        for dim in src.dims:
+            assert np.all(agg[dim].data == src[dim].data)
+
+
+@rasterio_available
 def test_calc_res():
     """Assert that resolution is calculated correctly when using the xarray
     rasterio backend.


### PR DESCRIPTION
Addresses #958

When we resample a raster data set over a full extent canvas of same size, recalculating `coords` might cause extremely small floating-point errors. This leads to discrepancy between `coords` of input and output DataArray/Dataset (while we expect them to be exactly the same).

cc: @brendancol 