### PR TITLE
WIP: Color key support for 2D Aggregates

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1070,3 +1070,36 @@ def test_shade_with_discrete_color_key_dask():
     arr = tf.Image(data, dims=['x', 'y'])
     img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
     assert img is not None
+
+
+def test_shade_with_discrete_color_key_with_missing_values():
+    data = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 1, 1, 0],
+                     [0, 2, 2, 2, 0],
+                     [0, 3, 3, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    arr = tf.Image(data, dims=['x', 'y'])
+    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow', 4:'black'})
+    assert img is not None
+
+
+def test_shade_with_discrete_color_key_with_wrong_types():
+    data = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 1, 1, 0],
+                     [0, 2, 2, 2, 0],
+                     [0, 3, 3, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    arr = tf.Image(data, dims=['x', 'y'])
+    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow', 4.4:'black'})
+    assert img is not None
+
+
+def test_shade_with_discrete_color_key_with_float_arr():
+    data = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 1, 1, 0],
+                     [0, 2, 2, 2, 0],
+                     [0, 3, 3, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='f8')
+    arr = tf.Image(data, dims=['x', 'y'])
+    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
+    assert img is not None

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1047,3 +1047,26 @@ def test_shade_should_handle_zeros_array():
     arr = tf.Image(data, dims=['x', 'y'])
     img = tf.shade(arr, cmap=['white', 'black'], how='linear')
     assert img is not None
+
+
+def test_shade_with_discrete_color_key_numpy():
+    data = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 1, 1, 0],
+                     [0, 2, 2, 2, 0],
+                     [0, 3, 3, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    arr = tf.Image(data, dims=['x', 'y'])
+    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
+    assert img is not None
+
+
+def test_shade_with_discrete_color_key_dask():
+    data = np.array([[0, 0, 0, 0, 0],
+                     [0, 1, 1, 1, 0],
+                     [0, 2, 2, 2, 0],
+                     [0, 3, 3, 3, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    data = da.from_array(data)
+    arr = tf.Image(data, dims=['x', 'y'])
+    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
+    assert img is not None

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -551,7 +551,7 @@ def shade(agg, cmap=["lightblue", "darkblue"], color_key=Sets1to3,
         raise ValueError("min_alpha ({}) and alpha ({}) must be between 0 and 255".format(min_alpha,alpha))
 
     if agg.ndim == 2:
-        if color_key is not None:
+        if color_key is not None and isinstance(color_key, dict):
             return _apply_discrete_colorkey(agg, color_key, name, alpha)
         else:
             return _interpolate(agg, cmap, how, alpha, span, min_alpha, name)


### PR DESCRIPTION
The objective of this PR is to support coloring 2d aggregates using a discrete color key:

The current implementation supports the following:

Shade numpy-backed xr.DataArray
```python
def test_shade_with_discrete_color_key_numpy():
    data = np.array([[0, 0, 0, 0, 0],
                     [0, 1, 1, 1, 0],
                     [0, 2, 2, 2, 0],
                     [0, 3, 3, 3, 0],
                     [0, 0, 0, 0, 0]], dtype='uint32')
    arr = tf.Image(data, dims=['x', 'y'])
    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
    assert img is not None
```

Shade dask-backed xr.DataArray
```python
def test_shade_with_discrete_color_key_dask():
    data = np.array([[0, 0, 0, 0, 0],
                     [0, 1, 1, 1, 0],
                     [0, 2, 2, 2, 0],
                     [0, 3, 3, 3, 0],
                     [0, 0, 0, 0, 0]], dtype='uint32')
    data = da.from_array(data)
    arr = tf.Image(data, dims=['x', 'y'])
    img = tf.shade(arr, color_key={1: 'aqua', 2:'purple', 3:'yellow'})
    assert img is not None
```