### PR TITLE
CI: add recent Python versions in the matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
         shell: bash -l {0} 
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
-      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
+      CHANS_DEV: "-c pyviz/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
+          mamba-version: "*"
           channels: pyviz/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
@@ -42,17 +44,19 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit develop_install -o tests -o examples
-      - name: panel and dataclasses on 3.6  
+      - name: doit develop_install 3.6
         if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
+          doit develop_install -o tests -o examples --conda-mode=mamba
           mamba install "panel=0.12" dataclasses
+      - name: doit develop_install > 3.6
+        if: matrix.python-version > '3.6'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit develop_install -o tests -o examples
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     timeout-minutes: 60
     defaults:
       run:
@@ -35,8 +35,8 @@ jobs:
           channels: pyviz/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
-      - name: conda update > 3.6
-        if: matrix.python-version != '3.6'
+      - name: conda update > 3.9
+        if: matrix.python-version > '3.9'
         run: |
           conda update -n base conda
       - name: conda setup
@@ -48,7 +48,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install -o tests -o examples --conda-mode=mamba
-      - name: panel 3.6
+      - name: panel and dataclasses on 3.6  
         if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
           channels: pyviz/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
@@ -47,7 +46,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install -o tests -o examples --conda-mode=mamba
+          doit develop_install -o tests -o examples
       - name: panel and dataclasses on 3.6  
         if: matrix.python-version == '3.6'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,12 +59,6 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
-      # - name: Patch with latest dask from conda-forge
-      #   if: (!contains(matrix.python-version, '3.6'))
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     conda install ${{ env.CHANS_DEV}} "dask>=2021.05.0"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          channel-priority: strict
           miniconda-version: "latest"
           mamba-version: "*"
           channels: pyviz/label/dev,conda-forge,nodefaults
@@ -44,19 +45,17 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install 3.6
-        if: matrix.python-version == '3.6'
+      - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install -o tests -o examples --conda-mode=mamba
-          mamba install "panel=0.12" dataclasses
-      - name: doit develop_install > 3.6
-        if: matrix.python-version > '3.6'
+      - name: Python 3.6 installs
+        if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install -o tests -o examples
+          mamba install "panel=0.12" dataclasses
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,14 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.10"]
+        # python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0} 
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
-      CHANS_DEV: "-c pyviz/label/dev"
+      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -58,7 +59,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          conda install -c conda-forge "dask>=2021.05.0"
+          conda install ${{ env.CHANS_DEV}} "dask>=2021.05.0"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,6 @@ jobs:
       run:
         shell: bash -l {0} 
     env:
-      DESC: "Python ${{ matrix.python-version }} tests"
-      CHANS_DEV: "-c pyviz/label/dev -c conda-forge -c nodefaults"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -33,32 +31,29 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          mamba-version: "*"
+          channels: pyviz/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
-      - name: conda setup 3.6
-        if: matrix.python-version == '3.6'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda create -c pyviz/label/dev -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: conda setup > 3.6
+      - name: conda update > 3.6
         if: matrix.python-version != '3.6'
         run: |
-          conda update -n base -c defaults conda
-          conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install 3.6
+          conda update -n base conda
+      - name: conda setup
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+      - name: doit develop_install
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit develop_install -o tests -o examples --conda-mode=mamba
+      - name: panel 3.6
         if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install -c pyviz/label/dev -o tests -o examples
-          conda install -c pyviz/label/dev "panel=0.12"
-      - name: doit develop_install > 3.6
-        if: matrix.python-version != '3.6'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
+          mamba install "panel=0.12"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ["3.10"]
-        # python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     timeout-minutes: 60
     defaults:
       run:
@@ -41,7 +40,6 @@ jobs:
         run: |
           conda update -n base -c defaults conda
           conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
-          # doit env_create ${{ env.CHANS_DEV}} --python=${{ matrix.python-version }}
       - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"
@@ -53,12 +51,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install ${{ env.CHANS_DEV}} "panel=0.12"
-      - name: Patch with latest dask from conda-forge
-        if: (!contains(matrix.python-version, '3.6'))
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda install ${{ env.CHANS_DEV}} "dask>=2021.05.0"
+      # - name: Patch with latest dask from conda-forge
+      #   if: (!contains(matrix.python-version, '3.6'))
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     conda install ${{ env.CHANS_DEV}} "dask>=2021.05.0"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,10 +39,9 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
-          conda config --set always_yes True
           conda update -n base -c defaults conda
-          conda install -c pyviz "pyctdev>=0.5"
-          doit env_create ${{ env.CHANS_DEV}} --python=${{ matrix.python-version }}
+          conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
+          # doit env_create ${{ env.CHANS_DEV}} --python=${{ matrix.python-version }}
       - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,13 @@ jobs:
           miniconda-version: "latest"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
-      - name: conda setup
+      - name: conda setup 3.6
+        if: matrix.python-version == '3.6'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
+      - name: conda setup > 3.6
+        if: matrix.python-version != '3.6'
         run: |
           conda update -n base -c defaults conda
           conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
@@ -45,11 +51,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
-      - name: Current dev version of panel is broken on py36
-        if: (matrix.python-version == '3.6')
+      - name: doit develop_install 3.6
+        if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
+          doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
           conda install ${{ env.CHANS_DEV}} "panel=0.12"
       # - name: Patch with latest dask from conda-forge
       #   if: (!contains(matrix.python-version, '3.6'))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,10 +22,7 @@ jobs:
         shell: bash -l {0} 
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
-      HV_REQUIREMENTS: "unit_tests"
-      PYTHON_VERSION: ${{ matrix.python-version }}
       CHANS_DEV: "-c pyviz/label/dev"
-      CHANS: "-c pyviz -c bokeh -c conda-forge"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +41,6 @@ jobs:
           conda config --set always_yes True
           conda update -n base -c defaults conda
           conda install -c pyviz "pyctdev>=0.5"
-          doit ecosystem_setup
           doit env_create ${{ env.CHANS_DEV}} --python=${{ matrix.python-version }}
       - name: doit develop_install
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          mamba install "panel=0.12"
+          mamba install "panel=0.12" dataclasses
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-    timeout-minutes: 40
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0} 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     timeout-minutes: 40
     defaults:
       run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,24 +40,25 @@ jobs:
         if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
-          conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
+          conda create -c pyviz/label/dev -n test-environment python=${{ matrix.python-version }} pyctdev
       - name: conda setup > 3.6
         if: matrix.python-version != '3.6'
         run: |
           conda update -n base -c defaults conda
           conda create ${{ env.CHANS_DEV}} -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
       - name: doit develop_install 3.6
         if: matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
+          doit develop_install -c pyviz/label/dev -o tests -o examples
+          conda install -c pyviz/label/dev "panel=0.12"
+      - name: doit develop_install > 3.6
+        if: matrix.python-version != '3.6'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
           doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples
-          conda install ${{ env.CHANS_DEV}} "panel=0.12"
       # - name: Patch with latest dask from conda-forge
       #   if: (!contains(matrix.python-version, '3.6'))
       #   run: |

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -81,6 +81,7 @@ examples are on https://examples.pyviz.org.
 
 .. toctree::
     :titlesonly:
+    :hidden:
     :maxdepth: 2
 
     Census <https://examples.pyviz.org/census/census.html>

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -81,7 +81,6 @@ examples are on https://examples.pyviz.org.
 
 .. toctree::
     :titlesonly:
-    :hidden:
     :maxdepth: 2
 
     Census <https://examples.pyviz.org/census/census.html>

--- a/dodo.py
+++ b/dodo.py
@@ -8,7 +8,7 @@ def task_pip_on_conda():
     """Experimental: provide pip build env via conda"""
     return {'actions':[
         # some ecosystem=pip build tools must be installed with conda when using conda...
-        'conda install -y pip twine wheel',
+        'conda install -y pip twine wheel rfc3986 keyring',
         # ..and some are only available via conda-forge
         'conda install -y -c conda-forge tox virtualenv',
     ]}

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ examples = [
 
 extras_require = {
     'tests': [
-        'pytest >=3.9.3,<6.0',
+        'pytest >=3.9.3',
         'pytest-benchmark >=3.0.0',
         'pytest-cov',
         'codecov',

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,6 @@ extras_require = {
         'bokeh',
         'pyarrow',
         'netcdf4',
-        'twine',   # required for pip packaging
-        'rfc3986', # required by twine
-        'keyring', # required by twine
         'spatialpandas'
     ],
     'examples': examples,

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version                     test group                     extra envs  extra commands
-envlist = {py27,py36,py37,py38}-{lint,unit,unit_nojit,unit_deploy,examples,all,examples_extra}-{default}-{dev,pkg}
+envlist = {py27,py36,py37,py38,py39,py310}-{lint,unit,unit_nojit,unit_deploy,examples,all,examples_extra}-{default}-{dev,pkg}
 build = wheel
 
 [_lint]


### PR DESCRIPTION
This PR is ready in itself even if 4 tests are failing on Py 3.8, 3.9 and 3.10 due to the latest version of pandas (1.4.0) being pulled on these versions. 
```
=========================== short test summary info ============================
FAILED datashader/tests/test_datatypes.py::TestRaggedGetitem::test_getitem_invalid
FAILED datashader/tests/test_datatypes.py::TestRaggedInterface::test_tolist
FAILED datashader/tests/test_datatypes.py::TestRaggedMethods::test_where_series[True]
FAILED datashader/tests/test_datatypes.py::TestRaggedMethods::test_where_series[False]
= 4 failed, 765 passed, 48 skipped, 2 xfailed, 658 warnings in 300.81s (0:05:00) =
```