### PR TITLE
Disable the interactivity warning on the homepage

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          nbsite build --what=html --output=builtdocs
+          nbsite build --what=html --output=builtdocs --org holoviz --project-name datashader
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v3
         if: (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@
 
 .. notebook:: datashader ../examples/index.ipynb
     :offset: 0
+    :disable_interactivity_warning:
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Initial commit disables the interactivity warning on the homepage. If there are other pages that need it, I will declare those too.