### PR TITLE
Support antialiased line self_intersect in categorical aggs

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -428,16 +428,17 @@ The axis argument to Canvas.line must be 0 or 1
         if line_width > 0:
             # Eventually this should be replaced with attributes and/or
             # member functions of Reduction classes.
+            non_cat_agg = agg
+            if isinstance(non_cat_agg, rd.by):
+                non_cat_agg = non_cat_agg.reduction
+
             antialias_combination = AntialiasCombination.NONE
-            if isinstance(agg, (rd.any, rd.max)):
+            if isinstance(non_cat_agg, (rd.any, rd.max)):
                 antialias_combination = AntialiasCombination.MAX
-            elif isinstance(agg, rd.min):
+            elif isinstance(non_cat_agg, rd.min):
                 antialias_combination = AntialiasCombination.MIN
-            elif isinstance(agg, (rd.count, rd.sum)):
-                if agg.self_intersect:
-                    antialias_combination = AntialiasCombination.SUM_1AGG
-                else:
-                    antialias_combination = AntialiasCombination.SUM_2AGG
+            elif isinstance(non_cat_agg, (rd.count, rd.sum)) and non_cat_agg.self_intersect:
+                antialias_combination = AntialiasCombination.SUM_1AGG
             else:
                 antialias_combination = AntialiasCombination.SUM_2AGG
             glyph.set_antialias_combination(antialias_combination)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -1914,8 +1914,12 @@ def test_line_antialias_categorical():
     x_range = y_range = (-0.1875, 1.1875)
     cvs = ds.Canvas(plot_width=11, plot_height=11, x_range=x_range, y_range=y_range)
 
-    for self_intersect in [False, True]:
-        agg = cvs.line(source=df, x="x", y="y", line_width=1,
-                       agg=ds.by("cat", ds.count(self_intersect=self_intersect)))
-        assert_eq_ndarray(agg.data[:, :, 0], line_antialias_sol_0, close=True)
-        assert_eq_ndarray(agg.data[:, :, 1], line_antialias_sol_1, close=True)
+    agg = cvs.line(source=df, x="x", y="y", line_width=1,
+                   agg=ds.by("cat", ds.count(self_intersect=False)))
+    assert_eq_ndarray(agg.data[:, :, 0], line_antialias_sol_0, close=True)
+    assert_eq_ndarray(agg.data[:, :, 1], line_antialias_sol_1, close=True)
+
+    agg = cvs.line(source=df, x="x", y="y", line_width=1,
+                   agg=ds.by("cat", ds.count(self_intersect=True)))
+    assert_eq_ndarray(agg.data[:, :, 0], line_antialias_sol_0_intersect, close=True)
+    assert_eq_ndarray(agg.data[:, :, 1], line_antialias_sol_1, close=True)


### PR DESCRIPTION
PR #1081 (antialiased lines for categorical aggs) didn't include support for 1-stage agg (`self_intersect=True`) as introduced by PR #1072. This PR fixes it.

Demo of fix:
![aa_cat_self_intersect](https://user-images.githubusercontent.com/580326/166905956-8aa8f8d1-a687-48a8-8ec3-b69ab1716d63.png)
Note the self-intersections near the center of the second plot. Before this fix the second plot looked the same as the first.