### PR TITLE
Fix out-of-bounds error on Points aggregation

### DIFF
--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -163,7 +163,8 @@ class Point(_PointLike):
                 xx = int(x_mapper(x) * sx + tx)
                 yy = int(y_mapper(y) * sy + ty)
 
-                xi, yi = min(xx, xxmax-1), min(yy, yymax-1)
+                xi, yi = (xx-1 if xx == xxmax else xx,
+                          yy-1 if yy == yymax else yy)
                 append(i, xi, yi, *aggs_and_cols)
 
         @ngjit

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -163,8 +163,8 @@ class Point(_PointLike):
                 xx = int(x_mapper(x) * sx + tx)
                 yy = int(y_mapper(y) * sy + ty)
 
-                xi, yi = (xx-1 if xx == xxmax else xx,
-                          yy-1 if yy == yymax else yy)
+                xi, yi = (xxmax-1 if xx >= xxmax else xx,
+                          yymax-1 if yy >= yymax else yy)
                 append(i, xi, yi, *aggs_and_cols)
 
         @ngjit

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -159,9 +159,9 @@ class Point(_PointLike):
             if (xmin <= x <= xmax) and (ymin <= y <= ymax):
                 xx = int(x_mapper(x) * sx + tx)
                 yy = int(y_mapper(y) * sy + ty)
-                xi, yi = (xx - 1 if x == xmax else xx,
-                          yy - 1 if y == ymax else yy)
 
+                xi, yi = (xx - 1 if x >= (xmax-1e-15) else xx,
+                          yy - 1 if y >= (ymax-1e-15) else yy)
                 append(i, xi, yi, *aggs_and_cols)
 
         @ngjit


### PR DESCRIPTION
- [x] Fix for https://github.com/holoviz/datashader/issues/976

The problem here is floating point comparison issues, in particular on this line:

```python
xi, yi = (xx - 1 if x == xmax else xx,
          yy - 1 if y == ymax else yy)
```

where `y=9.921649019012754` and `ymax=9.921649019012756` this result in an out-of-bounds index (`yi`) being used during the aggregation step:

```python
agg[y, x] += 1
```

This PR isn't a particularly principled fix but simply allows for a 1e15 tolerance. Any other suggestions (without high computational cost welcome), one other option is to check against the actual shape of the array.