### PR TITLE
Allow floating-point tolerances in tf.stack coords

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -520,6 +520,28 @@ def test_stack():
     np.testing.assert_equal(img.data, out)
 
 
+def test_stack_tolerance():
+    # Floating-point coords
+    coords = [c.astype(np.float64) for c in coords2]
+
+    for offsets in ([1e-10, 0.0], [0.0, 1e-10]):
+        img2_float = tf.Image(
+            img2.data, dims=img2.dims,
+            coords=[coords[0] + offsets[0], coords[1] + offsets[1]])
+
+        # Prior to fix for issue #1038 the next line gives:
+        # TypeError: ufunc 'over' not supported for the input types, and the
+        # inputs could not be safely coerced to any supported types according
+        # to the casting rule ''safe''
+        img = tf.stack(img2_float, img1)
+        np.testing.assert_array_equal(img.x_axis, img2_float.x_axis)
+        np.testing.assert_array_equal(img.y_axis, img2_float.y_axis)
+
+        img = tf.stack(img1, img2_float)
+        np.testing.assert_array_equal(img.x_axis, img1.x_axis)
+        np.testing.assert_array_equal(img.y_axis, img1.y_axis)
+
+
 def test_masks():
     # Square
     mask = tf._square_mask(2)
@@ -929,7 +951,7 @@ def test_int_array_density():
     assert np.allclose(tf._array_density(data, float_type=False), 0.75)
     assert np.allclose(tf._array_density(data, float_type=False, px=3), 1)
 
-    
+
 def test_float_array_density():
     data = np.ones((4, 4), dtype='float32')
     assert tf._array_density(data, float_type=True) == 1.0
@@ -940,7 +962,7 @@ def test_float_array_density():
     data[2, 0] = data[0, 2] = data[1, 1] = 1
     assert np.allclose(tf._array_density(data, float_type=True), 0.75)
     assert np.allclose(tf._array_density(data, float_type=True, px=3), 1)
-    
+
 
 def test_rgb_dynspread():
     b = 0xffff0000

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -132,7 +132,7 @@ def stack(*imgs, **kwargs):
     op = composite_op_lookup[kwargs.get('how', 'over')]
     if len(imgs) == 1:
         return imgs[0]
-    imgs = xr.align(*imgs, copy=False, join='outer')
+    imgs = xr.align(*imgs, copy=False, join='override')
     with np.errstate(divide='ignore', invalid='ignore'):
         out = tz.reduce(tz.flip(op), [i.data for i in imgs])
     return Image(out, coords=imgs[0].coords, dims=imgs[0].dims, name=name)


### PR DESCRIPTION
Candidate fix for issue #1038. There is a wider discussion in issue #959.

The underlying problem is that `xr.DataArray`/`tf.Image` objects passed to `tf.stack` may have slightly different coordinates (e.g. 1e-15 for reproducer in #1038). When the images are stacked using
https://github.com/holoviz/datashader/blob/25578abde75c7fa28c6633b33cb8d8a1e433da67/datashader/transfer_functions/__init__.py#L135
xarray takes the union of these coordinates, making the coordinate shapes larger, and eventually we get the somewhat cryptic error
```
TypeError: ufunc 'over' not supported for the input types
```
I have opted for a really simple one line fix which is easy to understand but might be overly smart.  It is to use `xr.align(*imgs, ..., join="override")` which uses the coordinates of the first `img` and ignores the others provides they all have the same shape (which they always do, it is checked a few lines earlier). This kwarg option has been in xarray since August 2019 (v0.13.0) so it is well tested.

This change fixes the reproducer in issue #1038 and does not cause any existing tests to fail.

But it may be a bit general. Maybe it also needs a prior check that the coordinates are not only the same shape but are also close enough. We would have to put in a numerical tolerance for this, with the possibility of annoying those using very large or very small coordinates. And what would we do with coordinates that fail this "close enough" test? We shouldn't use the previous code as this gives the cryptic error. So the least bad options are
  1. Always use `join="override"` and state in the docs this is what we are going to do.
  2. Put in a numerical tolerance and raise some sort of "not close enough" exception.