### PR TITLE
Fix the failing example on Windows / Python 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,9 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           mamba install "panel=0.12" dataclasses
+      - name: patch for fiona on windows / 3.7 
+        if: matrix.os == 'windows-latest' && matrix.python-version == '3.7'
+        run: mamba install "fiona=1.8.19" "gdal=3.2.2"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,10 @@ jobs:
           mamba install "panel=0.12" dataclasses
       - name: patch for fiona on windows / 3.7 
         if: matrix.os == 'windows-latest' && matrix.python-version == '3.7'
-        run: mamba install "fiona=1.8.19" "gdal=3.2.2"
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          mamba install "fiona=1.8.19" "gdal=3.2.2"
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest']
-        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ["3.7"]
-        # python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     timeout-minutes: 60
     defaults:
       run:
@@ -73,23 +71,23 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit env_capture
-      # - name: doit test_lint
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     doit test_lint
-      # - name: doit test_unit_deploy
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     doit test_unit_deploy
-      # - name: doit test_unit_nojit
-      #   run: |
-      #     eval "$(conda shell.bash hook)"
-      #     conda activate test-environment
-      #     doit test_unit_nojit
-      #   env:
-      #     NUMBA_DISABLE_JIT: 1
+      - name: doit test_lint
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_lint
+      - name: doit test_unit_deploy
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_unit_deploy
+      - name: doit test_unit_nojit
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_unit_nojit
+        env:
+          NUMBA_DISABLE_JIT: 1
       - name: doit test_examples
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ['windows-latest']
+        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ["3.7"]
+        # python-version: ["3.7", "3.8", "3.9", "3.10"]
     timeout-minutes: 60
     defaults:
       run:
@@ -65,23 +67,23 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit env_capture
-      - name: doit test_lint
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_lint
-      - name: doit test_unit_deploy
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_unit_deploy
-      - name: doit test_unit_nojit
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_unit_nojit
-        env:
-          NUMBA_DISABLE_JIT: 1
+      # - name: doit test_lint
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     doit test_lint
+      # - name: doit test_unit_deploy
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     doit test_unit_deploy
+      # - name: doit test_unit_nojit
+      #   run: |
+      #     eval "$(conda shell.bash hook)"
+      #     conda activate test-environment
+      #     doit test_unit_nojit
+      #   env:
+      #     NUMBA_DISABLE_JIT: 1
       - name: doit test_examples
         run: |
           eval "$(conda shell.bash hook)"

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands = pytest datashader -k "not benchmarks and not test_tiles"
 description = Test that default examples run
 deps = .[examples, tests]
 commands = datashader fetch-data --path=examples --use-test-data
-           pytest --nbsmoke-run "datashader\examples\user_guide\8_Polygons.ipynb"
+           pytest --nbsmoke-run "examples\user_guide\8_Polygons.ipynb"
        ;     pytest --nbsmoke-run -k ".ipynb"
 # could add more, to test types of example other than nbs
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,7 @@ commands = pytest datashader -k "not benchmarks and not test_tiles"
 description = Test that default examples run
 deps = .[examples, tests]
 commands = datashader fetch-data --path=examples --use-test-data
-           pytest --nbsmoke-run "examples\user_guide\8_Polygons.ipynb"
-       ;     pytest --nbsmoke-run -k ".ipynb"
+           pytest --nbsmoke-run -k ".ipynb"
 # could add more, to test types of example other than nbs
 
 [_examples_extra]

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,8 @@ commands = pytest datashader -k "not benchmarks and not test_tiles"
 description = Test that default examples run
 deps = .[examples, tests]
 commands = datashader fetch-data --path=examples --use-test-data
-           pytest --nbsmoke-run -k ".ipynb"
+           pytest --nbsmoke-run "datashader\examples\user_guide\8_Polygons.ipynb"
+       ;     pytest --nbsmoke-run -k ".ipynb"
 # could add more, to test types of example other than nbs
 
 [_examples_extra]


### PR DESCRIPTION
The test workflow was failing on Windows / Python 3.7 with an error coming from `fiona` (`ImportError: the 'read_file' function requires the 'fiona' package, but it is not installed or does not import correctly.`). An [issue](https://github.com/conda-forge/fiona-feedstock/issues/196) has been opened on the repo of the conda-forge recipe of `fiona`. In the meantime, this PR pins gdal and fiona to older versions on Windows / Python 3.7, which fixes the issue.