### PR TITLE
Fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ extras_require = {
         'pytest-cov',
         'codecov',
         'flake8',
+        'nbconvert <6',
         'nbsmoke[all] >=0.4.0',
         'fastparquet >=0.1.6',  # optional dependency
         'holoviews >=1.10.0',

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ description = Flake check python and notebooks, and verify notebooks
 deps = .[tests]
 # verify takes quite a long time - maybe split into flakes and lint?
 commands = flake8
-           pytest --nbsmoke-lint -k ".ipynb"
-           pytest --nbsmoke-verify -k ".ipynb"
+           pytest --nbsmoke-lint -k ".ipynb" examples
+           pytest --nbsmoke-verify -k ".ipynb" examples
 
 [_unit]
 description = Run unit tests


### PR DESCRIPTION
Fixing Datashader tests:

- Made sure nbsmoke is run only on the examples/ directory. 
- nbsmoke currently actually runs on all files with "ipynb" in the name, so it gets confused by `.ipynb.zip` or `.ipynb~` that may be sitting around, but that would need to be changed in nbsmoke. (Actually already done in an [unmerged (and unmergeable) PR](https://github.com/pyviz-dev/nbsmoke/pull/42/files#diff-246198e9655d3fcd024b6a42d0c06633a22328a7d2fd8e4fa6acfe10bf066ae9R79).)
- Pinned nbconvert<6 due to incompatible changes (leading to `jinja2.exceptions.TemplateNotFound: basic
../../../miniconda/envs/3.6/lib/python3.6/site-packages/jinja2/loaders.py:429: TemplateNotFound`)