### PR TITLE
Scale the norm directly without matplotlib

### DIFF
--- a/datashader/mpl_ext.py
+++ b/datashader/mpl_ext.py
@@ -407,6 +407,7 @@ class ScalarDSArtist(DSArtist):
                 self.norm.vmin = A.min()
             if self._vmax is None:
                 self.norm.vmax = A.max()
+        self.autoscale_None()
 
         # Make the image with matplotlib
         return self.to_rgba(A, bytes=True, norm=True)

--- a/datashader/mpl_ext.py
+++ b/datashader/mpl_ext.py
@@ -398,9 +398,15 @@ class ScalarDSArtist(DSArtist):
 
         # Rescale the norm to the current array
         self.set_array(A)
-        self.norm.vmin = self._vmin
-        self.norm.vmax = self._vmax
-        self.autoscale_None()
+        if self._vmin is not None:
+            self.norm.vmin = self._vmin
+        if self._vmax is not None:
+            self.norm.vmax = self._vmax
+        if A.size:
+            if self._vmin is None:
+                self.norm.vmin = A.min()
+            if self._vmax is None:
+                self.norm.vmax = A.max()
 
         # Make the image with matplotlib
         return self.to_rgba(A, bytes=True, norm=True)


### PR DESCRIPTION
Fixes #1069 

Between its version 3.4 and 3.5 Matplotlib has changed the way *norm* is processed, and has also added callbacks that react on new values of vmin/vmax. Apparently in datashader's artist the *norm* gets attributed a vmin/vmax (this happens somewhere in matplotlib's code) even if `None` is declared for both of them. `dssshow` has `None` as default value of vmin/vmax, datashader's artist tries to set the norm's vmin/vmax in the `shade` method to `None` (before calling the `autoscale_None()` method), which fails with an error.

This PR simply avoids the step of setting vmin/vmax to `None` on the norm, instead the change made computes automatically vmin/vmax when they were not defined by the user. I think how vmin/vmax is computed is OK with the norms that are accepted by `dsshow`, i.e. this is what calling `autoscale_None` would do.