### PR TITLE
Fix antialiased line issues

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: conda setup
         run: |
           eval "$(conda shell.bash hook)"
-          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev "typing_extensions<4.2.0"
       - name: temporarily patch setup.py on windows
         if: matrix.os == 'windows-latest'
         run: sed -i -e 's/numpy >=1.7,!=1.22/numpy <1.22/g' setup.py

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -261,7 +261,7 @@ class Canvas(object):
             approximating the visual appearance of a subpixel line
             width.
         antialias : bool, optional
-            This option is kept for backward compatibility only. 
+            This option is kept for backward compatibility only.
             ``True`` is equivalent to ``line_width=1`` and
             ``False`` (the default) to ``line_width=0``. Do not specify
             both ``antialias`` and ``line_width`` in the same call as a
@@ -335,7 +335,8 @@ class Canvas(object):
         """
         from .glyphs import (LineAxis0, LinesAxis1, LinesAxis1XConstant,
                              LinesAxis1YConstant, LineAxis0Multi,
-                             LinesAxis1Ragged, LineAxis1Geometry)
+                             LinesAxis1Ragged, LineAxis1Geometry,
+                             AntialiasCombination)
 
         validate_xy_or_geometry('Line', x, y, geometry)
 
@@ -427,7 +428,11 @@ The axis argument to Canvas.line must be 0 or 1
         glyph.set_line_width(line_width)
         if line_width > 0:
             if isinstance(agg, (rd.any, rd.max)):
-                glyph.set_antialias_combination_max()
+                glyph.set_antialias_combination(AntialiasCombination.MAX)
+            elif isinstance(agg, rd.min):
+                glyph.set_antialias_combination(AntialiasCombination.MIN)
+            else:
+                glyph.set_antialias_combination(AntialiasCombination.SUM)
 
             # Switch agg to floating point.
             if isinstance(agg, rd.count):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -427,16 +427,25 @@ The axis argument to Canvas.line must be 0 or 1
 
         glyph.set_line_width(line_width)
         if line_width > 0:
+            # Eventually this will be replaced with attributes and/or
+            # member functions of Reduction classes.
+            antialias_combination = AntialiasCombination.NONE
             if isinstance(agg, (rd.any, rd.max)):
-                glyph.set_antialias_combination(AntialiasCombination.MAX)
+                antialias_combination = AntialiasCombination.MAX
             elif isinstance(agg, rd.min):
-                glyph.set_antialias_combination(AntialiasCombination.MIN)
+                antialias_combination = AntialiasCombination.MIN
+            elif isinstance(agg, (rd.count, rd.sum)):
+                if agg.self_intersect:
+                    antialias_combination = AntialiasCombination.SUM_1AGG
+                else:
+                    antialias_combination = AntialiasCombination.SUM_2AGG
             else:
-                glyph.set_antialias_combination(AntialiasCombination.SUM)
+                antialias_combination = AntialiasCombination.SUM_2AGG
+            glyph.set_antialias_combination(antialias_combination)
 
             # Switch agg to floating point.
             if isinstance(agg, rd.count):
-                agg = rd.count_f32()
+                agg = rd.count_f32(self_intersect=agg.self_intersect)
             elif isinstance(agg, rd.any):
                 agg = rd.any_f32()
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -427,7 +427,7 @@ The axis argument to Canvas.line must be 0 or 1
 
         glyph.set_line_width(line_width)
         if line_width > 0:
-            # Eventually this will be replaced with attributes and/or
+            # Eventually this should be replaced with attributes and/or
             # member functions of Reduction classes.
             antialias_combination = AntialiasCombination.NONE
             if isinstance(agg, (rd.any, rd.max)):

--- a/datashader/glyphs/__init__.py
+++ b/datashader/glyphs/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from .points import Point, MultiPointGeometry   # noqa (API import)
 from .line import (  # noqa (API import)
+    AntialiasCombination,
     LineAxis0,
     LineAxis0Multi,
     LinesAxis1,

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -19,8 +19,8 @@ except ImportError:
     cuda_args = None
 
 
-# It would be preferable to replace this with attributes and/or
-# member functions of Reduction classes.
+# This Enum should eventually be replaced with attributes
+# and/or member functions of Reduction classes.
 class AntialiasCombination(Enum):
     NONE = 0
     SUM_1AGG = 1

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -694,6 +694,10 @@ def _full_antialias(line_width, i, x0, x1, y0, y1, *aggs_and_cols):
         scale = line_width
         line_width = 1.0
 
+    # Scale by column value, if required.
+    if len(aggs_and_cols) > 1:
+        scale *= aggs_and_cols[1][i]
+
     aa = 1.0
     halfwidth = 0.5*(line_width + aa)
 
@@ -949,7 +953,7 @@ def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, want_anti
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         nrows, ncols = xs.shape
 
@@ -1019,7 +1023,7 @@ def _build_extend_line_axis1_none_constant(draw_segment, expand_aggs_and_cols, w
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         ncols = xs.shape[1]
         for i in range(xs.shape[0]):
@@ -1090,7 +1094,7 @@ def _build_extend_line_axis1_x_constant(
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         ncols = ys.shape[1]
         for i in range(ys.shape[0]):
@@ -1166,7 +1170,7 @@ def _build_extend_line_axis1_y_constant(
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         ncols = xs.shape[1]
         for i in range(xs.shape[0]):
@@ -1286,7 +1290,7 @@ def _build_extend_line_axis1_ragged(
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         nrows = len(x_start_i)
         x_flat_len = len(x_flat)
@@ -1462,7 +1466,7 @@ def _build_extend_line_axis1_geometry(
 
         accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
-        temp_aggs_and_cols = (temp_agg,)
+        temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
         for i in eligible_inds:
             if missing[i]:

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -6,7 +6,7 @@ from toolz import memoize
 
 from datashader.glyphs.points import _PointLike, _GeometryLike
 from datashader.utils import (isnull, isreal, ngjit, nanmax_in_place,
-                              nanmin_in_place, nansum_in_place)
+                              nanmin_in_place, nansum_in_place, parallel_fill)
 from numba import cuda
 
 
@@ -1072,7 +1072,7 @@ def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, antialias
 
         for j in range(ncols):
             if j > 0:
-                temp_agg.fill(null_value)
+                parallel_fill(temp_agg, null_value)
 
             for i in range(nrows - 1):
                 perform_extend_line(i, j, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
@@ -1151,7 +1151,7 @@ def _build_extend_line_axis1_none_constant(draw_segment, expand_aggs_and_cols, a
         ncols = xs.shape[1]
         for i in range(xs.shape[0]):
             if i > 0:
-                temp_agg.fill(null_value)
+                parallel_fill(temp_agg, null_value)
 
             for j in range(ncols - 1):
                 perform_extend_line(i, j, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
@@ -1234,7 +1234,7 @@ def _build_extend_line_axis1_x_constant(
             # Each time in this loop need to use its own canvas/agg/reduction
             # So create a temporary one and use that, and need use a "max" reduction.
             if i > 0:
-                temp_agg.fill(null_value)
+                parallel_fill(temp_agg, null_value)
 
             for j in range(ncols - 1):
                 perform_extend_line(
@@ -1318,7 +1318,7 @@ def _build_extend_line_axis1_y_constant(
         ncols = xs.shape[1]
         for i in range(xs.shape[0]):
             if i > 0:
-                temp_agg.fill(null_value)
+                parallel_fill(temp_agg, null_value)
 
             for j in range(ncols - 1):
                 perform_extend_line(
@@ -1467,7 +1467,7 @@ def _build_extend_line_axis1_ragged(
                               y_stop_index - y_start_index)
 
             if i > 0:
-                temp_agg.fill(null_value)
+                parallel_fill(temp_agg, null_value)
 
             for j in range(segment_len - 1):
 
@@ -1644,7 +1644,7 @@ def _build_extend_line_axis1_geometry(
                 stop1 = offsets1[j + 1]
 
                 if j > 0:
-                    temp_agg.fill(null_value)
+                    parallel_fill(temp_agg, null_value)
 
                 for k in range(start1, stop1 - 2, 2):
                     x0 = values[k]

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -19,7 +19,7 @@ except ImportError:
     cuda_args = None
 
 
-# Eventually this will be replaced with attributes and/or
+# It would be preferable to replace this with attributes and/or
 # member functions of Reduction classes.
 class AntialiasCombination(Enum):
     NONE = 0
@@ -830,7 +830,7 @@ def _full_antialias(line_width, antialias_combination, i, x0, x1, y0, y1,
                 # Within segment
                 distance = abs((x-x0)*rightx + (y-y0)*righty)
                 if not overwrite and not segment_start and \
-                        (x-x0)*prev_alongx + (y-y0)*prev_alongy <= 0.0 and \
+                        -prev_length <= (x-x0)*prev_alongx + (y-y0)*prev_alongy <= 0.0 and \
                         abs((x-x0)*prev_rightx + (y-y0)*prev_righty) <= halfwidth:
                     prev_correction = True
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -277,7 +277,19 @@ class OptionalFieldReduction(Reduction):
     def _finalize(bases, cuda=False, **kwargs):
         return xr.DataArray(bases[0], **kwargs)
 
-class count(OptionalFieldReduction):
+
+class SelfIntersectingOptionalFieldReduction(OptionalFieldReduction):
+    """
+    Base class for optional field reductions for which self-intersecting
+    geometry may or may not be desireable.
+    Ignored if not using antialiasing.
+    """
+    def __init__(self, column=None, self_intersect=True):
+        super().__init__(column)
+        self.self_intersect = self_intersect
+
+
+class count(SelfIntersectingOptionalFieldReduction):
     """Count elements in each bin, returning the result as a uint32.
 
     Parameters
@@ -293,7 +305,6 @@ class count(OptionalFieldReduction):
     @ngjit
     def _append_no_field(x, y, agg):
         agg[y, x] += 1
-
 
     @staticmethod
     @ngjit
@@ -322,7 +333,7 @@ class count(OptionalFieldReduction):
         return aggs.sum(axis=0, dtype='u4')
 
 
-class count_f32(OptionalFieldReduction):
+class count_f32(SelfIntersectingOptionalFieldReduction):
     """Count elements in each bin, returning the result as a float32.
 
     Is floating point rather than boolean to deal with fractional antialiased
@@ -601,7 +612,19 @@ class _sum_zero(FloatingReduction):
     def _combine(aggs):
         return aggs.sum(axis=0, dtype='f8')
 
-class sum(FloatingReduction):
+
+class SelfIntersectingFloatingReduction(FloatingReduction):
+    """
+    Base class for floating reductions for which self-intersecting geometry
+    may or may not be desireable.
+    Ignored if not using antialiasing.
+    """
+    def __init__(self, column=None, self_intersect=True):
+        super().__init__(column)
+        self.self_intersect = self_intersect
+
+
+class sum(SelfIntersectingFloatingReduction):
     """Sum of all elements in ``column``.
 
     Elements of resulting aggregate are nan if they are not updated.

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from datashader.glyphs import Glyph
 from datashader.glyphs.line import _build_draw_segment, \
-    _build_map_onto_pixel_for_line
+    _build_map_onto_pixel_for_line, AntialiasCombination
 from datashader.utils import ngjit
 
 py2_skip = pytest.mark.skipif(sys.version_info.major < 3, reason="py2 not supported")
@@ -28,7 +28,7 @@ def draw_line():
 
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
     return _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols,
-                               False)
+                               False, AntialiasCombination.NONE)
 
 
 @py2_skip

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -39,7 +39,8 @@ def test_draw_line_left_border(benchmark, draw_line):
     x1, y1 = (0, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    benchmark(draw_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, x0, y0, x1, y1, 0, True, agg)
+    benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
+              x0, x1, y0, y1, 0.0, 0.0, agg)
 
 
 @py2_skip
@@ -50,7 +51,9 @@ def test_draw_line_diagonal(benchmark, draw_line):
     x1, y1 = (n, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    benchmark(draw_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, x0, y0, x1, y1, 0, True, agg)
+    benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
+              x0, x1, y0, y1, 0.0, 0.0, agg)
+
 
 @py2_skip
 @pytest.mark.benchmark(group="draw_line")
@@ -60,4 +63,5 @@ def test_draw_line_offset(benchmark, draw_line):
     x1, y1 = (n, n//4-1)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    benchmark(draw_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, x0, y0, x1, y1, 0, True, agg)
+    benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
+              x0, x1, y0, y1, 0.0, 0.0, agg)

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -5,7 +5,8 @@ import pytest
 
 from datashader.glyphs import Glyph
 from datashader.glyphs.line import (
-    _build_draw_segment, _build_extend_line_axis0, _build_map_onto_pixel_for_line
+    _build_draw_segment, _build_extend_line_axis0, _build_map_onto_pixel_for_line,
+    AntialiasCombination
 )
 from datashader.utils import ngjit
 
@@ -22,7 +23,7 @@ def extend_line():
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
     draw_line = _build_draw_segment(append, map_onto_pixel,
-                                    expand_aggs_and_cols, False)
+                                    expand_aggs_and_cols, False, AntialiasCombination.NONE)
     return _build_extend_line_axis0(draw_line, expand_aggs_and_cols)[0]
 
 

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -24,7 +24,7 @@ def extend_line():
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
     draw_line = _build_draw_segment(append, map_onto_pixel,
                                     expand_aggs_and_cols, False, AntialiasCombination.NONE)
-    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols)[0]
+    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols, AntialiasCombination.NONE)[0]
 
 
 @py2_skip

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -56,7 +56,8 @@ map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
 _draw_segment = _build_draw_segment(append, map_onto_pixel_for_line,
                                     expand_aggs_and_cols, 0, AntialiasCombination.NONE)
-extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols)
+extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols,
+                                          AntialiasCombination.NONE)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)
@@ -79,7 +80,7 @@ def draw_segment(x0, y0, x1, y1, i, segment_start, agg):
     xmin, xmax, ymin, ymax = 0, 5, 0, 5
     _draw_segment(
         i, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
-        segment_start, x0, x1, y0, y1, agg)
+        segment_start, False, x0, x1, y0, y1, 0.0, 0.0, agg)
 
 
 def draw_trapezoid(x0, x1, y0, y1, y2, y3, i, trapezoid_start, stacked, agg):

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -11,6 +11,7 @@ from datashader.glyphs.line import (
     _build_map_onto_pixel_for_line,
     _build_draw_segment,
     _build_extend_line_axis0,
+    AntialiasCombination,
 )
 from datashader.glyphs.trimesh import(
     _build_map_onto_pixel_for_triangle,
@@ -54,7 +55,7 @@ map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 # Line rasterization
 expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
 _draw_segment = _build_draw_segment(append, map_onto_pixel_for_line,
-                                    expand_aggs_and_cols, 0)
+                                    expand_aggs_and_cols, 0, AntialiasCombination.NONE)
 extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols)
 
 # Triangles rasterization

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -1300,10 +1300,6 @@ def test_line_autorange(DataFrame, df_args, cvs_kwargs, line_width):
             [np.nan,   np.nan,   0.646447, 0.646447, np.nan,   0.646447, 0.646447, np.nan,   np.nan  ],
             [np.nan,   np.nan,   np.nan,   0.646447, 1.292893, 0.646447, np.nan,   np.nan,   np.nan  ]
         ], dtype='f4')
-
-        if cvs_kwargs == dict(x='x', y='y', axis=0):
-            # axis0 single draws both lines at the same time.
-            sol[[0, -1], [4, 4]] = 0.646447
     else:
         sol = np.array([[0, 0, 0, 0, 2, 0, 0, 0, 0],
                         [0, 0, 0, 1, 0, 1, 0, 0, 0],

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -588,6 +588,22 @@ def nanmax_in_place(ret, other):
 
 
 @ngjit
+def nanmin_in_place(ret, other):
+    """Min of 2 arrays but taking nans into account.  Could use np.nanmin but
+    would need to replace zeros with nans where both arrays are nans.
+    Return the first array.
+    """
+    ny, nx = ret.shape
+    for j in range(ny):
+        for i in range(nx):
+            if isnull(ret[j, i]):
+                if not isnull(other[j, i]):
+                    ret[j, i] = other[j, i]
+            elif not isnull(other[j, i]) and other[j,i] < ret[j, i]:
+                ret[j,i] = other[j, i]
+
+
+@ngjit
 def nansum_in_place(ret, other):
     """Sum of 2 arrays but taking nans into account.  Could use np.nansum but
     would need to replace zeros with nans where both arrays are nans.

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -571,49 +571,57 @@ def isnull(val):
     return not (val <= 0 or val > 0)
 
 
-@ngjit
+@ngjit_parallel
 def nanmax_in_place(ret, other):
     """Max of 2 arrays but taking nans into account.  Could use np.nanmax but
     would need to replace zeros with nans where both arrays are nans.
     Return the first array.
     """
-    ny, nx = ret.shape
-    for j in range(ny):
-        for i in range(nx):
-            if isnull(ret[j, i]):
-                if not isnull(other[j, i]):
-                    ret[j, i] = other[j, i]
-            elif not isnull(other[j, i]) and other[j,i] > ret[j, i]:
-                ret[j,i] = other[j, i]
+    ret = ret.ravel()
+    other = other.ravel()
+    for i in nb.prange(len(ret)):
+        if isnull(ret[i]):
+            if not isnull(other[i]):
+                ret[i] = other[i]
+        elif not isnull(other[i]) and other[i] > ret[i]:
+            ret[i] = other[i]
 
 
-@ngjit
+@ngjit_parallel
 def nanmin_in_place(ret, other):
     """Min of 2 arrays but taking nans into account.  Could use np.nanmin but
     would need to replace zeros with nans where both arrays are nans.
     Return the first array.
     """
-    ny, nx = ret.shape
-    for j in range(ny):
-        for i in range(nx):
-            if isnull(ret[j, i]):
-                if not isnull(other[j, i]):
-                    ret[j, i] = other[j, i]
-            elif not isnull(other[j, i]) and other[j,i] < ret[j, i]:
-                ret[j,i] = other[j, i]
+    ret = ret.ravel()
+    other = other.ravel()
+    for i in nb.prange(len(ret)):
+        if isnull(ret[i]):
+            if not isnull(other[i]):
+                ret[i] = other[i]
+        elif not isnull(other[i]) and other[i] < ret[i]:
+            ret[i] = other[i]
 
 
-@ngjit
+@ngjit_parallel
 def nansum_in_place(ret, other):
     """Sum of 2 arrays but taking nans into account.  Could use np.nansum but
     would need to replace zeros with nans where both arrays are nans.
     Return the first array.
     """
-    ny, nx = ret.shape
-    for j in range(ny):
-        for i in range(nx):
-            if isnull(ret[j, i]):
-                if not isnull(other[j, i]):
-                    ret[j, i] = other[j, i]
-            elif not isnull(other[j, i]):
-                ret[j,i] += other[j, i]
+    ret = ret.ravel()
+    other = other.ravel()
+    for i in nb.prange(len(ret)):
+        if isnull(ret[i]):
+            if not isnull(other[i]):
+                ret[i] = other[i]
+        elif not isnull(other[i]):
+            ret[i] += other[i]
+
+
+@ngjit_parallel
+def parallel_fill(array, value):
+    """Parallel version of np.fill()"""
+    array = array.ravel()
+    for i in nb.prange(len(array)):
+        array[i] = value


### PR DESCRIPTION
This is a WIP to fix various issues with antialiased lines for the impending release.

The major change is support for both 1 and 2-stage aggregations. Where possible (e.g. `ds.any` and `ds.max`) a single-stage agg is used on an individual line segment basis. `ds.min` always uses a 2-stage agg on an individual line segment basis. `ds.count` and `ds.sum` now have 2 options controlled by `self_intersect` boolean kwarg. If `False` the usual 2-stage agg is used which is very accurate but slower and ignores line self-intersections. If `True`, the default, a 1-stage agg is used that considers the previous line segment so that pixels are not overwritten at line segment joins; this therefore deals with self-intersections and is faster but there will be rendering artifacts in some situations (some are fixable, others are unavoidable).

I am open to suggestions for a better name for the kwarg than `self_intersect`.

Antialiased self-intersecting path using `ds.count` now looks like this (from 15-Large_Data.ipynb): 
![paths](https://user-images.githubusercontent.com/580326/164520629-bc4305a3-8406-4d05-ab56-3e36d0200c7f.png)

Antialiased multiple timeseries using `ds.count` now looks like this (from 3_Timeseries.ipynb):
![overlap_ts](https://user-images.githubusercontent.com/580326/164520646-bd4761c2-bf5d-471f-9b48-111ca70995b5.png)

