### PR TITLE
handle cupy array in spread and dynspread functions

### DIFF
--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -707,8 +707,8 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
     padded_shape = (M + 2*extra, N + 2*extra)
     float_type = img.dtype in [np.float32, np.float64]
     fill_value = np.nan if float_type else 0
-    # convert img.data to a numpy array to pass it to nb.jit kernels
     if cupy and isinstance(img.data, cupy.ndarray):
+        # Convert img.data to numpy array before passing to nb.jit kernels
         img.data = cupy.asnumpy(img.data)
 
     if is_image:
@@ -861,8 +861,8 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
         raise ValueError("max_px must be >= 0")
     # Simple linear search. Not super efficient, but max_px is usually small.
     float_type = img.dtype in [np.float32, np.float64]
-    # convert img.data to a numpy array to pass it to nb.jit kernels
     if cupy and isinstance(img.data, cupy.ndarray):
+        # Convert img.data to numpy array before passing to nb.jit kernels
         img.data = cupy.asnumpy(img.data)
 
     px_=0

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -707,6 +707,9 @@ def spread(img, px=1, shape='circle', how=None, mask=None, name=None):
     padded_shape = (M + 2*extra, N + 2*extra)
     float_type = img.dtype in [np.float32, np.float64]
     fill_value = np.nan if float_type else 0
+    # convert img.data to a numpy array to pass it to nb.jit kernels
+    if cupy and isinstance(img.data, cupy.ndarray):
+        img.data = cupy.asnumpy(img.data)
 
     if is_image:
         kernel = _build_spread_kernel(how, is_image)
@@ -858,6 +861,10 @@ def dynspread(img, threshold=0.5, max_px=3, shape='circle', how=None, name=None)
         raise ValueError("max_px must be >= 0")
     # Simple linear search. Not super efficient, but max_px is usually small.
     float_type = img.dtype in [np.float32, np.float64]
+    # convert img.data to a numpy array to pass it to nb.jit kernels
+    if cupy and isinstance(img.data, cupy.ndarray):
+        img.data = cupy.asnumpy(img.data)
+
     px_=0
     for px in range(1, max_px + 1):
         px_=px


### PR DESCRIPTION
This PR aims to fix an issue where cuDF based aggregates when passed to spread & dynspread, throw a typing error. 

```python
import datashader as ds
from datashader.transfer_functions import spread, dynspread
import cudf
import numpy as np

df = cudf.DataFrame(np.random.multivariate_normal((0,0), [[0.1, 0.1], [0.1, 1.0]], (1000000,)), columns=['x', 'y'])
dynspread(ds.Canvas().points(df,x='x', y='y')) #or spread(ds.Canvas().points(df,x='x', y='y'))
```

```bash
TypingError: Failed in nopython mode pipeline (step: nopython frontend)
non-precise type pyobject
During: typing of argument at datashader/datashader/transfer_functions/__init__.py (775)

File "../datashader/datashader/transfer_functions/__init__.py", line 775:
def _array_density(arr, float_type, px=1):
    <source elided>
    """
    M, N = arr.shape
    ^

This error may have been caused by the following argument(s):
- argument 0: Cannot determine Numba type of <class 'cupy._core.core.ndarray'>

```

As per the [suggestion](https://github.com/holoviz/holoviews/issues/5045#issuecomment-886256149) made in the corresponding [holoviews issue](https://github.com/holoviz/holoviews/issues/5045), just converting the aggregate `img.data` to a numpy from cupy before calling the `@nb.jit _array_utils()` function seems to fix the issue.


