### PR TITLE
Remove unneeded future imports

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 
 from packaging.version import Version
 

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -11,7 +11,7 @@ algorithm.
    https://gitlab.com/ianjcalvert/edgehammer
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from math import ceil
 

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 
 # Lookup of web color names to their hex codes.

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from itertools import count
 

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -4,7 +4,7 @@ Binary graphical composition operators
 See https://www.cairographics.org/operators/; more could easily be added from there.
 """
 
-from __future__ import division
+from __future__ import annotations
 
 import numba as nb
 import numpy as np

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from numbers import Number
 from math import log10

--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel
 import cudf

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 
 from collections import OrderedDict
 import numpy as np

--- a/datashader/data_libraries/dask_cudf.py
+++ b/datashader/data_libraries/dask_cudf.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashader.data_libraries.dask import dask_pipeline
 from datashader.core import bypixel
 import dask_cudf

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 
 import pandas as pd
 

--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashader.glyphs.quadmesh import _QuadMeshLike
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel

--- a/datashader/datatypes.py
+++ b/datashader/datatypes.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 
 import re
 

--- a/datashader/glyphs/__init__.py
+++ b/datashader/glyphs/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from .points import Point, MultiPointGeometry   # noqa (API import)
 from .line import (  # noqa (API import)
     AntialiasCombination,

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 import numpy as np
 from toolz import memoize
 

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 from packaging.version import Version
 import inspect
 import warnings

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 from enum import Enum
 import math
 import numpy as np

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 from packaging.version import Version
 import numpy as np
 from toolz import memoize
@@ -22,7 +22,7 @@ def values(s):
             return s.to_cupy(na_value=np.nan)
         else:
             return s.to_gpu_array(fillna=np.nan)
-        
+
     else:
         return s.values
 

--- a/datashader/glyphs/trimesh.py
+++ b/datashader/glyphs/trimesh.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import annotations
 from math import floor
 import numpy as np
 from toolz import memoize

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -1,7 +1,7 @@
 """Assign coordinates to the nodes of a graph.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import numpy as np
 import param

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from toolz import identity
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 from packaging.version import Version
 import numpy as np
 from datashape import dshape, isnumeric, Record, Option

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from itertools import groupby
 from math import floor, ceil

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import annotations
 
 import pytest
 

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import pytest
 skimage = pytest.importorskip("skimage")
 

--- a/datashader/tests/test_colors.py
+++ b/datashader/tests/test_colors.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashader.colors import rgb, hex_to_rgb
 
 import pytest

--- a/datashader/tests/test_composite.py
+++ b/datashader/tests/test_composite.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import numpy as np
 
 from datashader.composite import add, saturate, over, source

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import annotations
 
 import os
 

--- a/datashader/tests/test_datatypes.py
+++ b/datashader/tests/test_datatypes.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import pytest
 import numpy as np
 import pandas as pd
@@ -709,8 +709,8 @@ class TestRaggedGetitem(eb.BaseGetitemTests):
     def test_getitem_ellipsis_and_slice(self, data):
         pass
 
-    # Ellipsis, numpy.newaxis, None, not supported in RaggedArray.__getitem__ 
-    # so the error message raised RaggedArray.__getitem__ isn't the same as 
+    # Ellipsis, numpy.newaxis, None, not supported in RaggedArray.__getitem__
+    # so the error message raised RaggedArray.__getitem__ isn't the same as
     # the one raised by the base extension.
     @pytest.mark.skip(reason="RaggedArray.__getitem__ raises a different error message")
     def test_getitem_invalid(self, data):

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashape import dshape
 import pandas as pd
 import numpy as np

--- a/datashader/tests/test_layout.py
+++ b/datashader/tests/test_layout.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import pytest
 skimage = pytest.importorskip("skimage")
 

--- a/datashader/tests/test_macros.py
+++ b/datashader/tests/test_macros.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import warnings
 import pytest
 

--- a/datashader/tests/test_mpl_ext.py
+++ b/datashader/tests/test_mpl_ext.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import pytest
 
 pytest.importorskip("matplotlib")

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from collections import OrderedDict
 import os
 from numpy import nan

--- a/datashader/tests/test_pipeline.py
+++ b/datashader/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import numpy as np
 import pandas as pd
 import datashader as ds

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import numpy as np
 from numpy import nan
 import xarray as xr

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import pytest
 
 try:

--- a/datashader/tests/test_tiles.py
+++ b/datashader/tests/test_tiles.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import datashader as ds
 import datashader.transfer_functions as tf
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import annotations
 
 from io import BytesIO
 

--- a/datashader/tests/test_utils.py
+++ b/datashader/tests/test_utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 from datashape import dshape
 import numpy as np
 from xarray import DataArray

--- a/datashader/tests/test_xarray.py
+++ b/datashader/tests/test_xarray.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import annotations
 import numpy as np
 import xarray as xr
 

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 from io import BytesIO
 
 import math

--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from collections.abc import Iterator
 

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import annotations
 
 from math import ceil, isnan
 from packaging.version import Version

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 import re

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -8,7 +8,7 @@ Test files may be generated starting from any file format supported by Pandas:
   python -c "import filetimes ; filetimes.base='<hdf5base>' ; filetimes.categories=['<cat1>','<cat2>']; filetimes.timed_write('<file>')"
 """
 
-from __future__ import print_function
+from __future__ import annotations
 
 import time
 global_start = time.time()

--- a/examples/pcap_to_parquet.py
+++ b/examples/pcap_to_parquet.py
@@ -4,7 +4,7 @@
 Convert PCAP output to undirected graph and save in Parquet format.
 """
 
-from __future__ import print_function
+from __future__ import annotations
 
 import re
 import socket

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -1,41 +1,41 @@
-from __future__ import division
+from __future__ import annotations
 
 if __name__ == "__main__":
     from bokeh.io import curdoc
     from bokeh.plotting import Figure
     from bokeh.models import ColumnDataSource, CustomJS
     from bokeh.tile_providers import get_provider
-    
+
     import rasterio as rio
     import datashader as ds
     import datashader.transfer_functions as tf
     from datashader.colors import Hot
-    
+
     def on_dims_change(attr, old, new):
         update_image()
-    
+
     def update_image():
-    
+
         global dims, raster_data
-    
+
         dims_data = dims.data
-    
+
         if not dims_data['width'] or not dims_data['height']:
             return
-    
+
         xmin = max(dims_data['xmin'][0], raster_data.bounds.left)
         ymin = max(dims_data['ymin'][0], raster_data.bounds.bottom)
         xmax = min(dims_data['xmax'][0], raster_data.bounds.right)
         ymax = min(dims_data['ymax'][0], raster_data.bounds.top)
-    
+
         canvas = ds.Canvas(plot_width=dims_data['width'][0],
                            plot_height=dims_data['height'][0],
                            x_range=(xmin, xmax),
                            y_range=(ymin, ymax))
-    
+
         agg = canvas.raster(raster_data)
         img = tf.shade(agg, cmap=Hot, how='linear')
-    
+
         new_data = {}
         new_data['image'] = [img.data]
         new_data['x'] = [xmin]
@@ -43,11 +43,11 @@ if __name__ == "__main__":
         new_data['dh'] = [ymax - ymin]
         new_data['dw'] = [xmax - xmin]
         image_source.stream(new_data, 1)
-    
+
     # load nyc taxi data
     path = './data/projected.tif'
     raster_data = rio.open(path)
-    
+
     # manage client-side dimensions
     dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[], ymax=[]))
     dims.on_change('data', on_dims_change)
@@ -63,22 +63,22 @@ if __name__ == "__main__":
         };
         dims.data = new_data;
     };
-    
+
     if (typeof throttle != 'undefined' && throttle != null) {
         clearTimeout(throttle);
     }
-    
+
     throttle = setTimeout(update_dims, 100, "replace");
     """
-    
+
     # Create plot -------------------------------
     xmin = -8240227.037
     ymin = 4974203.152
     xmax = -8231283.905
     ymax = 4979238.441
-    
+
     path = './data/projected.tif'
-    
+
     fig = Figure(x_range=(xmin, xmax),
                  y_range=(ymin, ymax),
                  plot_height=600,
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     fig.min_border_right = 0
     fig.min_border_top = 0
     fig.min_border_bottom = 0
-    
+
     image_source = ColumnDataSource(dict(image=[], x=[], y=[], dw=[], dh=[]))
     fig.image_rgba(source=image_source,
                    image='image',
@@ -103,5 +103,5 @@ if __name__ == "__main__":
                    dw='dw',
                    dh='dh',
                    dilate=False)
-    
+
     curdoc().add_root(fig)

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import annotations
 
 import math
 

--- a/examples/taxi_preprocessing_example.py
+++ b/examples/taxi_preprocessing_example.py
@@ -1,22 +1,22 @@
 """Download data needed for the examples"""
 
-from __future__ import print_function
+from __future__ import annotations
 
 if __name__ == "__main__":
 
     from os import path, makedirs, remove
     from download_sample_data import bar as progressbar
-    
+
     import pandas as pd
     import numpy as np
     import sys
-    
+
     try:
         import requests
     except ImportError:
         print('Download script required requests package: conda install requests')
         sys.exit(1)
-    
+
     def _download_dataset(url):
         r = requests.get(url, stream=True)
         output_path = path.split(url)[1]
@@ -26,12 +26,12 @@ if __name__ == "__main__":
                 if chunk:
                     f.write(chunk)
                     f.flush()
-    
+
     examples_dir = path.dirname(path.realpath(__file__))
     data_dir = path.join(examples_dir, 'data')
     if not path.exists(data_dir):
         makedirs(data_dir)
-    
+
     # Taxi data
     def latlng_to_meters(df, lat_name, lng_name):
         lat = df[lat_name]
@@ -42,16 +42,16 @@ if __name__ == "__main__":
         my = my * origin_shift / 180.0
         df.loc[:, lng_name] = mx
         df.loc[:, lat_name] = my
-    
+
     taxi_path = path.join(data_dir, 'nyc_taxi.csv')
     if not path.exists(taxi_path):
         print("Downloading Taxi Data...")
         url = ('https://storage.googleapis.com/tlc-trip-data/2015/'
                'yellow_tripdata_2015-01.csv')
-    
+
         _download_dataset(url)
         df = pd.read_csv('yellow_tripdata_2015-01.csv')
-    
+
         print('Filtering Taxi Data')
         df = df.loc[(df.pickup_longitude < -73.75) &
                     (df.pickup_longitude > -74.15) &
@@ -61,7 +61,7 @@ if __name__ == "__main__":
                     (df.pickup_latitude < 40.84) &
                     (df.dropoff_latitude > 40.68) &
                     (df.dropoff_latitude < 40.84)].copy()
-    
+
         print('Reprojecting Taxi Data')
         latlng_to_meters(df, 'pickup_latitude', 'pickup_longitude')
         latlng_to_meters(df, 'dropoff_latitude', 'dropoff_longitude')
@@ -70,7 +70,7 @@ if __name__ == "__main__":
                   inplace=True)
         df.to_csv(taxi_path, index=False)
         remove('yellow_tripdata_2015-01.csv')
-        
-    
+
+
     print("\nAll data downloaded.")
-    
+


### PR DESCRIPTION
This PR removes unneeded `__future__` imports of `absolute_import`, `division` and `print_function`. Support for Python 2.* required them and they are no longer necessary. Table of minimum versions at https://docs.python.org/3/library/__future__.html shows they have all been available since Python 3.0.

This is part of issue #1112.