### PR TITLE
Rescale discrete levels for how='eq_hist'

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1034,13 +1034,13 @@ def test_eq_hist():
     data[np.random.randint(300**2, size=100)] = np.nan
     data = (data - np.nanmin(data)).reshape((300, 300))
     mask = np.isnan(data)
-    eq = tf.eq_hist(data, mask)
+    eq, _ = tf.eq_hist(data, mask)
     check_eq_hist_cdf_slope(eq)
     assert (np.isnan(eq) == mask).all()
     # Integer
     data = np.random.normal(scale=100, size=(300, 300)).astype('i8')
     data = data - data.min()
-    eq = tf.eq_hist(data)
+    eq, _ = tf.eq_hist(data)
     check_eq_hist_cdf_slope(eq)
 
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -82,6 +82,15 @@ eq_hist_sol = {'a': np.array([[0, 4291543295, 4288846335],
                               [4281281791, 4278190335, 0]], dtype='u4')}
 eq_hist_sol['c'] = eq_hist_sol['b']
 
+eq_hist_sol_rescale_discrete_levels = {
+    'a': np.array([[0, 4289306879, 4287070463],
+                   [4284834047, 0, 4282597631],
+                   [4280361215, 4278190335, 0]], dtype='u4'),
+    'b': np.array([[0, 4289306879, 4287070463],
+                   [4285228543, 0, 4282597631],
+                   [4280755711, 4278190335, 0]], dtype='u4')}
+eq_hist_sol_rescale_discrete_levels['c'] = eq_hist_sol_rescale_discrete_levels['b']
+
 
 def check_span(x, cmap, how, sol):
     # Copy inputs that will be modified
@@ -156,9 +165,14 @@ def test_shade(agg, attr, span):
     assert_eq_xr(img, sol)
 
     # span option not supported with how='eq_hist'
-    img = tf.shade(x, cmap=cmap, how='eq_hist')
-    sol = tf.Image(eq_hist_sol[attr], coords=coords, dims=dims)
-    assert_eq_xr(img, sol)
+    if span is None:
+        img = tf.shade(x, cmap=cmap, how='eq_hist', rescale_discrete_levels=False)
+        sol = tf.Image(eq_hist_sol[attr], coords=coords, dims=dims)
+        assert_eq_xr(img, sol)
+
+        img = tf.shade(x, cmap=cmap, how='eq_hist', rescale_discrete_levels=True)
+        sol = tf.Image(eq_hist_sol_rescale_discrete_levels[attr], coords=coords, dims=dims)
+        assert_eq_xr(img, sol)
 
     img = tf.shade(x, cmap=cmap,
                    how=lambda x, mask: np.where(mask, np.nan, x ** 2))

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -485,10 +485,10 @@ def test_shade_zeros(array):
 @pytest.mark.parametrize('agg', aggs)
 @pytest.mark.parametrize('attr', ['d'])
 @pytest.mark.parametrize('rescale', [False, True])
-def test_shade_rescale_small_values(agg, attr, rescale):
+def test_shade_rescale_discrete_levels(agg, attr, rescale):
     x = getattr(agg, attr)
     cmap = ['pink', 'red']
-    img = tf.shade(x, cmap=cmap, how='eq_hist', rescale_small_values=rescale)
+    img = tf.shade(x, cmap=cmap, how='eq_hist', rescale_discrete_levels=rescale)
     if rescale:
         sol = np.array([[0xff8d85ff, 0xff716bff, 0xff5450ff],
                         [0xff3835ff, 0xff8d85ff, 0xff1c1aff],

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -256,9 +256,13 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_small_val
                 if max_data is None:
                     raise ValueError("interpolator did not return a valid max_data")
 
-                lower_span = 1.0 - 0.6*np.log10(max_data)
-                lower_span = np.clip(lower_span, 0.0, 0.9)
-                if lower_span < span[0]:
+                # Straight line y = mx + c through (2, 1.5) and (100, 1) where
+                # x is max_data (number of discrete levels) and y is lower span limit.
+                m = -0.5/98.0  # (y[1] - y[0]) / (x[1] - x[0])
+                c = 1.5 - 2*m  # y[0] - m*x[0]
+                multiple = m*max_data + c
+                if multiple > 1:
+                    lower_span = max(span[1] - multiple*(span[1] - span[0]), 0)
                     span = (lower_span, 1)
         else:
             if how == 'eq_hist':

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -545,7 +545,7 @@ def _apply_discrete_colorkey(agg, color_key, alpha, name, color_baseline):
 
 def shade(agg, cmap=["lightblue", "darkblue"], color_key=Sets1to3,
           how='eq_hist', alpha=255, min_alpha=40, span=None, name=None,
-          color_baseline=None, rescale_discrete_levels=True):
+          color_baseline=None, rescale_discrete_levels=False):
     """Convert a DataArray to an image by choosing an RGBA pixel color for each value.
 
     Requires a DataArray with a single data dimension, here called the

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -185,9 +185,9 @@ def eq_hist(data, mask=None, nbins=256*256):
 
 
 
-_interpolate_lookup = {'log': lambda d, m: (np.log1p(np.where(m, np.nan, d)), None),
-                       'cbrt': lambda d, m: (np.where(m, np.nan, d)**(1/3.), None),
-                       'linear': lambda d, m: (np.where(m, np.nan, d), None),
+_interpolate_lookup = {'log': lambda d, m: np.log1p(np.where(m, np.nan, d)),
+                       'cbrt': lambda d, m: np.where(m, np.nan, d)**(1/3.),
+                       'linear': lambda d, m: np.where(m, np.nan, d),
                        'eq_hist': eq_hist}
 
 
@@ -245,7 +245,10 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_small_val
 
     with np.errstate(invalid="ignore", divide="ignore"):
         # Transform data (log, eq_hist, etc.)
-        data, max_data = interpolater(data, mask)
+        data = interpolater(data, mask)
+        max_data = None
+        if isinstance(data, (list, tuple)):
+            data, max_data = data
 
         # Transform span
         if span is None:


### PR DESCRIPTION
This is a candidate fix for issue #357.

Under normal circumstances if `how='eq_hist'` then the `span` is calculated as `(np.nanmin, np.nanmax)` of the masked data, hence the data is colored using the full `cmap` range. If there are a small number of discrete values in the data then this can lead to low values, which are often in the majority, being rendered at the low end of `cmap` with low `alpha`.

This PR adds a new `rescale_small_values` boolean kwarg to `shade()` with a default of `False`. If it is `True`, `how='eq_hist'` and there are a small number of discrete values in the masked data then the lower `span` limit is reduced so that the data is rendered more towards the top end of the `cmap` range.

The exact form of the equation relating the `lower_span` limit to the max value of the masked data `max_data` is to be determined. Currently trialling (line 259):
```python
lower_span = 1.0 - 0.6*np.log10(max_data)
```

