### PR TITLE
Fix dynspread not to count already-spread pixels and respect array bnds

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -948,7 +948,7 @@ def test_rgb_dynspread():
     coords = [np.arange(5), np.arange(5)]
     img = tf.Image(data, coords=coords, dims=dims)
     assert tf.dynspread(img).equals(tf.spread(img, 1))
-    assert tf.dynspread(img, threshold=0.9).equals(tf.spread(img, 2))
+    assert tf.dynspread(img, threshold=0.9).equals(tf.spread(img, 3))
     assert tf.dynspread(img, threshold=0).equals(img)
     assert tf.dynspread(img, max_px=0).equals(img)
 
@@ -964,7 +964,7 @@ def test_array_dynspread():
     coords = [np.arange(5), np.arange(5)]
     arr = xr.DataArray(data, coords=coords, dims=dims)
     assert tf.dynspread(arr).equals(tf.spread(arr, 1))
-    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 2))
+    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 3))
     assert tf.dynspread(arr, threshold=0).equals(arr)
     assert tf.dynspread(arr, max_px=0).equals(arr)
 
@@ -996,7 +996,7 @@ def test_categorical_dynspread():
     arr = xr.DataArray(data, coords=coords + [['a', 'b', 'c']],
                        dims=dims + ['cat'])
     assert tf.dynspread(arr).equals(tf.spread(arr, 1))
-    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 2))
+    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 3))
     assert tf.dynspread(arr, threshold=0).equals(arr)
     assert tf.dynspread(arr, max_px=0).equals(arr)
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -912,60 +912,78 @@ def test_rgb_density():
     assert tf._rgb_density(data) == 1.0
     data = np.zeros((4, 4), dtype='uint32')
     assert tf._rgb_density(data) == np.inf
-    data[2, 2] = b
+    data[3, 3] = b
     assert tf._rgb_density(data) == 0
-    data[2, 1] = data[1, 2] = data[1, 1] = b
-    assert np.allclose(tf._rgb_density(data), 3./8.)
+    data[2, 0] = data[0, 2] = data[1, 1] = b
+    assert np.allclose(tf._rgb_density(data), 0.75)
+    assert np.allclose(tf._rgb_density(data, 3), 1)
 
 def test_int_array_density():
     data = np.ones((4, 4), dtype='uint32')
     assert tf._array_density(data, float_type=False) == 1.0
     data = np.zeros((4, 4), dtype='uint32')
     assert tf._array_density(data, float_type=False) == np.inf
-    data[2, 2] = 1
+    data[3, 3] = 1
     assert tf._array_density(data, float_type=False) == 0
-    data[2, 1] = data[1, 2] = data[1, 1] = 1
-    assert np.allclose(tf._array_density(data, float_type=False), 3./8.)
+    data[2, 0] = data[0, 2] = data[1, 1] = 1
+    assert np.allclose(tf._array_density(data, float_type=False), 0.75)
+    assert np.allclose(tf._array_density(data, float_type=False, px=3), 1)
 
+    
 def test_float_array_density():
     data = np.ones((4, 4), dtype='float32')
     assert tf._array_density(data, float_type=True) == 1.0
     data = np.full((4, 4), np.nan, dtype='float32')
     assert tf._array_density(data, float_type=True) == np.inf
-    data[2, 2] = 1
+    data[3, 3] = 1
     assert tf._array_density(data, float_type=True) == 0
-    data[2, 1] = data[1, 2] = data[1, 1] = 1
-    assert np.allclose(tf._array_density(data, float_type=True), 3./8.)
-
+    data[2, 0] = data[0, 2] = data[1, 1] = 1
+    assert np.allclose(tf._array_density(data, float_type=True), 0.75)
+    assert np.allclose(tf._array_density(data, float_type=True, px=3), 1)
+    
 
 def test_rgb_dynspread():
     b = 0xffff0000
+    coords = [np.arange(5), np.arange(5)]
     data = np.array([[b, b, 0, 0, 0],
                      [b, b, 0, 0, 0],
                      [0, 0, 0, 0, 0],
                      [0, 0, 0, b, 0],
                      [0, 0, 0, 0, 0]], dtype='uint32')
-    coords = [np.arange(5), np.arange(5)]
     img = tf.Image(data, coords=coords, dims=dims)
-    assert tf.dynspread(img).equals(tf.spread(img, 1))
-    assert tf.dynspread(img, threshold=0.9).equals(tf.spread(img, 3))
-    assert tf.dynspread(img, threshold=0).equals(img)
+    assert tf.dynspread(img).equals(img)
+    data = np.array([[b, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [b, 0, 0, 0, b],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    img = tf.Image(data, coords=coords, dims=dims)
+    assert tf.dynspread(img, threshold=0.4).equals(tf.spread(img, 0))
+    assert tf.dynspread(img, threshold=0.7).equals(tf.spread(img, 1))
+    assert tf.dynspread(img, threshold=1.0).equals(tf.spread(img, 3))
     assert tf.dynspread(img, max_px=0).equals(img)
 
     pytest.raises(ValueError, lambda: tf.dynspread(img, threshold=1.1))
     pytest.raises(ValueError, lambda: tf.dynspread(img, max_px=-1))
 
 def test_array_dynspread():
+    coords = [np.arange(5), np.arange(5)]
     data = np.array([[1, 1, 0, 0, 0],
                      [1, 1, 0, 0, 0],
                      [0, 0, 0, 0, 0],
                      [0, 0, 0, 1, 0],
                      [0, 0, 0, 0, 0]], dtype='uint32')
-    coords = [np.arange(5), np.arange(5)]
     arr = xr.DataArray(data, coords=coords, dims=dims)
-    assert tf.dynspread(arr).equals(tf.spread(arr, 1))
-    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 3))
-    assert tf.dynspread(arr, threshold=0).equals(arr)
+    assert tf.dynspread(arr).equals(arr)
+    data = np.array([[1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0],
+                     [1, 0, 0, 0, 1],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]], dtype='uint32')
+    arr = xr.DataArray(data, coords=coords, dims=dims)
+    assert tf.dynspread(arr, threshold=0.4).equals(tf.spread(arr, 0))
+    assert tf.dynspread(arr, threshold=0.7).equals(tf.spread(arr, 1))
+    assert tf.dynspread(arr, threshold=1.0).equals(tf.spread(arr, 3))
     assert tf.dynspread(arr, max_px=0).equals(arr)
 
     pytest.raises(ValueError, lambda: tf.dynspread(arr, threshold=1.1))
@@ -973,33 +991,32 @@ def test_array_dynspread():
 
 
 def test_categorical_dynspread():
-    a_data = np.array([[0, 1, 0, 0, 0],
+    a_data = np.array([[1, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0]], dtype='int32')
 
     b_data = np.array([[0, 0, 0, 0, 0],
-                       [0, 1, 0, 0, 0],
                        [0, 0, 0, 0, 0],
+                       [1, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0]], dtype='int32')
 
-    c_data = np.array([[1, 0, 0, 0, 0],
-                       [1, 0, 0, 0, 0],
+    c_data = np.array([[0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0],
-                       [0, 0, 0, 1, 0],
+                       [0, 0, 0, 0, 1],
+                       [0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0]], dtype='int32')
 
     data = np.dstack([a_data, b_data, c_data])
     coords = [np.arange(5), np.arange(5)]
     arr = xr.DataArray(data, coords=coords + [['a', 'b', 'c']],
                        dims=dims + ['cat'])
-    assert tf.dynspread(arr).equals(tf.spread(arr, 1))
-    assert tf.dynspread(arr, threshold=0.9).equals(tf.spread(arr, 3))
-    assert tf.dynspread(arr, threshold=0).equals(arr)
+    assert tf.dynspread(arr, threshold=0.4).equals(tf.spread(arr, 0))
+    assert tf.dynspread(arr, threshold=0.7).equals(tf.spread(arr, 1))
+    assert tf.dynspread(arr, threshold=1.0).equals(tf.spread(arr, 3))
     assert tf.dynspread(arr, max_px=0).equals(arr)
-
 
 
 def check_eq_hist_cdf_slope(eq):

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -745,7 +745,7 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
     # Simple linear search. Not super efficient, but max_px is usually small.
     float_type = img.dtype in [np.float32, np.float64]
     px_=0
-    for px in range(max_px + 1):
+    for px in range(1, max_px + 1):
         px_=px
         if is_image:
             density = _rgb_density(img.data, px*2)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -744,24 +744,28 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
         raise ValueError("max_px must be >= 0")
     # Simple linear search. Not super efficient, but max_px is usually small.
     float_type = img.dtype in [np.float32, np.float64]
+    px_=0
     for px in range(max_px + 1):
-        out = spread(img, px, shape=shape, how=how, name=name)
         if is_image:
-            density = _rgb_density(out.data)
+            density = _rgb_density(img.data, px*2)
         elif len(img.shape) == 2:
-            density = _array_density(out.data, float_type)
+            density = _array_density(img.data, float_type, px*2)
         else:
             masked = np.logical_not(np.isnan(out)) if float_type else (out != 0)
             flat_mask = np.sum(masked, axis=2, dtype='uint32')
-            density = _array_density(flat_mask.data, False)
+            density = _array_density(flat_mask.data, False, px*2)
         if density >= threshold:
             break
+        px_=px
 
-    return out
+    if px_>=1:
+        return spread(img, px_, shape=shape, how=how, name=name)
+    else:
+        return img
 
 
 @nb.jit(nopython=True, nogil=True, cache=True)
-def _array_density(arr, float_type):
+def _array_density(arr, float_type, px=1):
     """Compute a density heuristic of an array.
 
     The density is a number in [0, 1], and indicates the normalized mean number
@@ -774,8 +778,8 @@ def _array_density(arr, float_type):
             el = arr[y, x]
             if (float_type and not np.isnan(el)) or (not float_type and el!=0):
                 cnt += 1
-                for i in range(y - 1, y + 2):
-                    for j in range(x - 1, x + 2):
+                for i in     range(max(0, y - px), min(y + px + 1, M)):
+                    for j in range(max(0, x - px), min(x + px + 1, N)):
                         if float_type and not np.isnan(arr[i, j]):
                             total += 1
                         elif not float_type and arr[i, j] != 0:
@@ -784,7 +788,7 @@ def _array_density(arr, float_type):
 
 
 @nb.jit(nopython=True, nogil=True, cache=True)
-def _rgb_density(arr):
+def _rgb_density(arr, px=1):
     """Compute a density heuristic of an image.
 
     The density is a number in [0, 1], and indicates the normalized mean number
@@ -796,8 +800,8 @@ def _rgb_density(arr):
         for x in range(1, N - 1):
             if (arr[y, x] >> 24) & 255:
                 cnt += 1
-                for i in range(y - 1, y + 2):
-                    for j in range(x - 1, x + 2):
+                for i in     range(max(0, y - px), min(y + px + 1, M)):
+                    for j in range(max(0, x - px), min(x + px + 1, N)):
                         if (arr[i, j] >> 24) & 255:
                             total += 1
     return (total - cnt)/(cnt * 8) if cnt else np.inf

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -746,6 +746,7 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
     float_type = img.dtype in [np.float32, np.float64]
     px_=0
     for px in range(max_px + 1):
+        px_=px
         if is_image:
             density = _rgb_density(img.data, px*2)
         elif len(img.shape) == 2:
@@ -755,9 +756,9 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
             flat_mask = np.sum(masked, axis=2, dtype='uint32')
             density = _array_density(flat_mask.data, False, px*2)
         if density >= threshold:
+            px_=px_-1
             break
-        px_=px
-
+        
     if px_>=1:
         return spread(img, px_, shape=shape, how=how, name=name)
     else:
@@ -769,22 +770,24 @@ def _array_density(arr, float_type, px=1):
     """Compute a density heuristic of an array.
 
     The density is a number in [0, 1], and indicates the normalized mean number
-    of non-empty adjacent pixels for each non-empty pixel.
+    of non-empty pixels that have neighbors in the given px radius.
     """
     M, N = arr.shape
-    cnt = total = 0
-    for y in range(1, M - 1):
-        for x in range(1, N - 1):
+    cnt = has_neighbors = 0
+    for y in range(0, M):
+        for x in range(0, N):
             el = arr[y, x]
             if (float_type and not np.isnan(el)) or (not float_type and el!=0):
                 cnt += 1
+                neighbors = 0
                 for i in     range(max(0, y - px), min(y + px + 1, M)):
                     for j in range(max(0, x - px), min(x + px + 1, N)):
-                        if float_type and not np.isnan(arr[i, j]):
-                            total += 1
-                        elif not float_type and arr[i, j] != 0:
-                            total += 1
-    return (total - cnt)/(cnt * 8) if cnt else np.inf
+                        if ((float_type and not np.isnan(arr[i, j])) or
+                            (not float_type and arr[i, j] != 0)):
+                            neighbors += 1
+                if neighbors>1: # (excludes self)
+                    has_neighbors += 1
+    return has_neighbors/cnt if cnt else np.inf
 
 
 @nb.jit(nopython=True, nogil=True, cache=True)
@@ -792,16 +795,19 @@ def _rgb_density(arr, px=1):
     """Compute a density heuristic of an image.
 
     The density is a number in [0, 1], and indicates the normalized mean number
-    of non-empty adjacent pixels for each non-empty pixel.
+    of non-empty pixels that have neighbors in the given px radius.
     """
     M, N = arr.shape
-    cnt = total = 0
-    for y in range(1, M - 1):
-        for x in range(1, N - 1):
+    cnt = has_neighbors = 0
+    for y in range(0, M):
+        for x in range(0, N):
             if (arr[y, x] >> 24) & 255:
                 cnt += 1
+                neighbors = 0
                 for i in     range(max(0, y - px), min(y + px + 1, M)):
                     for j in range(max(0, x - px), min(x + px + 1, N)):
                         if (arr[i, j] >> 24) & 255:
-                            total += 1
-    return (total - cnt)/(cnt * 8) if cnt else np.inf
+                            neighbors += 1
+                if neighbors>1: # (excludes self)
+                    has_neighbors += 1
+    return has_neighbors/cnt if cnt else np.inf

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -755,7 +755,7 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
             masked = np.logical_not(np.isnan(img)) if float_type else (img != 0)
             flat_mask = np.sum(masked, axis=2, dtype='uint32')
             density = _array_density(flat_mask.data, False, px*2)
-        if density >= threshold:
+        if density > threshold:
             px_=px_-1
             break
         

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -751,7 +751,7 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
         elif len(img.shape) == 2:
             density = _array_density(img.data, float_type, px*2)
         else:
-            masked = np.logical_not(np.isnan(out)) if float_type else (out != 0)
+            masked = np.logical_not(np.isnan(img)) if float_type else (img != 0)
             flat_mask = np.sum(masked, axis=2, dtype='uint32')
             density = _array_density(flat_mask.data, False, px*2)
         if density >= threshold:

--- a/examples/getting_started/3_Interactivity.ipynb
+++ b/examples/getting_started/3_Interactivity.ipynb
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "datashaded = hd.datashade(points, aggregator=ds.count_cat('cat')).redim.range(x=(-5,5),y=(-5,5))\n",
-    "hd.dynspread(datashaded, threshold=0.50, how='over').opts(height=500,width=500)"
+    "hd.dynspread(datashaded, threshold=0.8, how='over', max_px=5).opts(height=500,width=500)"
    ]
   },
   {
@@ -214,7 +214,7 @@
     "gaussspread = hd.dynspread(datashaded, threshold=0.50, how='over').opts(plot=dict(height=400,width=400))\n",
     "\n",
     "color_key = [(name,color) for name,color in zip([\"d1\",\"d2\",\"d3\",\"d4\",\"d5\"], Sets1to3)]\n",
-    "color_points = hv.NdOverlay({n: hv.Points([0,0], label=str(n)).opts(style=dict(color=c)) for n,c in color_key})\n",
+    "color_points = hv.NdOverlay({n: hv.Points([0,0], label=str(n)).opts(color=c,size=0) for n,c in color_key})\n",
     "\n",
     "color_points * gaussspread"
    ]

--- a/examples/user_guide/4_Trajectories.ipynb
+++ b/examples/user_guide/4_Trajectories.ipynb
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from holoviews.operation.datashader import datashade\n",
+    "from holoviews.operation.datashader import datashade, spread\n",
     "import holoviews as hv\n",
     "hv.extension('bokeh')"
    ]
@@ -168,8 +168,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opts = hv.opts.RGB(width=500, height=500)\n",
-    "datashade(hv.Path(df, kdims=['x','y']), normalization='linear', aggregator=ds.any()).opts(opts)"
+    "opts = hv.opts.RGB(width=900, height=500, aspect='equal')\n",
+    "spread(datashade(hv.Path(df, kdims=['x','y']), normalization='linear', aggregator=ds.any())).opts(opts)"
    ]
   },
   {

--- a/examples/user_guide/7_Networks.ipynb
+++ b/examples/user_guide/7_Networks.ipynb
@@ -414,7 +414,7 @@
     "\n",
     "circle = hv.Graph(edges, label='Bokeh edges').opts(node_size=5)\n",
     "hnodes = circle.nodes.opts(size=5)\n",
-    "dscirc = (hd.dynspread(hd.datashade(circle))*hnodes).relabel(\"Datashader edges\")\n",
+    "dscirc = (hd.spread(hd.datashade(circle))*hnodes).relabel(\"Datashader edges\")\n",
     "\n",
     "circle + dscirc"
    ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     # `conda install dask[complete]` happily gives you dask...which is
     # happily like pip's dask[complete]. (conda's dask-core is more
     # like pip's dask.)
-    'dask[complete] >=0.18.0',
+    'dask[complete] >=0.18.0, <2021.05',
     'datashape >=0.5.1',
     'numba >=0.51',
     'numpy >=1.7',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     # `conda install dask[complete]` happily gives you dask...which is
     # happily like pip's dask[complete]. (conda's dask-core is more
     # like pip's dask.)
-    'dask[complete] >=0.18.0, <2021.05',
+    'dask[complete] >=0.18.0,
     'datashape >=0.5.1',
     'numba >=0.51',
     'numpy >=1.7',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     # `conda install dask[complete]` happily gives you dask...which is
     # happily like pip's dask[complete]. (conda's dask-core is more
     # like pip's dask.)
-    'dask[complete] >=0.18.0,
+    'dask[complete] >=0.18.0',
     'datashape >=0.5.1',
     'numba >=0.51',
     'numpy >=1.7',


### PR DESCRIPTION
Fixes #1000. As described in #1000, dynspread was not working as documented or designed, because it was iteratively measuring the density of already-spread pixels, which produced large dense regions that were indistinguishable from dense regions of datapoints. Also, it turns out, the density calculations were reading outside the bounds of the array, which is dangerous and likely to give incorrect readings for density, even though it does not involve _writing_ outside the array. 

Fixed both problems by (1) respecting the bounds of the array when computing density, and (2) iteratively measuring density using an increasing neighborhood (as before) but no longer with actual spreading for each interative step (unlike before). I.e., instead of spreading then checking to see if the density metric is exceeded, simply tries increasingly large values of a neighborhood radius to count how many pixels have neighbors within this radius, and stopping when that normalized number reaches the specified threshold. The neighborhood search is now twice as large as the spreading amount being tested, since unlike actual spreading each datapoint has to check distance to the neighboring datapoint's center, not edge, but it no longer has to do actual spreading, so the speed may not decrease much. 

In any case, the behavior is now vastly more appropriate, and is approximately how I first envisioned dynspread working, smoothly switching to larger point sizes (even for large `max_px` values of e.g. 100) on zooming in. The default threshold of 0.5 actually still seems about right to me, so no need to update that. The `max_px` default of 3 now seems low; 5 seems more visible and clear once zooming in. But I'll leave the default value unchanged here since really it's the default value in the plotting library (e.g. HoloViews hv.operation.datashader.dynspread) that affects interactive use.

Here's an example using the datashader_dashboard, with `max_px=10` (fairly big!):

https://user-images.githubusercontent.com/1695496/114293108-0ca77500-9a59-11eb-86ed-9679603e7fd1.mp4


