### PR TITLE
WIP: Add 2d color key support

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1055,7 +1055,7 @@ def test_shade_with_discrete_color_key():
                      [0, 2, 2, 2, 0],
                      [0, 3, 3, 3, 0],
                      [0, 0, 0, 0, 0]], dtype='uint32')
-    color_key = {1: 'white', 2: 'purple', 3: 'yellow', 4.4: 'pink'}
+    color_key = {1: 'white', 2: 'purple', 3: 'yellow'}
     result = np.array([[0, 0, 0, 0, 0],
                        [0, 4294967295, 4294967295, 4294967295, 0],
                        [0, 4286578816, 4286578816, 4286578816, 0],

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -424,6 +424,16 @@ def _apply_discrete_colorkey(agg, color_key, name, alpha=255, nodata=0):
     if not agg.ndim == 2:
         raise ValueError("agg must be 2D")
 
+    # validate color_key
+    datatype = agg.data.dtype.type
+    try:
+        converted_keys = [datatype(key) for key in color_key.keys()]
+    except ValueError:
+        raise TypeError("Invalid color_key. Keys should be in the same type (or be convertible to be the same) as of input agg")
+
+    if not converted_keys == list(color_key.keys()):
+        raise TypeError("Invalid color_key. Keys should be in the same type (or be convertible to be the same) as of input agg")
+
     if cupy and isinstance(agg.data, cupy.ndarray):
         array = cupy.array
     else:
@@ -520,7 +530,7 @@ def shade(agg, cmap=["lightblue", "darkblue"], color_key=Sets1to3,
         Regardless of this value, ``NaN`` values are set to be fully
         transparent when doing colormapping.
     min_alpha : float, optional
-        The minimum alpha value to use for non-empty pixels when 
+        The minimum alpha value to use for non-empty pixels when
         alpha is indicating data value, in [0, 255].  Use a higher value
         to avoid undersaturation, i.e. poorly visible low-value datapoints,
         at the expense of the overall dynamic range.

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -391,6 +391,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Datashader also supports coloring 2D aggregates using a discrete color key. Similar to 3D case, user can supply a color_key to specify the categories and corresponding colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvas = ds.Canvas(plot_width=300, plot_height=300,\n",
+    "                   x_range=(-2, 2), y_range=(-2, 2))\n",
+    "\n",
+    "normal_distributed_df = pd.DataFrame({\n",
+    "   'x': np.random.normal(0, 1, 10000000),\n",
+    "   'y': np.random.normal(0, 1, 10000000)\n",
+    "})\n",
+    "normal_agg = canvas.points(normal_distributed_df, 'x', 'y')\n",
+    "\n",
+    "# categorize by values\n",
+    "normal_agg.data[np.where(normal_agg.data < 50)] = 1\n",
+    "normal_agg.data[np.where((normal_agg.data < 100) & (normal_agg.data >= 50))] = 2\n",
+    "normal_agg.data[np.where((normal_agg.data < 150) & (normal_agg.data >= 100))] = 3\n",
+    "normal_agg.data[np.where((normal_agg.data < 200) & (normal_agg.data >= 150))] = 4\n",
+    "normal_agg.data[np.where(normal_agg.data >= 200)] = 5\n",
+    "\n",
+    "color_key = {1: 'lavender', 2: 'lightpink', 3: 'lightsalmon', 4: 'lightcoral', 5: 'orangered'}\n",
+    "tf.shade(normal_agg, color_key=color_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Transforming data values for colormapping\n",
     "\n",
     "In each of the above examples, you may have noticed that we were never required to specify any parameters about the data values; the plots just appear like magic.  That magic is implemented in `tf.shade`.  What `tf.shade` does for a 2D aggregate (non-categorical) is:\n",
@@ -744,9 +777,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR continues https://github.com/holoviz/datashader/pull/985 in order to support discrete color keys for 2D agg. Following features will be added:

- [x] test with cupy arrays
- [x] test with dask arrays
- [x] add an example user guide
- [x] add to documentation
- [x] make sure all tests pass (test_shade_with_discrete_color_key passed in all 9 testing environments)
- [ ] see if it works with earlier version of pandas