### PR TITLE
Fix nodata handling for xarray raster files

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1130,8 +1130,19 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]
         attrs = dict(res=res[0])
-        if source._file_obj is not None and hasattr(source._file_obj, 'nodata'):
-            attrs['nodata'] = source._file_obj.nodata
+
+        # Find nodata value if available in any of the common conventional locations
+        # See https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html
+        # and https://github.com/holoviz/datashader/issues/990
+        for a in ['_FillValue', 'missing_value', 'fill_value', 'nodata', 'NODATA']:
+            if a in source.attrs:
+                attrs['nodata'] = source.attrs[a]
+                break
+        if 'nodata' not in attrs:
+            try:
+                attrs['nodata'] = source.attrs['nodatavals'][0]
+            except:
+                pass
 
         # Handle DataArray with layers
         if data.ndim == 3:

--- a/datashader/tests/test_antialias.py
+++ b/datashader/tests/test_antialias.py
@@ -1,4 +1,4 @@
-"""Tests for antialiased line drawing in Datasahder"""
+"""Tests for antialiased line drawing in Datashader"""
 
 # The single-pixel width tests consist of 6 test cases, each drawing a
 # different set of lines on a square canvas. Tests 1 to 4 are all sets of lines


### PR DESCRIPTION
Fix for https://github.com/holoviz/datashader/issues/990 and https://github.com/holoviz/hvplot/issues/563. 

Previously, Datashader Canvas.raster was accessing the underlying `_file_obj` attribute of a provided Xarray DataArray raster to find a 'nodata' (to be treated as NaN) value. `_file_obj` was clearly marked private, so accessing it directly was presumably always a bad idea.  This usage broke with xarray 0.17 when the `_file_obj` attribute was hidden inside a closure.  Instead, what other libraries (e.g. [rioxarray](https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html)) seem to do is look for various "nodata" attributes on the xarray object, presumably each corresponding to some convention or the output of some file reader or file writer. 

With this PR, Datashader now checks the DataArray attrs for ['_FillValue', 'missing_value', 'fill_value', 'nodata', 'NODATA'] (in that order), taking a single scalar value from the first one it finds. If it fails to find any of them, it then looks for 'nodatavals', and if that's a list and has at least one element it takes the first in the list. Otherwise, there is no "nodata" value available.

These attr names were suggested by various people at the linked issues and in the rioxarray docs, and I do not have access to any files actually defining or respecting such conventions. So I haven't tested that these actually work "in the wild", but at least if I hack in those attribute values into an already-constructed DataArray it seems to work:

```python
from datashader import transfer_functions as tf, reductions as rd
import numpy as np, datashader as ds, xarray as xr

def f(x,y):
    return np.cos((x**2+y**2)**2)

def sample(fn, n=50, range_=(0.0,2.4)):
    xs = ys = np.linspace(range_[0], range_[1], n)
    x,y = np.meshgrid(xs, ys)
    z   = fn(x,y)
    return xr.DataArray(z, coords=[('y',ys), ('x',xs)])

da = sample(f)
da.attrs['missing_value'] = 1
out = ds.Canvas().raster(da, interpolate='linear')
out.attrs

{'res': 0.04897959183673469, 'nodata': 1}
```