### PR TITLE
Calculate raster coords identically to other primitives

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.6, 3.7, 3.8]
-    timeout-minutes: 40
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0} 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -286,44 +286,6 @@ def orient_array(raster, res=None, layer=None):
     return array
 
 
-def compute_coords(width, height, x_range, y_range, res):
-    """
-    Computes DataArray coordinates at bin centers
-
-    Parameters
-    ----------
-    width : int
-        Number of coordinates along the x-axis
-    height : int
-        Number of coordinates along the y-axis
-    x_range : tuple
-        Left and right edge of the coordinates
-    y_range : tuple
-        Bottom and top edges of the coordinates
-    res : tuple
-        Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
-        sizes"), respectively. Used to determine coordinate orientation.
-
-    Returns
-    -------
-    xs : numpy.ndarray
-        1D array of x-coordinates
-    ys : numpy.ndarray
-        1D array of y-coordinates
-    """
-    (x0, x1), (y0, y1) = x_range, y_range
-    xd = (x1-x0)/float(width)
-    yd = (y1-y0)/float(height)
-    xpad, ypad = abs(xd/2.), abs(yd/2.)
-    x0, x1 = x0+xpad, x1-xpad
-    y0, y1 = y0+ypad, y1-ypad
-    xs = np.linspace(x0, x1, width)
-    ys = np.linspace(y0, y1, height)
-    if res[0] < 0: xs = xs[::-1]
-    if res[1] > 0: ys = ys[::-1]
-    return xs, ys
-
-
 def downsample_aggregate(aggregate, factor, how='mean'):
     """Create downsampled aggregate factor in pixels units"""
     ys, xs = aggregate.shape[:2]


### PR DESCRIPTION
Fixes issue #1038, supersedes PR #1042.

Calculation of x, y coords for rasters was using a different code path to that used by other geometric primitives, leading to very small differences (~1e-15) that can cause problems when using `tf.stack`.

This PR removes the `utils.compute_coords` function that was only used by `Canvas.raster` and instead uses the same combination of `Axis.compute_scale_and_translation` and `Axis.compute_index` as the other primitives, so that now the coordinates are identical.

I have slightly refactored where this code is called in `Canvas.raster` as the x and y coords are now independent, and replaced use of `np.isclose(...).all()` with `np.allclose(...)` which is simpler.