### PR TITLE
Implementation of first and last reduction

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,16 +49,13 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda create -n test-environment python=${{ matrix.python-version }} pyctdev "typing_extensions<4.2.0"
-      - name: temporarily patch setup.py on windows
-        if: matrix.os == 'windows-latest'
-        run: sed -i -e 's/numpy >=1.7,!=1.22/numpy <1.22/g' setup.py
       - name: doit develop_install
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit develop_install -o tests -o examples --conda-mode=mamba
-      - name: patch for fiona on windows / 3.7 
-        if: matrix.os == 'windows-latest' && matrix.python-version == '3.7'
+      - name: patch for fiona on mac and windows / 3.7 
+        if: (matrix.os == 'windows-latest' || matrix.os == 'macos-latest') && matrix.python-version == '3.7'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -876,7 +876,7 @@ class first(Reduction):
 
     @staticmethod
     @ngjit
-    def _append(x, y, agg,field):
+    def _append(x, y, agg, field):
         if not isnull(field) and isnull(agg[y, x]):
             agg[y, x] = field
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -875,20 +875,21 @@ class first(Reduction):
     _dshape = dshape(Option(ct.float64))
 
     @staticmethod
-    def _append(x, y, agg):
-        raise NotImplementedError("first is currently implemented only for rasters")
+    def _append(x, y, agg,field):
+        if not isnull(field) and isnull(agg[y, x]):
+            agg[y, x] = field
 
     @staticmethod
     def _create(shape, array_module):
-        raise NotImplementedError("first is currently implemented only for rasters")
+        return array_module.full(shape, np.nan)
 
     @staticmethod
     def _combine(aggs):
         raise NotImplementedError("first is currently implemented only for rasters")
 
     @staticmethod
-    def _finalize(bases, **kwargs):
-        raise NotImplementedError("first is currently implemented only for rasters")
+    def _finalize(bases,cuda=False, **kwargs):
+        return xr.DataArray(bases[0], **kwargs)
 
 
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -886,7 +886,7 @@ class first(Reduction):
 
     @staticmethod
     def _combine(aggs):
-        raise NotImplementedError("first is currently implemented only for rasters")
+        raise NotImplementedError("first is not implemented for dask DataFrames")
 
     @staticmethod
     def _finalize(bases, cuda=False, **kwargs):
@@ -922,7 +922,7 @@ class last(Reduction):
 
     @staticmethod
     def _combine(aggs):
-        raise NotImplementedError("last is currently implemented only for rasters")
+        raise NotImplementedError("last is not implemented for dask DataFrames")
 
     @staticmethod
     def _finalize(bases, cuda=False, **kwargs):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -925,7 +925,7 @@ class last(Reduction):
         raise NotImplementedError("last is currently implemented only for rasters")
 
     @staticmethod
-    def _finalize(bases, **kwargs):
+    def _finalize(bases,cuda=False, **kwargs):
         return xr.DataArray(bases[0], **kwargs)
 
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -889,7 +889,7 @@ class first(Reduction):
         raise NotImplementedError("first is currently implemented only for rasters")
 
     @staticmethod
-    def _finalize(bases,cuda=False, **kwargs):
+    def _finalize(bases, cuda=False, **kwargs):
         return xr.DataArray(bases[0], **kwargs)
 
 
@@ -925,7 +925,7 @@ class last(Reduction):
         raise NotImplementedError("last is currently implemented only for rasters")
 
     @staticmethod
-    def _finalize(bases,cuda=False, **kwargs):
+    def _finalize(bases, cuda=False, **kwargs):
         return xr.DataArray(bases[0], **kwargs)
 
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -875,6 +875,7 @@ class first(Reduction):
     _dshape = dshape(Option(ct.float64))
 
     @staticmethod
+    @ngjit
     def _append(x, y, agg,field):
         if not isnull(field) and isnull(agg[y, x]):
             agg[y, x] = field
@@ -910,6 +911,7 @@ class last(Reduction):
     _dshape = dshape(Option(ct.float64))
 
     @staticmethod
+    @ngjit
     def _append(x, y, agg,field):
         if not isnull(field):
             agg[y, x] = field

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -910,12 +910,13 @@ class last(Reduction):
     _dshape = dshape(Option(ct.float64))
 
     @staticmethod
-    def _append(x, y, agg):
-        raise NotImplementedError("last is currently implemented only for rasters")
+    def _append(x, y, agg,field):
+        if not isnull(field):
+            agg[y, x] = field
 
     @staticmethod
     def _create(shape, array_module):
-        raise NotImplementedError("last is currently implemented only for rasters")
+        return array_module.full(shape, np.nan)
 
     @staticmethod
     def _combine(aggs):
@@ -923,7 +924,7 @@ class last(Reduction):
 
     @staticmethod
     def _finalize(bases, **kwargs):
-        raise NotImplementedError("last is currently implemented only for rasters")
+        return xr.DataArray(bases[0], **kwargs)
 
 
 

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -562,9 +562,7 @@ def test_first():
         [np.nan, 100., 102., np.nan, np.nan],
         [100., 101., 101., np.nan, np.nan]], dtype='float64')
 
-    out = xr.DataArray(sol, coords=[lincoords, lincoords],
-                       dims=['y', 'x'])
-    assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg, sol)
 
 
 def test_last():

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -546,6 +546,47 @@ def test_categorical_std(df):
         assert_eq_xr(agg, out)
 
 
+def test_first():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(axis.compute_scale_and_translate((0, 5), 5), 5)
+
+    df = pd.DataFrame({'x': [4, 0, 2, 2, 5, 2],
+                       'y': [0, 4, 5, 1, 1, 3],
+                       'z': [100, 101, 102, 103, 104, 105]})
+    cvs = ds.Canvas(plot_height=5, plot_width=5)
+    agg = cvs.line(df, 'x', 'y', agg=ds.first('z'))
+    sol = np.array([
+        [np.nan, np.nan, np.nan, np.nan, 100.],
+        [np.nan, np.nan, 102., 100., 103.],
+        [np.nan, np.nan, 100., 104., np.nan],
+        [np.nan, 100., 102., np.nan, np.nan],
+        [100., 101., 101., np.nan, np.nan]], dtype='float64')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq_xr(agg, out)
+
+
+def test_last():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(axis.compute_scale_and_translate((0, 5), 5), 5)
+
+    df = pd.DataFrame({'x': [4, 0, 2, 2, 5, 2],
+                       'y': [0, 4, 5, 1, 1, 3],
+                       'z': [100, 101, 102, 103, 104, 105]})
+    cvs = ds.Canvas(plot_height=5, plot_width=5)
+    agg = cvs.line(df, 'x', 'y', agg=ds.last('z'))
+    sol = np.array([
+        [np.nan, np.nan, np.nan, np.nan, 100.],
+        [np.nan, np.nan, 102., 103., 103.],
+        [np.nan, np.nan, 102., 104., np.nan],
+        [np.nan, 100., 104., np.nan, np.nan],
+        [100., 101., 101., np.nan, np.nan]], dtype='float64')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq_xr(agg, out)
+
 @pytest.mark.parametrize('df', dfs)
 def test_multiple_aggregates(df):
     agg = c.points(df, 'x', 'y',

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -547,9 +547,6 @@ def test_categorical_std(df):
 
 
 def test_first():
-    axis = ds.core.LinearAxis()
-    lincoords = axis.compute_index(axis.compute_scale_and_translate((0, 5), 5), 5)
-
     df = pd.DataFrame({'x': [4, 0, 2, 2, 5, 2],
                        'y': [0, 4, 5, 1, 1, 3],
                        'z': [100, 101, 102, 103, 104, 105]})
@@ -566,9 +563,6 @@ def test_first():
 
 
 def test_last():
-    axis = ds.core.LinearAxis()
-    lincoords = axis.compute_index(axis.compute_scale_and_translate((0, 5), 5), 5)
-
     df = pd.DataFrame({'x': [4, 0, 2, 2, 5, 2],
                        'y': [0, 4, 5, 1, 1, 3],
                        'z': [100, 101, 102, 103, 104, 105]})
@@ -581,9 +575,7 @@ def test_last():
         [np.nan, 100., 104., np.nan, np.nan],
         [100., 101., 101., np.nan, np.nan]], dtype='float64')
 
-    out = xr.DataArray(sol, coords=[lincoords, lincoords],
-                       dims=['y', 'x'])
-    assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg, sol)
 
 @pytest.mark.parametrize('df', dfs)
 def test_multiple_aggregates(df):


### PR DESCRIPTION
For my current work, it is useful for me to make use of the first([column]) and last([column]) reductions, which at the moment are implemented only for rasters.

For both reductions, I've initialised a numpy array with numpy.nan values ( create() method). The append() method is implemented as follows:

- first([column]): check if field is not null and if agg[y,x] is null (has not yet been filled), then set agg[y,x] = field
- last([column]): check if field is not null, then set agg[y,x] = field

For both reductions, the finalize() method wraps the numpy array to a xarray DataArray (similar to the count() reduction).

Please let me know if you think this may be a good fit for the project.

