### PR TITLE
Fix/cudf api updates

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     # adding pyct here is temporary (this conda recipe template will disappear when new pyctdev is released)
     - pyct
   run_constrained:
-    - cudf >=0.10.0
+    - cudf >=22.02
 test:
   imports:
     - datashader

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -490,8 +490,8 @@ class AreaToZeroAxis1(_PointLike):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[list(x_names)].as_gpu_matrix()
-                ys = df[list(y_names)].as_gpu_matrix()
+                xs = df[list(x_names)].to_cupy()
+                ys = df[list(y_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df[list(x_names)].values
@@ -597,9 +597,9 @@ class AreaToLineAxis1(_AreaToLineLike):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[list(x_names)].as_gpu_matrix()
-                ys = df[list(y_names)].as_gpu_matrix()
-                y_stacks = df[list(y_stack_names)].as_gpu_matrix()
+                xs = df[list(x_names)].to_cupy()
+                ys = df[list(y_names)].to_cupy()
+                y_stacks = df[list(y_stack_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df[list(x_names)].values
@@ -666,7 +666,7 @@ class AreaToZeroAxis1XConstant(AreaToZeroAxis1):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                ys = df[list(y_names)].as_gpu_matrix()
+                ys = df[list(y_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(ys.shape)]
             else:
                 ys = df[list(y_names)].values
@@ -746,8 +746,8 @@ class AreaToLineAxis1XConstant(AreaToLineAxis1):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                ys = df[list(y_names)].as_gpu_matrix()
-                y_stacks = df[list(y_stack_names)].as_gpu_matrix()
+                ys = df[list(y_names)].to_cupy()
+                y_stacks = df[list(y_stack_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(ys.shape)]
             else:
                 ys = df[list(y_names)].values
@@ -814,7 +814,7 @@ class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[list(x_names)].as_gpu_matrix()
+                xs = df[list(x_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df[list(x_names)].values
@@ -880,7 +880,7 @@ class AreaToLineAxis1YConstant(AreaToLineAxis1):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[list(x_names)].as_gpu_matrix()
+                xs = df[list(x_names)].to_cupy()
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df[list(x_names)].values

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -93,11 +93,11 @@ class Glyph(Expr):
     @staticmethod
     def to_gpu_matrix(df, columns):
         if not isinstance(columns, (list, tuple)):
-            return df[columns].to_gpu_array()
+            return df[columns].to_cupy()
         else:
             return cudf.concat([
                 df[name].rename(str(i)) for i, name in enumerate(columns)
-            ], axis=1).as_gpu_matrix()
+            ], axis=1).to_cupy()
 
     def expand_aggs_and_cols(self, append):
         """

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -17,7 +17,8 @@ except Exception:
 
 def values(s):
     if isinstance(s, cudf.Series):
-        return s.to_cupy(na_value=np.nan)
+        import cupy
+        return cupy.asarray(s.fillna(np.nan))
     else:
         return s.values
 
@@ -191,8 +192,9 @@ class Point(_PointLike):
             xmin, xmax, ymin, ymax = bounds
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[x_name].to_cupy(na_value=np.nan)
-                ys = df[y_name].to_cupy(na_value=np.nan)
+                import cupy
+                xs = cupy.asarray(df[x_name].fillna(np.nan))
+                ys = cupy.asarray(df[y_name].fillna(np.nan))
                 do_extend = extend_cuda[cuda_args(xs.shape[0])]
             else:
                 xs = df[x_name].values

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -17,7 +17,7 @@ except Exception:
 
 def values(s):
     if isinstance(s, cudf.Series):
-        return s.to_gpu_array(fillna=np.nan)
+        return s.to_cupy(na_value=np.nan)
     else:
         return s.values
 
@@ -191,8 +191,8 @@ class Point(_PointLike):
             xmin, xmax, ymin, ymax = bounds
 
             if cudf and isinstance(df, cudf.DataFrame):
-                xs = df[x_name].to_gpu_array(fillna=np.nan)
-                ys = df[y_name].to_gpu_array(fillna=np.nan)
+                xs = df[x_name].to_cupy(na_value=np.nan)
+                ys = df[y_name].to_cupy(na_value=np.nan)
                 do_extend = extend_cuda[cuda_args(xs.shape[0])]
             else:
                 xs = df[x_name].values

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -42,7 +42,7 @@ class extract(Preprocess):
                 nullval = np.nan
             else:
                 nullval = 0
-            return cupy.array(df[self.column].to_gpu_array(fillna=nullval))
+            return df[self.column].to_cupy(na_value=nullval)
         elif isinstance(df, xr.Dataset):
             # DataArray could be backed by numpy or cupy array
             return df[self.column].data
@@ -81,7 +81,7 @@ class category_codes(CategoryPreprocess):
 
     def apply(self, df):
         if cudf and isinstance(df, cudf.DataFrame):
-            return df[self.column].cat.codes.to_gpu_array()
+            return df[self.column].cat.codes.to_cupy()
         else:
             return df[self.column].cat.codes.values
 
@@ -114,7 +114,7 @@ class category_modulo(category_codes):
     def apply(self, df):
         result = (df[self.column] - self.offset) % self.modulo
         if cudf and isinstance(df, cudf.DataFrame):
-            return result.to_gpu_array()
+            return result.to_cupy()
         else:
             return result.values
 
@@ -193,7 +193,7 @@ class category_values(CategoryPreprocess):
             else:
                 nullval = 0
             a = cupy.asarray(a)
-            b = cupy.asarray(df[self.column].to_gpu_array(fillna=nullval))
+            b = cupy.asarray(df[self.column].to_cupy(na_value=nullval))
             return cupy.stack((a, b), axis=-1)
         else:
             b = df[self.column].values

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -42,7 +42,7 @@ class extract(Preprocess):
                 nullval = np.nan
             else:
                 nullval = 0
-            return df[self.column].to_cupy(na_value=nullval)
+            return cupy.asarray(df[self.column].fillna(nullval))
         elif isinstance(df, xr.Dataset):
             # DataArray could be backed by numpy or cupy array
             return df[self.column].data
@@ -81,7 +81,8 @@ class category_codes(CategoryPreprocess):
 
     def apply(self, df):
         if cudf and isinstance(df, cudf.DataFrame):
-            return df[self.column].cat.codes.to_cupy()
+            import cupy
+            return cupy.asarray(df[self.column].cat.codes)
         else:
             return df[self.column].cat.codes.values
 
@@ -113,8 +114,9 @@ class category_modulo(category_codes):
 
     def apply(self, df):
         result = (df[self.column] - self.offset) % self.modulo
-        if cudf and isinstance(df, cudf.DataFrame):
-            return result.to_cupy()
+        if cudf and isinstance(df, cudf.Series):
+            import cupy
+            return cupy.asarray(result)
         else:
             return result.values
 
@@ -193,7 +195,7 @@ class category_values(CategoryPreprocess):
             else:
                 nullval = 0
             a = cupy.asarray(a)
-            b = cupy.asarray(df[self.column].to_cupy(na_value=nullval))
+            b = cupy.asarray(df[self.column].fillna(nullval))
             return cupy.stack((a, b), axis=-1)
         else:
             b = df[self.column].values


### PR DESCRIPTION
This PR replaces deprecated methods in cudf, related to conversion to a cupy array from cudf.DataFrame and cudf.Series. The new methods also provide performance improvements as demonstrated here: https://docs.rapids.ai/api/cudf/nightly/user_guide/10min-cudf-cupy.html#Converting-a-cuDF-Series-to-a-CuPy-Array

Finally, also updating the minimum version of cudf's last stable release (22.02)
