### PR TITLE
Fix the downstream tests workflow

### DIFF
--- a/.github/workflows/downstream_tests.yaml
+++ b/.github/workflows/downstream_tests.yaml
@@ -3,7 +3,7 @@ name: downstream_tests
 on:
   # Run this workflow after the build workflow has completed.
   workflow_run:
-    workflows: [build]
+    workflows: [packages]
     types: [completed]
   # Or by triggering it manually via Github's UI
   workflow_dispatch:


### PR DESCRIPTION
The identifier of the build workflow is apparently its name, not filename.