### PR TITLE
Correctly orient (y, x) arrays

### DIFF
--- a/datashader/tests/test_utils.py
+++ b/datashader/tests/test_utils.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 from datashape import dshape
+import numpy as np
+from xarray import DataArray
 
-from datashader.utils import Dispatcher, apply, isreal
+from datashader.utils import Dispatcher, apply, calc_res, isreal, orient_array
 
 
 def test_Dispatcher():
@@ -27,7 +29,66 @@ def test_isreal():
     assert not isreal('complex64')
     assert not isreal('{x: int64, y: float64}')
 
+
 def test_apply():
     f = lambda a, b, c=1, d=2: a + b + c + d
     assert apply(f, (1, 2,)) == 6
     assert apply(f, (1, 2,), dict(c=3)) == 8
+
+
+def test_calc_res():
+    x = [5, 7]
+    y = [0, 1]
+    z = [[0, 0], [0, 0]]
+    dims = ('y', 'x')
+
+    # x and y increasing
+    xarr = DataArray(z, coords=dict(x=x, y=y), dims=dims)
+    xres, yres = calc_res(xarr)
+    assert xres == 2
+    assert yres == -1
+
+    # x increasing, y decreasing
+    xarr = DataArray(z, coords=dict(x=x, y=y[::-1]), dims=dims)
+    xres, yres = calc_res(xarr)
+    assert xres == 2
+    assert yres == 1
+
+    # x decreasing, y increasing
+    xarr = DataArray(z, coords=dict(x=x[::-1], y=y), dims=dims)
+    xres, yres = calc_res(xarr)
+    assert xres == -2
+    assert yres == -1
+
+    # x and y decreasing
+    xarr = DataArray(z, coords=dict(x=x[::-1], y=y[::-1]), dims=dims)
+    xres, yres = calc_res(xarr)
+    assert xres == -2
+    assert yres == 1
+
+
+def test_orient_array():
+    x = [5, 7]
+    y = [0, 1]
+    z = np.array([[0, 1], [2, 3]])
+    dims = ('y', 'x')
+
+    # x and y increasing
+    xarr = DataArray(z, coords=dict(x=x, y=y), dims=dims)
+    arr = orient_array(xarr)
+    assert np.array_equal(arr, z)
+
+    # x increasing, y decreasing
+    xarr = DataArray(z, coords=dict(x=x, y=y[::-1]), dims=dims)
+    arr = orient_array(xarr)
+    assert np.array_equal(arr, z[::-1])
+
+    # x decreasing, y increasing
+    xarr = DataArray(z, coords=dict(x=x[::-1], y=y), dims=dims)
+    arr = orient_array(xarr)
+    assert np.array_equal(arr, z[:, ::-1])
+
+    # x and y decreasing
+    xarr = DataArray(z, coords=dict(x=x[::-1], y=y[::-1]), dims=dims)
+    arr = orient_array(xarr)
+    assert np.array_equal(arr, z[::-1, ::-1])

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -14,7 +14,7 @@ from PIL.Image import fromarray
 
 from datashader.colors import rgb, Sets1to3
 from datashader.composite import composite_op_lookup, over, validate_operator
-from datashader.utils import nansum_missing, ngjit, orient_array
+from datashader.utils import nansum_missing, ngjit
 
 try:
     import cupy
@@ -230,7 +230,7 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha, name, rescale_discrete_
         raise ValueError("agg must be 2D")
     interpolater = _normalize_interpolate_how(how)
 
-    data = orient_array(agg)
+    data = agg.data
     if isinstance(data, da.Array):
         data = data.compute()
     else:
@@ -356,7 +356,7 @@ def _colorize(agg, color_key, how, alpha, span, min_alpha, name, color_baseline,
 
     # Reorient array (transposing the category dimension first)
     agg_t = agg.transpose(*((agg.dims[-1],)+agg.dims[:2]))
-    data = orient_array(agg_t).transpose([1, 2, 0])
+    data = agg_t.data.transpose([1, 2, 0])
     if isinstance(data, da.Array):
         data = data.compute()
     color_data = data.copy()


### PR DESCRIPTION
Candidate fix for #1054. Surprisingly small amount of code changed in the end.

`Canvas.raster` and `tf.shade` both accept `xr.DataArray`s with `dims[-2:] == ('y', 'x')` and the direction of each of `x` and `y` `coords` may be increasing or decreasing. The orientation of the `DataArray` returned from these functions should be the same as the input, so if e.g. the input to `Canvas.raster` is flipped in the x-direction then so will the output be. This keeps the data and coordinates in sync. This was not previously the case, the data was flipped within datashader but the coordinates weren't.

Because the data and its coordinates are synchronised, you can plot the `DataArray`s in `holoviews` or `hvplot` and they are correctly rendered with increasing x and y.

Here are two examples of this working. Firstly the OP's test case of issue #1054 using a GeoTIFF obtained from https://github.com/mommermi/geotiff_sample. The land is on the southeast, the x-coords are increasing and the y-coords are decreasing:

![two](https://user-images.githubusercontent.com/580326/173887179-41d198da-f850-4f53-9872-8241891f07a6.png)

At the top the datashader `Image` has y-flipped as the input data does because it just draws the image data and ignores the coordinates. Below this it is plotted directly by `hvplot` and also using `datashader` which use the coordinates correctly.

Second example to be completely explicit.

![one](https://user-images.githubusercontent.com/580326/173887525-b252a3ec-ea8a-4015-8576-4783365cbde3.png)

There are 4 `DataArray`s, one for each of the 4 x/y flipping combinations. `hv.Image` and `shade(image)` draw them all correctly as the coordinates remain correctly oriented with respect to the data regardless of if they are passed through datashader or not. At the bottom are `datashader.Image`s that are returned from `ds.Canvas.raster` followed by `ds.tf.shade`. The images are shown in their flipped orientation as the coordinates are ignored for rendering.

One thing I have not done is consider `DataArray`s with `dims == ('x', 'y')`. These are allowed but always interpreted as `dims == ('y', 'x')` so strange things can result. We will need to do something about this as even some of the reproducers in issue #1054 use `dims == ('x', 'y')` which made them not very helpful in diagnosing the cause of the problem. I don't think we can forceably transpose them to get `('y', 'x')` but we could do some checking and either raise an exception or print a warning. But we need to be careful as we cannot just look for `x` and `y` but also need to consider `lat`, `lon`, `latitude` and so on.

I have kept the `calc_res` function as it is. This returns the x and y resolutions (i.e. spacings) of the specified `DataArray`, but it chooses to reverse the yresolution. This annoys me a lot as it is unnecessary, but I have left it in case of external libraries that are  using this function as it is considered public.
