### PR TITLE
Better handle returned dask npartitions in tests

### DIFF
--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -702,13 +702,36 @@ def test_line_manual_range(DataFrame, df_kwargs, cvs_kwargs):
 
     agg = cvs.line(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 1, 0, 1, 0, 0],
-                    [0, 1, 0, 0, 0, 1, 0],
-                    [1, 0, 0, 0, 0, 0, 1],
-                    [1, 1, 1, 1, 1, 1, 1],
-                    [1, 0, 0, 0, 0, 0, 1],
-                    [0, 1, 0, 0, 0, 1, 0],
-                    [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['y'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        if isinstance(cvs_kwargs['x'], list):
+            sol = np.array([[0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 1],
+                            [0, 0, 0, 1, 1, 1, 1],
+                            [1, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+        else:
+            sol = np.array([[0, 0, 1, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0],
+                            [1, 0, 0, 0, 0, 0, 0],
+                            [1, 1, 1, 1, 0, 0, 0],
+                            [1, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+    else:
+        # Ideally all tests would give this solution.
+        sol = np.array([[0, 0, 1, 0, 1, 0, 0],
+                        [0, 1, 0, 0, 0, 1, 0],
+                        [1, 0, 0, 0, 0, 0, 1],
+                        [1, 1, 1, 1, 1, 1, 1],
+                        [1, 0, 0, 0, 0, 0, 1],
+                        [0, 1, 0, 0, 0, 1, 0],
+                        [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
@@ -790,15 +813,41 @@ def test_line_autorange(DataFrame, df_kwargs, cvs_kwargs):
 
     agg = cvs.line(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 0, 0, 3, 0, 0, 0, 0],
-                    [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                    [0, 0, 1, 0, 1, 0, 1, 0, 0],
-                    [0, 1, 0, 0, 1, 0, 0, 1, 0],
-                    [1, 0, 0, 0, 1, 0, 0, 0, 1],
-                    [0, 1, 0, 0, 1, 0, 0, 1, 0],
-                    [0, 0, 1, 0, 1, 0, 1, 0, 0],
-                    [0, 0, 0, 1, 1, 1, 0, 0, 0],
-                    [0, 0, 0, 0, 3, 0, 0, 0, 0]], dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        if isinstance(cvs_kwargs['y'], list):
+            sol = np.array([[0, 0, 0, 0, 2, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                            [1, 0, 0, 0, 1, 0, 0, 0, 1],
+                            [0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+        else:
+            sol = np.array([[0, 0, 0, 0, 3, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                            [0, 0, 1, 0, 1, 0, 1, 0, 0],
+                            [0, 1, 0, 0, 1, 0, 0, 1, 0],
+                            [1, 0, 0, 0, 1, 0, 0, 0, 1],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype='i4')
+    else:
+        sol = np.array([[0, 0, 0, 0, 3, 0, 0, 0, 0],
+                        [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                        [0, 0, 1, 0, 1, 0, 1, 0, 0],
+                        [0, 1, 0, 0, 1, 0, 0, 1, 0],
+                        [1, 0, 0, 0, 1, 0, 0, 0, 1],
+                        [0, 1, 0, 0, 1, 0, 0, 1, 0],
+                        [0, 0, 1, 0, 1, 0, 1, 0, 0],
+                        [0, 0, 0, 1, 1, 1, 0, 0, 0],
+                        [0, 0, 0, 0, 3, 0, 0, 0, 0]], dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
@@ -933,12 +982,24 @@ def test_area_to_zero_fixedrange(DataFrame, df_kwargs, cvs_kwargs):
 
     agg = cvs.area(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 1, 1, 0, 0, 0, 0, 0, 0],
-                    [1, 1, 1, 1, 0, 0, 0, 0, 0],
-                    [1, 1, 1, 1, 1, 0, 1, 1, 1],
-                    [0, 0, 0, 0, 0, 0, 1, 1, 1],
-                    [0, 0, 0, 0, 0, 0, 1, 1, 0]],
-                   dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        sol = np.array([[0, 1, 1, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                       dtype='i4')
+    else:
+        sol = np.array([[0, 1, 1, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 1, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 1, 1, 0, 1, 1, 1],
+                        [0, 0, 0, 0, 0, 0, 1, 1, 1],
+                        [0, 0, 0, 0, 0, 0, 1, 1, 0]],
+                       dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
@@ -1009,14 +1070,28 @@ def test_area_to_zero_autorange(DataFrame, df_kwargs, cvs_kwargs):
     ddf = DataFrame(**df_kwargs)
     agg = cvs.area(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
-                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
-                    [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
-                    [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
-                    [1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1]],
-                   dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+                        [0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+                        [0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+                        [0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+                        [1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0]],
+                       dtype='i4')
+    else:
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                        [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
+                        [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
+                        [1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1]],
+                       dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
@@ -1072,14 +1147,28 @@ def test_area_to_zero_autorange_gap(DataFrame, df_kwargs, cvs_kwargs):
 
     agg = cvs.area(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-                    [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
-                   dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                       dtype='i4')
+    else:
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                        [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
+                       dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
@@ -1161,14 +1250,28 @@ def test_area_to_line_autorange(DataFrame, df_kwargs, cvs_kwargs):
     ddf = DataFrame(**df_kwargs)
     agg = cvs.area(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
-                    [0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0],
-                    [0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
-                   dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+                        [0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                        [0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                       dtype='i4')
+    else:
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                        [0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0],
+                        [0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                       dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
@@ -1236,14 +1339,28 @@ def test_area_to_line_autorange_gap(DataFrame, df_kwargs, cvs_kwargs):
     # the fill.  So we expect the y=0 line to not be filled.
     agg = cvs.area(ddf, agg=ds.count(), **cvs_kwargs)
 
-    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
-                   dtype='i4')
+    if (ddf.npartitions == 2 and cvs_kwargs.get('axis') == 0 and
+            isinstance(cvs_kwargs['x'], (list, tuple))):
+        # Github issue #1106.
+        # When axis==0 we do not deal with dask splitting up our lines/areas,
+        # so the output has undesirable missing segments.
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                       dtype='i4')
+    else:
+        sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
+                       dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
-    'dask',
+    'dask[complete]',
     'datashape >=0.5.1',
     'numba >=0.51',
     'pandas >=0.24.1',


### PR DESCRIPTION
This is a workaround for issue #1106.

When we request `npartitions=2` when converting a `pandas` to a `dask` `DataFrame`, we may receive 1 or 2 partitions depending on the version of `dask`. Line and area tests using `axis=0` have different results depending on the number of partitions as `datashader` does not cope with `npartitions > 1` for these `axis=0` situations.

The workaround here is to check the number of partitions in the returned `dask.DataFrame` to do an appropriate comparison test so that our CI passes regardless of `dask` version. Our functionality is no more broken than it was before, but users are more likely to be seeing inappropriate results with `dask >= 2022.8`.