### PR TITLE
Add a GHA workflow to run HoloViz downstream tests

### DIFF
--- a/.github/workflows/downstream_tests.yaml
+++ b/.github/workflows/downstream_tests.yaml
@@ -1,0 +1,23 @@
+name: downstream_tests
+
+on:
+  # Run this workflow after the build workflow has completed.
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+  # Or by triggering it manually via Github's UI
+  workflow_dispatch:
+    inputs:
+      manual:
+        description: don't change me!
+        type: boolean
+        required: true
+        default: true
+
+jobs:
+  downstream_tests:
+    uses: pyviz-dev/holoviz_tasks/.github/workflows/run_downstream_tests.yaml@main
+    with:
+      downstream_repos_as_json: "{\"downstream_repo\":[\"holoviews\", \"hvplot\"]}"
+    secrets:
+      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
First time experimenting with this sort of workflow, and making use of a reusable workflow hosted at https://github.com/pyviz-dev/holoviz_tasks.