### PR TITLE
CI: pin fiona on macos / Python 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,8 +54,8 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install -o tests -o examples --conda-mode=mamba
-      - name: patch for fiona on windows / 3.7 
-        if: matrix.os == 'windows-latest' && matrix.python-version == '3.7'
+      - name: patch for fiona on mac and windows / 3.7 
+        if: (matrix.os == 'windows-latest' || matrix.os == 'macos-latest') && matrix.python-version == '3.7'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,9 +49,6 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev "typing_extensions<4.2.0"
-      - name: temporarily patch setup.py on windows
-        if: matrix.os == 'windows-latest'
-        run: sed -i -e 's/numpy >=1.7,!=1.22/numpy <1.22/g' setup.py
       - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"


### PR DESCRIPTION
To fix the issue we've seen elsewhere with geopandas/fiona when trying to read a shapefile.