### PR TITLE
Unpin pyct 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     'xarray >=0.9.6',
     'colorcet >=0.9.0',
     'param >=1.6.0',
-    'pyct[cmd] ==0.4.6',
+    'pyct[cmd]',
     'bokeh',
     'scipy',
 ]


### PR DESCRIPTION
0.4.6 is the latest release anyway
Bug in latest dev release (affecting test suite) is now fixed (https://github.com/pyviz-dev/pyct/issues/85).
