### PR TITLE
Remove future imports

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from packaging.version import Version
 
 import param

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -11,8 +11,6 @@ algorithm.
    https://gitlab.com/ianjcalvert/edgehammer
 """
 
-from __future__ import absolute_import, division, print_function
-
 from math import ceil
 
 from dask import compute, delayed

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
-
 # Lookup of web color names to their hex codes.
 color_lookup = {'aliceblue': '#F0F8FF', 'antiquewhite': '#FAEBD7',
                 'aqua': '#00FFFF', 'aquamarine': '#7FFFD4',

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from itertools import count
 
 from toolz import unique, concat, pluck, get, memoize

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -4,8 +4,6 @@ Binary graphical composition operators
 See https://www.cairographics.org/operators/; more could easily be added from there.
 """
 
-from __future__ import division
-
 import numba as nb
 import numpy as np
 import os

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -27,6 +27,11 @@ try:
 except Exception:
     dask_cudf = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 class Axis(object):
     """Interface for implementing axis transformations.
 
@@ -194,14 +199,14 @@ class Canvas(object):
         if geometry is None:
             glyph = Point(x, y)
         else:
-            from spatialpandas import GeoDataFrame
-            from spatialpandas.dask import DaskGeoDataFrame
-            if isinstance(source, DaskGeoDataFrame):
+            if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
                 # Downselect partitions to those that may contain points in viewport
                 x_range = self.x_range if self.x_range is not None else (None, None)
                 y_range = self.y_range if self.y_range is not None else (None, None)
                 source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-            elif not isinstance(source, GeoDataFrame):
+            elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+                pass
+            else:
                 raise ValueError(
                     "source must be an instance of spatialpandas.GeoDataFrame or \n"
                     "spatialpandas.dask.DaskGeoDataFrame.\n"
@@ -354,14 +359,14 @@ class Canvas(object):
             line_width = 1.0
 
         if geometry is not None:
-            from spatialpandas import GeoDataFrame
-            from spatialpandas.dask import DaskGeoDataFrame
-            if isinstance(source, DaskGeoDataFrame):
+            if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
                 # Downselect partitions to those that may contain lines in viewport
                 x_range = self.x_range if self.x_range is not None else (None, None)
                 y_range = self.y_range if self.y_range is not None else (None, None)
                 source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-            elif not isinstance(source, GeoDataFrame):
+            elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+                pass
+            else:
                 raise ValueError(
                     "source must be an instance of spatialpandas.GeoDataFrame or \n"
                     "spatialpandas.dask.DaskGeoDataFrame.\n"
@@ -733,14 +738,14 @@ The axis argument to Canvas.area must be 0 or 1
         """
         from .glyphs import PolygonGeom
         from .reductions import any as any_rdn
-        from spatialpandas import GeoDataFrame
-        from spatialpandas.dask import DaskGeoDataFrame
-        if isinstance(source, DaskGeoDataFrame):
+        if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
             # Downselect partitions to those that may contain polygons in viewport
             x_range = self.x_range if self.x_range is not None else (None, None)
             y_range = self.y_range if self.y_range is not None else (None, None)
             source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-        elif not isinstance(source, GeoDataFrame):
+        elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+            pass
+        else:
             raise ValueError(
                 "source must be an instance of spatialpandas.GeoDataFrame or \n"
                 "spatialpandas.dask.DaskGeoDataFrame.\n"

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from numbers import Number
 from math import log10
 

--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel
 import cudf

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 from collections import OrderedDict
 import numpy as np
 import pandas as pd

--- a/datashader/data_libraries/dask_cudf.py
+++ b/datashader/data_libraries/dask_cudf.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashader.data_libraries.dask import dask_pipeline
 from datashader.core import bypixel
 import dask_cudf

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import pandas as pd
 
 from datashader.core import bypixel

--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashader.glyphs.quadmesh import _QuadMeshLike
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel

--- a/datashader/datatypes.py
+++ b/datashader/datatypes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 from functools import total_ordering

--- a/datashader/glyphs/__init__.py
+++ b/datashader/glyphs/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .points import Point, MultiPointGeometry   # noqa (API import)
 from .line import (  # noqa (API import)
     AntialiasCombination,

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 import numpy as np
 from toolz import memoize
 

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 from packaging.version import Version
 import inspect
 import warnings

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 from enum import Enum
 import math
 import numpy as np

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -19,6 +19,11 @@ except ImportError:
     cudf = None
     cuda_args = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 # This Enum should eventually be replaced with attributes
 # and/or member functions of Reduction classes.
@@ -513,6 +518,7 @@ class LinesAxis1Ragged(_PointLike, _AntiAliasedLine):
 
 
 class LineAxis1Geometry(_GeometryLike, _AntiAliasedLine):
+    # spatialpandas must be available if a LineAxis1Geometry object is created.
 
     @property
     def geom_dtypes(self):

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -15,6 +15,11 @@ except Exception:
     cudf = None
     cuda_args = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 def values(s):
     if isinstance(s, cudf.Series):
@@ -22,7 +27,7 @@ def values(s):
             return s.to_cupy(na_value=np.nan)
         else:
             return s.to_gpu_array(fillna=np.nan)
-        
+
     else:
         return s.values
 
@@ -41,8 +46,11 @@ class _GeometryLike(Glyph):
 
     @property
     def geom_dtypes(self):
-        from spatialpandas.geometry import GeometryDtype
-        return (GeometryDtype,)
+        if spatialpandas:
+            from spatialpandas.geometry import GeometryDtype
+            return (GeometryDtype,)
+        else:
+            return ()  # Empty tuple
 
     def validate(self, in_dshape):
         if not isinstance(in_dshape[str(self.geometry)], self.geom_dtypes):
@@ -212,6 +220,7 @@ class Point(_PointLike):
 
 
 class MultiPointGeometry(_GeometryLike):
+    # spatialpandas must be available if a MultiPointGeometry object is created.
 
     @property
     def geom_dtypes(self):

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 from packaging.version import Version
 import numpy as np
 from toolz import memoize

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -5,8 +5,15 @@ from datashader.glyphs.line import _build_map_onto_pixel_for_line
 from datashader.glyphs.points import _GeometryLike
 from datashader.utils import ngjit
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 class PolygonGeom(_GeometryLike):
+    # spatialpandas must be available if a PolygonGeom object is created.
+
     @property
     def geom_dtypes(self):
         from spatialpandas.geometry import PolygonDtype, MultiPolygonDtype

--- a/datashader/glyphs/trimesh.py
+++ b/datashader/glyphs/trimesh.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 from math import floor
 import numpy as np
 from toolz import memoize

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -1,8 +1,6 @@
 """Assign coordinates to the nodes of a graph.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import numpy as np
 import param
 import scipy.sparse

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from toolz import identity
 
 from . import transfer_functions as tf

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from packaging.version import Version
 import numpy as np
 from datashape import dshape, isnumeric, Record, Option

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -24,8 +24,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from __future__ import absolute_import, division, print_function
-
 from itertools import groupby
 from math import floor, ceil
 

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import pytest
 
 import numpy as np

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 skimage = pytest.importorskip("skimage")
 

--- a/datashader/tests/test_colors.py
+++ b/datashader/tests/test_colors.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashader.colors import rgb, hex_to_rgb
 
 import pytest

--- a/datashader/tests/test_composite.py
+++ b/datashader/tests/test_composite.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 
 from datashader.composite import add, saturate, over, source

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import
-
 import os
 
 import dask.dataframe as dd

--- a/datashader/tests/test_datatypes.py
+++ b/datashader/tests/test_datatypes.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 import numpy as np
 import pandas as pd
@@ -709,8 +708,8 @@ class TestRaggedGetitem(eb.BaseGetitemTests):
     def test_getitem_ellipsis_and_slice(self, data):
         pass
 
-    # Ellipsis, numpy.newaxis, None, not supported in RaggedArray.__getitem__ 
-    # so the error message raised RaggedArray.__getitem__ isn't the same as 
+    # Ellipsis, numpy.newaxis, None, not supported in RaggedArray.__getitem__
+    # so the error message raised RaggedArray.__getitem__ isn't the same as
     # the one raised by the base extension.
     @pytest.mark.skip(reason="RaggedArray.__getitem__ raises a different error message")
     def test_getitem_invalid(self, data):

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashape import dshape
 import pandas as pd
 import numpy as np

--- a/datashader/tests/test_layout.py
+++ b/datashader/tests/test_layout.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 skimage = pytest.importorskip("skimage")
 

--- a/datashader/tests/test_macros.py
+++ b/datashader/tests/test_macros.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import warnings
 import pytest
 

--- a/datashader/tests/test_mpl_ext.py
+++ b/datashader/tests/test_mpl_ext.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 
 pytest.importorskip("matplotlib")

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from collections import OrderedDict
 import os
 from numpy import nan

--- a/datashader/tests/test_pipeline.py
+++ b/datashader/tests/test_pipeline.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 import pandas as pd
 import datashader as ds

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 from numpy import nan
 import xarray as xr

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytest
 
 try:

--- a/datashader/tests/test_tiles.py
+++ b/datashader/tests/test_tiles.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datashader as ds
 import datashader.transfer_functions as tf
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import
-
 from io import BytesIO
 
 import numpy as np

--- a/datashader/tests/test_utils.py
+++ b/datashader/tests/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from datashape import dshape
 import numpy as np
 from xarray import DataArray

--- a/datashader/tests/test_xarray.py
+++ b/datashader/tests/test_xarray.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 import xarray as xr
 

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -336,7 +336,7 @@ def tile_previewer(full_extent, tileset_url,
         from bokeh.io import output_file, save
         from os import path
     except ImportError:
-        raise ImportError('conda install bokeh to enable creation of simple tile viewer')
+        raise ImportError('install bokeh to enable creation of simple tile viewer')
 
     if output_dir:
         output_file(filename=path.join(output_dir, filename),
@@ -388,7 +388,7 @@ class S3TileRenderer(TileRenderer):
         try:
             import boto3
         except ImportError:
-            raise ImportError('conda install boto3 to enable rendering to S3')
+            raise ImportError('install boto3 to enable rendering to S3')
 
         try:
             from urlparse import urlparse

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
 import math

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections.abc import Iterator
 
 from collections import OrderedDict

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from math import ceil, isnan
 from packaging.version import Version
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import re
 

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -8,8 +8,6 @@ Test files may be generated starting from any file format supported by Pandas:
   python -c "import filetimes ; filetimes.base='<hdf5base>' ; filetimes.categories=['<cat1>','<cat2>']; filetimes.timed_write('<file>')"
 """
 
-from __future__ import print_function
-
 import time
 global_start = time.time()
 

--- a/examples/pcap_to_parquet.py
+++ b/examples/pcap_to_parquet.py
@@ -4,8 +4,6 @@
 Convert PCAP output to undirected graph and save in Parquet format.
 """
 
-from __future__ import print_function
-
 import re
 import socket
 import struct

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -1,41 +1,39 @@
-from __future__ import division
-
 if __name__ == "__main__":
     from bokeh.io import curdoc
     from bokeh.plotting import Figure
     from bokeh.models import ColumnDataSource, CustomJS
     from bokeh.tile_providers import get_provider
-    
+
     import rasterio as rio
     import datashader as ds
     import datashader.transfer_functions as tf
     from datashader.colors import Hot
-    
+
     def on_dims_change(attr, old, new):
         update_image()
-    
+
     def update_image():
-    
+
         global dims, raster_data
-    
+
         dims_data = dims.data
-    
+
         if not dims_data['width'] or not dims_data['height']:
             return
-    
+
         xmin = max(dims_data['xmin'][0], raster_data.bounds.left)
         ymin = max(dims_data['ymin'][0], raster_data.bounds.bottom)
         xmax = min(dims_data['xmax'][0], raster_data.bounds.right)
         ymax = min(dims_data['ymax'][0], raster_data.bounds.top)
-    
+
         canvas = ds.Canvas(plot_width=dims_data['width'][0],
                            plot_height=dims_data['height'][0],
                            x_range=(xmin, xmax),
                            y_range=(ymin, ymax))
-    
+
         agg = canvas.raster(raster_data)
         img = tf.shade(agg, cmap=Hot, how='linear')
-    
+
         new_data = {}
         new_data['image'] = [img.data]
         new_data['x'] = [xmin]
@@ -43,11 +41,11 @@ if __name__ == "__main__":
         new_data['dh'] = [ymax - ymin]
         new_data['dw'] = [xmax - xmin]
         image_source.stream(new_data, 1)
-    
+
     # load nyc taxi data
     path = './data/projected.tif'
     raster_data = rio.open(path)
-    
+
     # manage client-side dimensions
     dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[], ymax=[]))
     dims.on_change('data', on_dims_change)
@@ -63,22 +61,22 @@ if __name__ == "__main__":
         };
         dims.data = new_data;
     };
-    
+
     if (typeof throttle != 'undefined' && throttle != null) {
         clearTimeout(throttle);
     }
-    
+
     throttle = setTimeout(update_dims, 100, "replace");
     """
-    
+
     # Create plot -------------------------------
     xmin = -8240227.037
     ymin = 4974203.152
     xmax = -8231283.905
     ymax = 4979238.441
-    
+
     path = './data/projected.tif'
-    
+
     fig = Figure(x_range=(xmin, xmax),
                  y_range=(ymin, ymax),
                  plot_height=600,
@@ -94,7 +92,7 @@ if __name__ == "__main__":
     fig.min_border_right = 0
     fig.min_border_top = 0
     fig.min_border_bottom = 0
-    
+
     image_source = ColumnDataSource(dict(image=[], x=[], y=[], dw=[], dh=[]))
     fig.image_rgba(source=image_source,
                    image='image',
@@ -103,5 +101,5 @@ if __name__ == "__main__":
                    dw='dw',
                    dh='dh',
                    dilate=False)
-    
+
     curdoc().add_root(fig)

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import math
 
 from collections import OrderedDict

--- a/examples/taxi_preprocessing_example.py
+++ b/examples/taxi_preprocessing_example.py
@@ -1,22 +1,20 @@
 """Download data needed for the examples"""
 
-from __future__ import print_function
-
 if __name__ == "__main__":
 
     from os import path, makedirs, remove
     from download_sample_data import bar as progressbar
-    
+
     import pandas as pd
     import numpy as np
     import sys
-    
+
     try:
         import requests
     except ImportError:
         print('Download script required requests package: conda install requests')
         sys.exit(1)
-    
+
     def _download_dataset(url):
         r = requests.get(url, stream=True)
         output_path = path.split(url)[1]
@@ -26,12 +24,12 @@ if __name__ == "__main__":
                 if chunk:
                     f.write(chunk)
                     f.flush()
-    
+
     examples_dir = path.dirname(path.realpath(__file__))
     data_dir = path.join(examples_dir, 'data')
     if not path.exists(data_dir):
         makedirs(data_dir)
-    
+
     # Taxi data
     def latlng_to_meters(df, lat_name, lng_name):
         lat = df[lat_name]
@@ -42,16 +40,16 @@ if __name__ == "__main__":
         my = my * origin_shift / 180.0
         df.loc[:, lng_name] = mx
         df.loc[:, lat_name] = my
-    
+
     taxi_path = path.join(data_dir, 'nyc_taxi.csv')
     if not path.exists(taxi_path):
         print("Downloading Taxi Data...")
         url = ('https://storage.googleapis.com/tlc-trip-data/2015/'
                'yellow_tripdata_2015-01.csv')
-    
+
         _download_dataset(url)
         df = pd.read_csv('yellow_tripdata_2015-01.csv')
-    
+
         print('Filtering Taxi Data')
         df = df.loc[(df.pickup_longitude < -73.75) &
                     (df.pickup_longitude > -74.15) &
@@ -61,7 +59,7 @@ if __name__ == "__main__":
                     (df.pickup_latitude < 40.84) &
                     (df.dropoff_latitude > 40.68) &
                     (df.dropoff_latitude < 40.84)].copy()
-    
+
         print('Reprojecting Taxi Data')
         latlng_to_meters(df, 'pickup_latitude', 'pickup_longitude')
         latlng_to_meters(df, 'dropoff_latitude', 'dropoff_longitude')
@@ -70,7 +68,7 @@ if __name__ == "__main__":
                   inplace=True)
         df.to_csv(taxi_path, index=False)
         remove('yellow_tripdata_2015-01.csv')
-        
-    
+
+
     print("\nAll data downloaded.")
-    
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "param >=1.7.0",
-    "pyct >=0.4.4",
-    "setuptools >=30.3.0"
+    "param",
+    "pyct",
+    "setuptools"
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
-    'colorcet',
     'dask',
     'datashape',
     'numba >=0.51',
@@ -23,7 +22,7 @@ install_requires = [
 ]
 
 examples = [
-    'bokeh',
+    'colorcet',
     'geopandas',
     'holoviews',
     'matplotlib',
@@ -55,13 +54,11 @@ extras_require = {
         'streamz',
         ### conda only below here
         'fastparquet',
-        'geopandas',
         'graphviz',
         'python-graphviz',
         'python-snappy',
         'rasterio',
         'snappy',
-        'spatialpandas',
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,20 @@ import pyct.build
 
 install_requires = [
     'dask',
-    'datashape >=0.5.1',
+    'datashape',
     'numba >=0.51',
-    'pandas >=0.24.1',
-    'pillow >=3.1.1',
-    'xarray >=0.9.6',
-    'colorcet >=0.9.0',
-    'param >=1.6.1',
-    'pyct >=0.4.5',
+    'pandas',
+    'pillow',
+    'xarray',
+    'colorcet',
+    'param',
+    'pyct',
     'requests',
     'scipy',
 ]
 
 examples = [
-    'holoviews >=1.10.0',
+    'holoviews',
     'scikit-image',
     'bokeh',
     'matplotlib',
@@ -33,15 +33,15 @@ examples = [
 
 extras_require = {
     'tests': [
-        'pytest >=3.9.3',
-        'pytest-benchmark >=3.0.0',
+        'pytest',
+        'pytest-benchmark',
         'pytest-cov',
         'codecov',
         'flake8',
         'nbconvert',
         'nbsmoke[verify] >0.5',
-        'fastparquet >=0.1.6',  # optional dependency
-        'holoviews >=1.10.0',
+        'fastparquet',  # optional dependency
+        'holoviews',
         'bokeh',
         'pyarrow',
         'netcdf4',
@@ -51,8 +51,8 @@ extras_require = {
     ],
     'examples': examples,
     'examples_extra': examples + [
-        'networkx >=2.0',
-        'streamz >=0.2.0',
+        'networkx',
+        'streamz',
         ### conda only below here
         'graphviz',
         'python-graphviz',

--- a/setup.py
+++ b/setup.py
@@ -9,67 +9,67 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
+    'colorcet',
     'dask',
     'datashape',
     'numba >=0.51',
     'pandas',
-    'pillow',
-    'xarray',
-    'colorcet',
     'param',
+    'pillow',
     'pyct',
     'requests',
     'scipy',
+    'xarray',
 ]
 
 examples = [
-    'holoviews',
-    'scikit-image',
     'bokeh',
-    'matplotlib',
     'geopandas',
+    'holoviews',
+    'matplotlib',
+    'scikit-image',
     'spatialpandas',
 ]
 
 extras_require = {
     'tests': [
+        'bokeh',
+        'codecov',
+        'fastparquet',  # optional dependency
+        'flake8',
+        'holoviews',
+        'nbconvert',
+        'nbsmoke[verify] >0.5',
+        'netcdf4',
+        'pyarrow',
         'pytest',
         'pytest-benchmark',
         'pytest-cov',
-        'codecov',
-        'flake8',
-        'nbconvert',
-        'nbsmoke[verify] >0.5',
-        'fastparquet',  # optional dependency
-        'holoviews',
-        'bokeh',
-        'pyarrow',
-        'netcdf4',
-        'spatialpandas',
-        'rioxarray',
         'rasterio',
+        'rioxarray',
+        'spatialpandas',
     ],
     'examples': examples,
     'examples_extra': examples + [
         'networkx',
         'streamz',
         ### conda only below here
+        'fastparquet',
+        'geopandas',
         'graphviz',
         'python-graphviz',
-        'fastparquet',
         'python-snappy',
         'rasterio',
         'snappy',
         'spatialpandas',
-        'geopandas',
     ]
 }
 
 extras_require['doc'] = extras_require['examples_extra'] + [
     'nbsite >=0.7.1',
+    'numpydoc',
     'pydata-sphinx-theme <0.9.0',
     'sphinx-copybutton',
-    'numpydoc',
 ]
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
This PR removes unneeded `__future__` imports of `absolute_import`, `division` and `print_function`. Support for Python 2.* required them and they are no longer necessary. Table of minimum versions at https://docs.python.org/3/library/__future__.html shows they have all been available since Python 3.0.

This is part of issue #1112.