### PR TITLE
Correct dask and bokeh dependencies

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata.get('install_requires',{}) %}
-    - {{ dep }}
+    - {{ dep if dep != 'dask' else 'dask-core'}}
     {% endfor %}
     # adding pyct here is temporary (this conda recipe template will disappear when new pyctdev is released)
     - pyct

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
 [metadata]
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 
 [wheel]
 universal = 1
+
+[tool:pyctdev.conda]
+namespace_map =
+    dask=dask-core

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,9 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
-    # `conda install dask[complete]` happily gives you dask...which is
-    # happily like pip's dask[complete]. (conda's dask-core is more
-    # like pip's dask.)
-    'dask[complete] >=0.18.0',
+    'dask',
     'datashape >=0.5.1',
     'numba >=0.51',
-    'numpy >=1.7',
     'pandas >=0.24.1',
     'pillow >=3.1.1',
     'xarray >=0.9.6',
@@ -31,6 +27,7 @@ examples = [
     'bokeh',
     'matplotlib',
     'geopandas',
+    'spatialpandas',
 ]
 
 extras_require = {


### PR DESCRIPTION
Fixes #1053.

`install_requires` in `setup.py` now contains `dask`, which is what `pip` requires. `conda` requires `dask-core` only which is what the `pyctdev` mapping in `setup.cfg` produces. These changes ensure that `bokeh` is not an install dependency for `datashader`.

The `conda-forge` `datashader-feedstock` will need fixing in line with this, but I will do that when 0.14.2 is released and the `conda-forge` bot identifies the new release and raises a PR for the updates.

I have also changed `license_file` to `license_files` as the former is deprecated, and added `spatialpandas` to the `examples` dependencies as example 8 (polygons) uses `spatialpandas`. There is no requirement to add the full `dask` to the `examples` dependencies as this is automatically pulled in by the `spatialpandas` requirements.

`spatialpandas` needs to have similar changes to this PR, and we will have to check how the `dask` dependencies chain through the libraries following that. But there will be a `datashader` release before the next `spatialpandas` release and this PR is sufficient until the latter occurs.

I have check local installs using `pip` and `conda` (via `pyctdev`) and also built both `pip` and `conda` packages locally to check that the changes here are correct.