### PR TITLE
Check before calling _rescale_discrete_levels

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1136,3 +1136,9 @@ def test_shade_with_discrete_color_key():
         assert (result_cupy.data == result).all()
     except ImportError:
         cupy = None
+
+
+def test_interpolate_alpha_discrete_levels_None():
+    data = np.array([[0.0, 1.0], [1.0, 0.0]])
+    # Issue #1084: this raises a ValueError.
+    tf._interpolate_alpha(data, data, None, "eq_hist", 0.5, None, 0.4, True)

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -446,7 +446,7 @@ def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha, rescale_d
             np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
             norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
 
-        if rescale_discrete_levels:  # Only valid for how='eq_hist'
+        if rescale_discrete_levels and discrete_levels is not None:  # Only valid for how='eq_hist'
             norm_span = _rescale_discrete_levels(discrete_levels, norm_span)
 
     else:


### PR DESCRIPTION
Fixes #1084.

In `_interpolate_alpha` I wasn't checking before calling `_rescale_discrete_levels` the same as is done in `_interpolate`, i.e.
https://github.com/holoviz/datashader/blob/59d1d2df88433d5dc9383e8f8147a800d2f37f3b/datashader/transfer_functions/__init__.py#L278-L279

Test added, and I have checked that there are no other places that `_rescale_discrete_levels` is called that could cause a similar problem.