### PR TITLE
Rescale colorize

### DIFF
--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -202,6 +202,23 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
+def _rescale_discrete_levels(discrete_levels, span):
+    if discrete_levels is None:
+        raise ValueError("interpolator did not return a valid discrete_levels")
+
+    # Straight line y = mx + c through (2, 1.5) and (100, 1) where
+    # x is number of discrete_levels and y is lower span limit.
+    m = -0.5/98.0  # (y[1] - y[0]) / (x[1] - x[0])
+    c = 1.5 - 2*m  # y[0] - m*x[0]
+    multiple = m*discrete_levels + c
+
+    if multiple > 1:
+        lower_span = max(span[1] - multiple*(span[1] - span[0]), 0)
+        span = (lower_span, 1)
+
+    return span
+
+
 def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_discrete_levels):
     if cupy and isinstance(agg.data, cupy.ndarray):
         from ._cuda_utils import masked_clip_2d, interp
@@ -259,17 +276,7 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_discrete_
             span = np.nanmin(masked_data), np.nanmax(masked_data)
 
             if rescale_discrete_levels:  # Only valid for how='eq_hist'
-                if discrete_levels is None:
-                    raise ValueError("interpolator did not return a valid discrete_levels")
-
-                # Straight line y = mx + c through (2, 1.5) and (100, 1) where
-                # x is number of discrete_levels and y is lower span limit.
-                m = -0.5/98.0  # (y[1] - y[0]) / (x[1] - x[0])
-                c = 1.5 - 2*m  # y[0] - m*x[0]
-                multiple = m*discrete_levels + c
-                if multiple > 1:
-                    lower_span = max(span[1] - multiple*(span[1] - span[0]), 0)
-                    span = (lower_span, 1)
+                span = _rescale_discrete_levels(discrete_levels, span)
         else:
             if how == 'eq_hist':
                 # For eq_hist to work with span, we'd need to compute the histogram
@@ -319,7 +326,7 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_discrete_
     return Image(img, coords=agg.coords, dims=agg.dims, name=name)
 
 
-def _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline):
+def _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline, rescale_discrete_levels):
     if cupy and isinstance(agg.data, cupy.ndarray):
         array = cupy.array
     else:
@@ -391,7 +398,7 @@ def _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline)
 
     total = nansum_missing(data, axis=2)
     mask = np.isnan(total)
-    a = _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha)
+    a = _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha, rescale_discrete_levels)
 
     values = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
     if cupy and isinstance(values, cupy.ndarray):
@@ -407,7 +414,7 @@ def _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline)
                  name=name)
 
 
-def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha):
+def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha, rescale_discrete_levels):
 
     if cupy and isinstance(data, cupy.ndarray):
         from ._cuda_utils import interp, masked_clip_2d
@@ -430,13 +437,18 @@ def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha):
             total = np.where(~mask, total, np.nan)
 
         a_scaled = _normalize_interpolate_how(how)(total - offset, mask)
+        discrete_levels = None
         if isinstance(a_scaled, (list, tuple)):
-            a_scaled = a_scaled[0]  # Ignore discrete_levels
+            a_scaled, discrete_levels = a_scaled
 
         # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
         with np.warnings.catch_warnings():
             np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
             norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
+
+        if rescale_discrete_levels:  # Only valid for how='eq_hist'
+            norm_span = _rescale_discrete_levels(discrete_levels, norm_span)
+
     else:
         if how == 'eq_hist':
             # For eq_hist to work with span, we'll need to compute the histogram
@@ -671,7 +683,7 @@ def shade(agg, cmap=["lightblue", "darkblue"], color_key=Sets1to3,
         else:
             return _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_discrete_levels)
     elif agg.ndim == 3:
-        return _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline)
+        return _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline, rescale_discrete_levels)
     else:
         raise ValueError("agg must use 2D or 3D coordinates")
 

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -7,6 +7,7 @@ except ImportError: # py2.7
 
 from collections import OrderedDict
 from io import BytesIO
+import warnings
 
 import numpy as np
 import numba as nb
@@ -169,8 +170,10 @@ def eq_hist(data, mask=None, nbins=256*256):
 
     data2 = data if mask is None else data[~mask]
     if data2.dtype == bool or np.issubdtype(data2.dtype, np.integer):
-        if data2.dtype.kind == 'u':
-             data2 = data2.astype('i8')
+        # workaround for bincount not supporting uint64 (https://github.com/numpy/numpy/issues/17760)
+        if data2.dtype == np.uint64:
+            warnings.warn("uint64 aggregate not supported by numpy bincount; casting to uint32")
+            data2 = data2.astype(np.uint32)
         hist = np.bincount(data2.ravel())
         bin_centers = np.arange(len(hist))
         idx = int(np.nonzero(hist)[0][0])

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agg_d3_d5=aggc.sel(cat=['d3', 'd5']).sum(dim='cat')\n",
+    "agg_d3_d5=aggc.sel(cat=['d3', 'd5']).sum(dim='cat').astype('uint32')\n",
     "\n",
     "tf.Images(tf.shade(aggc.sel(cat='d3'), name=\"Category d3\"),\n",
     "          tf.shade(agg_d3_d5,          name=\"Categories d3 and d5\"))          "
@@ -755,9 +755,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sum_d2_d3 = aggc.sel(cat=['d2', 'd3']).sum(dim='cat').astype('uint32')\n",
+    "\n",
     "tf.Images(tf.set_background(img,\"black\", name=\"Black bg\"),\n",
-    "          tf.stack(img,tf.shade(aggc.sel(cat=['d2', 'd3']).sum(dim='cat')), name=\"Sum d2 and d3 colors\"),\n",
-    "          tf.stack(img,tf.shade(aggc.sel(cat=['d2', 'd3']).sum(dim='cat')), how='saturate', name=\"d2+d3 saturated\")) "
+    "          tf.stack(img,tf.shade(sum_d2_d3), name=\"Sum d2 and d3 colors\"),\n",
+    "          tf.stack(img,tf.shade(sum_d2_d3), name=\"d2+d3 saturated\", how='saturate')) "
    ]
   },
   {

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -315,14 +315,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf.Images(tf.shade(agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')), name=\"d3+d5 where d3==d5\"),\n",
-    "          tf.shade(      agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')), name=\"d1+d2+d3+d4+d5 where d3==d5\"))"
+    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "\n",
+    "tf.Images(tf.shade(sel1, name=\"d3+d5 where d3==d5\"),\n",
+    "          tf.shade(sel2, name=\"d1+d2+d3+d4+d5 where d3==d5\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we're specifying `uint64` because at least current versions of xarray's `where` method convert to floating point, and keeping the type unsigned is important for `shade` to know that zero is a missing-data value here, to be rendered with a transparent background.\n",
+    "\n",
     "The above two results are using the same mask (only those bins `where` the counts for 'd3' and 'd5' are equal), but applied to different aggregates (either just the `d3` and `d5` categories, or the entire set of counts).\n",
     "\n",
     "## Colormapping\n",
@@ -768,22 +773,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -315,8 +315,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
-    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint64')\n",
+    "sel1 = agg_d3_d5.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint32')\n",
+    "sel2 =       agg.where(aggc.sel(cat='d3') == aggc.sel(cat='d5')).astype('uint32')\n",
     "\n",
     "tf.Images(tf.shade(sel1, name=\"d3+d5 where d3==d5\"),\n",
     "          tf.shade(sel2, name=\"d1+d2+d3+d4+d5 where d3==d5\"))"

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -234,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total = tf.shade(merged.sum(dim='cols'), how='linear')\n",
+    "total = tf.shade(merged.sum(dim='cols').astype('uint32'), how='linear')\n",
     "total"
    ]
   },
@@ -242,6 +242,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we are using `uint32` to indicate to `shade` that the zero-count background pixels should be rendered as transparent rather than a color from the blue colormap used here. (Datashader uses NaN as the background value for floating-point aggregates and zero as the background value for unsigned integer types.)\n",
+    "\n",
     "With study, the overall structure of this dataset should be clear, according to what we know we put in when we created them:\n",
     "\n",
     "1. Individual rogue datapoints from curve 'a' are clearly visible (the seven sharp spikes)\n",
@@ -350,7 +352,7 @@
    "source": [
     "opts = hv.opts.RGB(width=600, height=300)\n",
     "ndoverlay = hv.NdOverlay({c:hv.Curve((df['Time'], df[c]), kdims=['Time'], vdims=['Value']) for c in cols})\n",
-    "datashade(ndoverlay, normalization='linear', aggregator=ds.count()).opts(opts)"
+    "datashade(ndoverlay, cnorm='linear', aggregator=ds.count()).opts(opts)"
    ]
   },
   {
@@ -407,7 +409,7 @@
    "source": [
     "opts = hv.opts.RGB(width=600, height=300)\n",
     "ndoverlay = hv.NdOverlay({c:hv.Curve((df['Time'], df[c]), vdims=['Time']) for c in cols})\n",
-    "datashade(ndoverlay, normalization='linear', aggregator=ds.count()).opts(opts) # BoxZoomTool(match_aspect=True)"
+    "datashade(ndoverlay, cnorm='linear', aggregator=ds.count()).opts(opts) # BoxZoomTool(match_aspect=True)"
    ]
   },
   {
@@ -475,8 +477,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "cvs = ds.Canvas(plot_height=400, plot_width=1000)\n",
-    "agg = cvs.line(df, x=time, y=list(range(points)), agg=ds.count(), axis=1)\n",
+    "agg = cvs.line(df, x=time, y=list(range(points)), agg=ds.count(), axis=1, line_width=0)\n",
     "img = tf.shade(agg, how='eq_hist')\n",
     "img"
    ]


### PR DESCRIPTION
https://github.com/holoviz/datashader/pull/1055 added rescaling of span to the `_interpolate` case in `tf.shade()` (2D aggregate), and this PR applies the same treatment to the `_colorize` case (3D/stacked categorical aggregate). `_colorize` is even more important to support here than `_interpolate`, because most examples use Bokeh to do the colormapping for non-categorical shading, while Datashader is the only place that categorical shading is implemented (so far).
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/1695496/163042477-a6948b69-76e7-46e9-93d8-fcf5fbcfc2bc.png">
