### PR TITLE
Fix CI part 2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda install ${{ env.CHANS_DEV}} "panel<0.13"
+          conda install ${{ env.CHANS_DEV}} "panel=0.12"
       - name: Patch with latest dask from conda-forge
         if: (!contains(matrix.python-version, '3.6'))
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
         if: (matrix.os == 'windows-latest')
         run: |
           eval "$(conda shell.bash hook)"
-          conda activate ${{ env.ENV_NAME }}
+          conda activate test-environment
           conda install ${{ env.CHANS_DEV}} "freetype=2.10.4"
       - name: doit env_capture
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate ${{ env.ENV_NAME }}
-          conda install ${{ env.CHANS_DEV}} -c conda-forge "freetype=2.10.4"
+          conda install ${{ env.CHANS_DEV}} "freetype=2.10.4"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda install ${{ env.CHANS_DEV}} "panel=0.12.4"
+          conda install ${{ env.CHANS_DEV}} "panel<0.13"
       - name: Patch with latest dask from conda-forge
         if: (!contains(matrix.python-version, '3.6'))
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
+      - name: Current dev version of panel is broken on py36
+        if: (matrix.python-version == '3.6')
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda install ${{ env.CHANS_DEV}} "panel=0.12.4"
       - name: Patch with latest dask from conda-forge
         if: (!contains(matrix.python-version, '3.6'))
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,6 +63,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install -c conda-forge "dask>=2021.05.0"
+      - name: Patch with an older version of freetype since 2.11.0 is broken with Matplotlib on Windows
+        if: (matrix.os == 'windows-latest')
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate ${{ env.ENV_NAME }}
+          conda install ${{ env.CHANS_DEV}} -c conda-forge "freetype=2.10.4"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/datashader/bokeh_ext.py
+++ b/datashader/bokeh_ext.py
@@ -86,7 +86,8 @@ def patch_event(image):
         JSON message containing patch events to update the plot
     """
     if bokeh_version > '0.12.9':
-        events = list(image.doc._held_events)
+        event_obj = image.doc.callbacks if bokeh_version >= '2.4' else image.doc
+        events = list(event_obj._held_events)
         if not events:
             return None
         if bokeh_version > '2.0.0':
@@ -94,7 +95,7 @@ def patch_event(image):
         else:
             protocol = Protocol("1.0")
         msg = protocol.create("PATCH-DOC", events)
-        image.doc._held_events = []
+        event_obj._held_events = []
         return msg
     data = dict(image.ds.data)
     data['image'] = [data['image'][0].tolist()]

--- a/datashader/datatypes.py
+++ b/datashader/datatypes.py
@@ -585,7 +585,7 @@ Invalid indices for take with allow_fill True: {inds}""".format(
         else:
             if len(self) == 0 and len(indices) > 0:
                 raise IndexError(
-                    "Cannot do a non-empty take from an empty axis"
+                    "cannot do a non-empty take from an empty axis|out of bounds"
                 )
 
             sequence = [self[i] for i in indices]

--- a/datashader/tests/benchmarks/test_bundling.py
+++ b/datashader/tests/benchmarks/test_bundling.py
@@ -24,7 +24,7 @@ def edges():
     # Four edges originating from the center node and connected to each
     # corner
     edges_df = pd.DataFrame({'id': np.arange(4),
-                             'source': np.zeros(4, dtype=np.int),
+                             'source': np.zeros(4, dtype=int),
                              'target': np.arange(1, 5)})
     edges_df.set_index('id')
     return edges_df

--- a/datashader/tests/test_bokeh_ext.py
+++ b/datashader/tests/test_bokeh_ext.py
@@ -77,5 +77,5 @@ def test_interactive_image_update():
     assert image['shape'] == [1, 1]
 
     # Ensure events are cleared after update
-    event_obj = image.doc.callbacks if bokeh_version >= '2.4' else image.doc
+    event_obj = img.doc.callbacks if bokeh_version >= '2.4' else img.doc
     assert event_obj._held_events == []

--- a/datashader/tests/test_bokeh_ext.py
+++ b/datashader/tests/test_bokeh_ext.py
@@ -5,7 +5,7 @@ import datashader as ds
 import datashader.transfer_functions as tf
 
 from bokeh.plotting import figure, Document
-from datashader.bokeh_ext import InteractiveImage
+from datashader.bokeh_ext import InteractiveImage, bokeh_version
 
 axis = ds.core.LinearAxis()
 lincoords = axis.compute_index(axis.compute_scale_and_translate((0, 1), 2), 2)
@@ -77,4 +77,5 @@ def test_interactive_image_update():
     assert image['shape'] == [1, 1]
 
     # Ensure events are cleared after update
-    assert img.doc._held_events == []
+    event_obj = image.doc.callbacks if bokeh_version >= '2.4' else image.doc
+    assert event_obj._held_events == []

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -25,7 +25,7 @@ def edges():
     # Four edges originating from the center node and connected to each
     # corner
     edges_df = pd.DataFrame({'id': np.arange(4),
-                             'source': np.zeros(4, dtype=np.int),
+                             'source': np.zeros(4, dtype=int),
                              'target': np.arange(1, 5)})
     edges_df.set_index('id')
     return edges_df
@@ -36,7 +36,7 @@ def weighted_edges():
     # Four weighted edges originating from the center node and connected
     # to each corner
     edges_df = pd.DataFrame({'id': np.arange(4),
-                             'source': np.zeros(4, dtype=np.int),
+                             'source': np.zeros(4, dtype=int),
                              'target': np.arange(1, 5),
                              'weight': np.ones(4)})
     edges_df.set_index('id')

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require = {
         'codecov',
         'flake8',
         'nbconvert',
-        'nbsmoke[all] >=0.6.0',
+        'nbsmoke[all] >0.5',
         'fastparquet >=0.1.6',  # optional dependency
         'holoviews >=1.10.0',
         'bokeh',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ extras_require = {
         'pytest-cov',
         'codecov',
         'flake8',
-        'nbconvert <6',
+        'nbconvert',
         'nbsmoke[all] >=0.4.0',
         'fastparquet >=0.1.6',  # optional dependency
         'holoviews >=1.10.0',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require = {
         'codecov',
         'flake8',
         'nbconvert',
-        'nbsmoke[all] >=0.4.0',
+        'nbsmoke[all] >=0.6.0',
         'fastparquet >=0.1.6',  # optional dependency
         'holoviews >=1.10.0',
         'bokeh',


### PR DESCRIPTION
Following on from PR #1022, this is an attempt to fix the remaining CI failures. There are 3 changes:

1. Exception text that needs to precisely match that expected in pandas (like in #1022).
2. Remove the upper version limit on `nbconvert` as certain versions were causing problems when running `pytest "--nbsmoke-run" "-k" ".ipynb"`
3. Change of `np.int` to `int` which is only causes a `DeprecationWarning` but I fixed it whilst I was there.

Fixes work locally for me, but need to check across the full CI matrix.
