### PR TITLE
Small enhancement to Cuda functions

### DIFF
--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -10,9 +10,11 @@ from numba import cuda
 
 try:
     import cudf
+    import cupy as cp
     from ..transfer_functions._cuda_utils import cuda_args
-except Exception:
+except ImportError:
     cudf = None
+    cp = None
     cuda_args = None
 
 
@@ -815,15 +817,17 @@ class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
+                ys = cp.array(y_values)
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df.loc[:, list(x_names)].to_numpy()
+                ys = y_values
                 do_extend = extend_cpu
 
             do_extend(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,
-                xs, y_values, *aggs_and_cols
+                xs, ys, *aggs_and_cols
             )
 
         return extend
@@ -881,16 +885,19 @@ class AreaToLineAxis1YConstant(AreaToLineAxis1):
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
+                ys = cp.array(y_values)
+                ysv = cp.array(y_stack_values)
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df.loc[:, list(x_names)].to_numpy()
-
+                ys = y_values
+                ysv = y_stack_values
                 do_extend = extend_cpu
 
             do_extend(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,
-                xs, y_values, y_stack_values, *aggs_and_cols
+                xs, ys, ysv, *aggs_and_cols
             )
 
         return extend

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -10,8 +10,9 @@ from numba import cuda
 
 try:
     import cudf
+    import cupy as cp
     from ..transfer_functions._cuda_utils import cuda_args
-except Exception:
+except ImportError:
     cudf = None
     cuda_args = None
 
@@ -324,16 +325,18 @@ class LinesAxis1XConstant(LinesAxis1):
             aggs_and_cols = aggs + info(df)
 
             if cudf and isinstance(df, cudf.DataFrame):
+                xs = cp.array(x_values)
                 ys = self.to_cupy_array(df, y_names)
                 do_extend = extend_cuda[cuda_args(ys.shape)]
             else:
+                xs = x_values
                 ys = df.loc[:, list(y_names)].to_numpy()
                 do_extend = extend_cpu
 
             do_extend(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,
-                x_values, ys, *aggs_and_cols
+                xs, ys, *aggs_and_cols
             )
 
         return extend
@@ -395,15 +398,17 @@ class LinesAxis1YConstant(LinesAxis1):
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
+                ys = cp.array(y_values)
                 do_extend = extend_cuda[cuda_args(xs.shape)]
             else:
                 xs = df.loc[:, list(x_names)].to_numpy()
+                ys = y_values
                 do_extend = extend_cpu
 
             do_extend(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,
-                xs, y_values, *aggs_and_cols
+                xs, ys, *aggs_and_cols
             )
 
         return extend

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -249,9 +249,6 @@ def test_count_cat(ddf):
     # add an extra category (this will count nans and out of bounds)
     sol = np.append(sol, [[[0], [0]],[[0], [0]]], axis=2)
 
-    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
-        pytest.skip("The following test is not implemented for cuda")
-
     # categorizing by binning the integer arange columns using [0,20] into 4 bins. Same result as for count_cat
     for col in 'i32', 'i64':
         out = xr.DataArray(

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -280,10 +280,6 @@ def test_categorical_count(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_count_binning(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The categorical binning of 'count' reduction is yet supported on the GPU"
-        )
     sol = np.array([[[5, 0, 0, 0],
                      [0, 0, 5, 0]],
                     [[0, 5, 0, 0],
@@ -356,10 +352,6 @@ def test_categorical_sum(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_sum_binning(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The categorical binning of 'sum' reduction is yet supported on the GPU"
-        )
     sol = np.array([[[8.0,  nan,  nan,  nan],
                      [nan,  nan, 60.0,  nan]],
                     [[nan, 35.0,  nan,  nan],
@@ -402,10 +394,6 @@ def test_categorical_max(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_max_binning(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The categorical binning of 'max' reduction is yet supported on the GPU"
-        )
     sol = np.array([[[  4, nan, nan, nan],
                      [nan, nan,  14, nan]],
                     [[nan,   9, nan, nan],
@@ -452,10 +440,6 @@ def test_categorical_mean(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_mean_binning(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The categorical binning of 'mean' reduction is yet supported on the GPU"
-        )
     sol = np.array([[[  2, nan, nan, nan],
                      [nan, nan,  12, nan]],
                     [[nan,   7, nan, nan],


### PR DESCRIPTION
Adds Cuda support for category_binning and removes most of the following warning, the rest will be removed with #1016. 

``` python
NumbaPerformanceWarning: Host array used in CUDA kernel will incur copy overhead to/from device.
    warn(NumbaPerformanceWarning(msg))
```

I'm not sure if I should replace `cp.array` with `cp.asarray`.

If needed, I can split this PR up into two.


**Logfiles:**
[datashader_tests_cudf_21.10.01.log](https://github.com/holoviz/datashader/files/8410721/datashader_tests_cudf_21.10.01.log)
[datashader_tests_cudf_22.02.00.log](https://github.com/holoviz/datashader/files/8410722/datashader_tests_cudf_22.02.00.log)

