### PR TITLE
Fix uint handling in eq_hist and xarray examples

### DIFF
--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -170,6 +170,8 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
+        if data2.dtype == 'uint32':
+             data2 = data2.astype('int32')
         flattened = data2.reshape(-1)
         assert(flattened.itemsize <= 4)
         hist = np.bincount(flattened)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -170,7 +170,8 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
-        hist = np.bincount(data2.ravel())
+        flattened = data2.reshape(-1)
+        hist = np.bincount(flattened)
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])
         hist, bin_centers = hist[idx:], bin_centers[idx:]

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -171,6 +171,7 @@ def eq_hist(data, mask=None, nbins=256*256):
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
         flattened = data2.reshape(-1)
+        assert(flattened.itemsize <= 4)
         hist = np.bincount(flattened)
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -151,7 +151,8 @@ def eq_hist(data, mask=None, nbins=256*256):
        Boolean array of missing points. Where True, the output will be `NaN`.
     nbins : int, optional
         Number of bins to use. Note that this argument is ignored for integer
-        arrays, which bin by the integer values directly.
+        and boolean arrays with dtypes 32 bits or smaller, which bin by the
+        integer values directly.
 
     Notes
     -----
@@ -169,11 +170,7 @@ def eq_hist(data, mask=None, nbins=256*256):
         interp = np.interp
 
     data2 = data if mask is None else data[~mask]
-    if data2.dtype == bool or np.issubdtype(data2.dtype, np.integer):
-        # workaround for bincount not supporting uint64 (https://github.com/numpy/numpy/issues/17760)
-        if data2.dtype == np.uint64:
-            warnings.warn("uint64 aggregate not supported by numpy bincount; casting to uint32")
-            data2 = data2.astype(np.uint32)
+    if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
         hist = np.bincount(data2.ravel())
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -171,7 +171,7 @@ def eq_hist(data, mask=None, nbins=256*256):
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
         if data2.dtype == 'uint32':
-             data2 = data2.astype('int32')
+             data2 = data2.astype('int16')
         flattened = data2.reshape(-1)
         assert(flattened.itemsize <= 4)
         hist = np.bincount(flattened)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -7,7 +7,6 @@ except ImportError: # py2.7
 
 from collections import OrderedDict
 from io import BytesIO
-import warnings
 
 import numpy as np
 import numba as nb

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -7,6 +7,7 @@ except ImportError: # py2.7
 
 from collections import OrderedDict
 from io import BytesIO
+import warnings
 
 import numpy as np
 import numba as nb
@@ -169,8 +170,10 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or np.issubdtype(data2.dtype, np.integer):
-        if data2.dtype.kind == 'u':
-             data2 = data2.astype('i8')
+        # workaround for bincount not supporting uint64 (https://github.com/numpy/numpy/issues/17760)
+        if data2.dtype == np.uint64:
+            warnings.warn("uint64 aggregate not supported by numpy bincount; casting to uint32")
+            data2 = data2.astype(np.uint32)
         hist = np.bincount(data2.ravel())
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -170,10 +170,7 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
-        if data2.dtype == 'uint32':
-             data2 = data2.astype('int16')
         flattened = data2.reshape(-1)
-        assert(flattened.itemsize <= 4)
         hist = np.bincount(flattened)
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -149,9 +149,9 @@ def eq_hist(data, mask=None, nbins=256*256):
     mask : ndarray, optional
        Boolean array of missing points. Where True, the output will be `NaN`.
     nbins : int, optional
-        Number of bins to use. Note that this argument is ignored for integer
-        and boolean arrays with dtypes 32 bits or smaller, which bin by the
-        integer values directly.
+        Maximum number of bins to use. If data is of type boolean or integer
+        this will determine when to switch from exact unique value counts to
+        a binned histogram.
 
     Notes
     -----
@@ -169,12 +169,16 @@ def eq_hist(data, mask=None, nbins=256*256):
         interp = np.interp
 
     data2 = data if mask is None else data[~mask]
-    if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.itemsize <= 4):
-        flattened = data2.reshape(-1)
-        hist = np.bincount(flattened)
-        bin_centers = np.arange(len(hist))
-        idx = int(np.nonzero(hist)[0][0])
-        hist, bin_centers = hist[idx:], bin_centers[idx:]
+
+    # Run more accurate value counting if data is of boolean or integer type
+    # and unique value array is smaller than nbins.
+    if data2.dtype == bool or (np.issubdtype(data2.dtype, np.integer) and data2.max() < nbins):
+        values, counts = np.unique(data2, return_counts=True)
+        vmin, vmax = values.min(), values.max()
+        interval = vmax-vmin
+        bin_centers = np.arange(vmin, vmax+1)
+        hist = np.zeros(interval+1, dtype='uint64')
+        hist[values-vmin] = counts
     else:
         hist, bin_edges = np.histogram(data2, bins=nbins)
         bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agg_d3_d5=aggc.sel(cat=['d3', 'd5']).sum(dim='cat')\n",
+    "agg_d3_d5=aggc.sel(cat=['d3', 'd5']).sum(dim='cat').astype('uint32')\n",
     "\n",
     "tf.Images(tf.shade(aggc.sel(cat='d3'), name=\"Category d3\"),\n",
     "          tf.shade(agg_d3_d5,          name=\"Categories d3 and d5\"))          "
@@ -755,9 +755,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sum_d2_d3 = aggc.sel(cat=['d2', 'd3']).sum(dim='cat').astype('uint32')\n",
+    "\n",
     "tf.Images(tf.set_background(img,\"black\", name=\"Black bg\"),\n",
-    "          tf.stack(img,tf.shade(aggc.sel(cat=['d2', 'd3']).sum(dim='cat')), name=\"Sum d2 and d3 colors\"),\n",
-    "          tf.stack(img,tf.shade(aggc.sel(cat=['d2', 'd3']).sum(dim='cat')), how='saturate', name=\"d2+d3 saturated\")) "
+    "          tf.stack(img,tf.shade(sum_d2_d3), name=\"Sum d2 and d3 colors\"),\n",
+    "          tf.stack(img,tf.shade(sum_d2_d3), name=\"d2+d3 saturated\", how='saturate')) "
    ]
   },
   {

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -326,7 +326,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we're specifying `uint64` because at least current versions of xarray's `where` method convert to floating point, and keeping the type unsigned is important for `shade` to know that zero is a missing-data value here, to be rendered with a transparent background.\n",
+    "Here we're specifying `uint32` because at least current versions of xarray's `where` method convert to floating point, and keeping the type unsigned is important for `shade` to know that zero is a missing-data value here, to be rendered with a transparent background.\n",
     "\n",
     "The above two results are using the same mask (only those bins `where` the counts for 'd3' and 'd5' are equal), but applied to different aggregates (either just the `d3` and `d5` categories, or the entire set of counts).\n",
     "\n",

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -315,14 +315,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf.Images(tf.shade(agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')), name=\"d3+d5 where d3==d5\"),\n",
-    "          tf.shade(      agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')), name=\"d1+d2+d3+d4+d5 where d3==d5\"))"
+    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "\n",
+    "tf.Images(tf.shade(sel1, name=\"d3+d5 where d3==d5\"),\n",
+    "          tf.shade(sel2, name=\"d1+d2+d3+d4+d5 where d3==d5\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we're specifying `uint64` because at least current versions of xarray's `where` method convert to floating point, and keeping the type unsigned is important for `shade` to know that zero is a missing-data value here, to be rendered with a transparent background.\n",
+    "\n",
     "The above two results are using the same mask (only those bins `where` the counts for 'd3' and 'd5' are equal), but applied to different aggregates (either just the `d3` and `d5` categories, or the entire set of counts).\n",
     "\n",
     "## Colormapping\n",
@@ -768,22 +773,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -315,8 +315,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
-    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint32')\n",
+    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint32')\n",
     "\n",
     "tf.Images(tf.shade(sel1, name=\"d3+d5 where d3==d5\"),\n",
     "          tf.shade(sel2, name=\"d1+d2+d3+d4+d5 where d3==d5\"))"

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -234,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total = tf.shade(merged.sum(dim='cols'), how='linear')\n",
+    "total = tf.shade(merged.sum(dim='cols').astype('uint32'), how='linear')\n",
     "total"
    ]
   },
@@ -242,6 +242,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we are using `uint32` to indicate to `shade` that the zero-count background pixels should be rendered as transparent rather than a color from the blue colormap used here. (Datashader uses NaN as the background value for floating-point aggregates and zero as the background value for unsigned integer types.)\n",
+    "\n",
     "With study, the overall structure of this dataset should be clear, according to what we know we put in when we created them:\n",
     "\n",
     "1. Individual rogue datapoints from curve 'a' are clearly visible (the seven sharp spikes)\n",
@@ -350,7 +352,7 @@
    "source": [
     "opts = hv.opts.RGB(width=600, height=300)\n",
     "ndoverlay = hv.NdOverlay({c:hv.Curve((df['Time'], df[c]), kdims=['Time'], vdims=['Value']) for c in cols})\n",
-    "datashade(ndoverlay, normalization='linear', aggregator=ds.count()).opts(opts)"
+    "datashade(ndoverlay, cnorm='linear', aggregator=ds.count()).opts(opts)"
    ]
   },
   {
@@ -407,7 +409,7 @@
    "source": [
     "opts = hv.opts.RGB(width=600, height=300)\n",
     "ndoverlay = hv.NdOverlay({c:hv.Curve((df['Time'], df[c]), vdims=['Time']) for c in cols})\n",
-    "datashade(ndoverlay, normalization='linear', aggregator=ds.count()).opts(opts) # BoxZoomTool(match_aspect=True)"
+    "datashade(ndoverlay, cnorm='linear', aggregator=ds.count()).opts(opts) # BoxZoomTool(match_aspect=True)"
    ]
   },
   {
@@ -475,8 +477,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "cvs = ds.Canvas(plot_height=400, plot_width=1000)\n",
-    "agg = cvs.line(df, x=time, y=list(range(points)), agg=ds.count(), axis=1)\n",
+    "agg = cvs.line(df, x=time, y=list(range(points)), agg=ds.count(), axis=1, line_width=0)\n",
     "img = tf.shade(agg, how='eq_hist')\n",
     "img"
    ]


### PR DESCRIPTION
Fixes https://github.com/holoviz/datashader/issues/1051 .

Xarray operations `sum` and `where` currently lose track of the input datatype, returning floats for unsigned int input. Usually that wouldn't be a problem, but preserving the type is crucial for `shade` to know that zero is a missing-data value, so patched the affected examples to make the types unsigned after those operations.

Also renamed the `normalization` option for HoloViews's `datashade` function to `cnorm`; apparently `normalization` is no longer accepted.