### PR TITLE
fix incorrect version comparison introduced in #1044

### DIFF
--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -93,7 +93,7 @@ class Glyph(Expr):
 
     @staticmethod
     def to_cupy_array(df, columns):
-        if cudf.__version__ >= Version("22.02"):
+        if Version(cudf.__version__) >= Version("22.02"):
             return df[columns].to_cupy()
         else:
             if not isinstance(columns, (list, tuple)):

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -18,7 +18,7 @@ except Exception:
 
 def values(s):
     if isinstance(s, cudf.Series):
-        if cudf.__version__ >= Version("22.02"):
+        if Version(cudf.__version__) >= Version("22.02"):
             return s.to_cupy(na_value=np.nan)
         else:
             return s.to_gpu_array(fillna=np.nan)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -42,7 +42,7 @@ class extract(Preprocess):
                 nullval = np.nan
             else:
                 nullval = 0
-            if cudf.__version__ >= Version("22.02"):
+            if Version(cudf.__version__) >= Version("22.02"):
                 return df[self.column].to_cupy(na_value=nullval)
             return cupy.array(df[self.column].to_gpu_array(fillna=nullval))
         elif isinstance(df, xr.Dataset):
@@ -83,7 +83,7 @@ class category_codes(CategoryPreprocess):
 
     def apply(self, df):
         if cudf and isinstance(df, cudf.DataFrame):
-            if cudf.__version__ >= Version("22.02"):
+            if Version(cudf.__version__) >= Version("22.02"):
                 return df[self.column].cat.codes.to_cupy()
             return df[self.column].cat.codes.to_gpu_array()
         else:
@@ -118,7 +118,7 @@ class category_modulo(category_codes):
     def apply(self, df):
         result = (df[self.column] - self.offset) % self.modulo
         if cudf and isinstance(df, cudf.Series):
-            if cudf.__version__ >= Version("22.02"):
+            if Version(cudf.__version__) >= Version("22.02"):
                 return result.to_cupy()
             return result.to_gpu_array()
         else:
@@ -199,7 +199,7 @@ class category_values(CategoryPreprocess):
             else:
                 nullval = 0
             a = cupy.asarray(a)
-            if cudf.__version__ >= Version("22.02"):
+            if Version(cudf.__version__) >= Version("22.02"):
                 b = df[self.column].to_cupy(na_value=nullval)
             else:
                 b = cupy.asarray(df[self.column].fillna(nullval))


### PR DESCRIPTION
#1044 introdced a syntax error, which compared string version with `packaging.version.Version`. Minor PR to fix it.
