### PR TITLE
Fix antialiased line divide by zero bug

### DIFF
--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -822,10 +822,13 @@ def _full_antialias(line_width, antialias_combination, i, x0, x1, y0, y1,
         prev_alongx = x0 - xm
         prev_alongy = y0 - ym
         prev_length = math.sqrt(prev_alongx**2 + prev_alongy**2)
-        prev_alongx /= prev_length
-        prev_alongy /= prev_length
-        prev_rightx = prev_alongy
-        prev_righty = -prev_alongx
+        if prev_length > 0.0:
+            prev_alongx /= prev_length
+            prev_alongy /= prev_length
+            prev_rightx = prev_alongy
+            prev_righty = -prev_alongx
+        else:
+            overwrite = True
 
     # y limits of scan.
     ystart = clip_y(math.ceil(cy[lowindex]))

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2069,3 +2069,20 @@ def test_line_antialias_categorical():
                    agg=ds.by("cat", ds.count(self_intersect=True)))
     assert_eq_ndarray(agg.data[:, :, 0], line_antialias_sol_0_intersect, close=True)
     assert_eq_ndarray(agg.data[:, :, 1], line_antialias_sol_1, close=True)
+
+
+@pytest.mark.parametrize('self_intersect', [False, True])
+def test_line_antialias_duplicate_points(self_intersect):
+    # Issue #1098. Duplicate points should not raise a divide by zero error and
+    # should produce same results as without duplicate points.
+    cvs = ds.Canvas(plot_width=10, plot_height=10, x_range=(-0.1, 1.1), y_range=(0.9, 2.1))
+
+    df = pd.DataFrame(dict(x=[0, 1], y=[1, 2]))
+    agg_no_duplicate = cvs.line(source=df, x="x", y="y", line_width=1,
+                                agg=ds.count(self_intersect=self_intersect))
+
+    df = pd.DataFrame(dict(x=[0, 0, 1], y=[1, 1, 2]))
+    agg_duplicate = cvs.line(source=df, x="x", y="y", line_width=1,
+                             agg=ds.count(self_intersect=self_intersect))
+
+    assert_eq_xr(agg_no_duplicate, agg_duplicate)


### PR DESCRIPTION
Fixes issue #1098.

Solution is to disable the special treatment of `self_intersect=True` in line segments for which the start segment point is the same as the previous duplicate point. The `self_intersect` would do nothing in this situation anyway so avoiding it does not affect the output produced and prevents the divide by zero.