### PR TITLE
Add requests as an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     'colorcet >=0.9.0',
     'param >=1.6.1',
     'pyct >=0.4.5',
+    'requests',
     'scipy',
 ]
 


### PR DESCRIPTION
Fixes #1047 by adding `requests` as a compulsory install dependency of `datashader`.

We should merge #1104 before this, then rebase this PR and recheck that it is required, i.e. that `requests` is not pulled in by another dependency change.