### PR TITLE
Curate dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,17 +99,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: ["3.9"]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
         with:
-          fetch-depth: "100"
+          fetch-depth: 0
       - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Update setuptools
+        run: |
+          pip install --upgrade setuptools
       - name: Install pyctdev
         run: |
           pip install pyctdev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,3 +92,47 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           codecov
+
+  test_pip:
+    name: Pip tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ["3.9"]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "100"
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pyctdev
+        run: |
+          pip install pyctdev
+      - name: doit develop_install
+        run: |
+          doit ecosystem=pip develop_install -o tests -o examples
+      - name: doit env_capture
+        run: |
+          doit ecosystem=pip env_capture
+      - name: doit test_lint
+        run: |
+          doit ecosystem=pip test_lint
+      - name: doit test_unit
+        run: |
+          doit ecosystem=pip test_unit
+      - name: doit test_unit_nojit
+        run: |
+          doit ecosystem=pip test_unit_nojit
+        env:
+          NUMBA_DISABLE_JIT: 1
+      - name: doit test_examples
+        run: |
+          doit ecosystem=pip test_examples
+      - name: codecov
+        run: |
+          codecov

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -27,6 +27,11 @@ try:
 except Exception:
     dask_cudf = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 class Axis(object):
     """Interface for implementing axis transformations.
 
@@ -194,14 +199,14 @@ class Canvas(object):
         if geometry is None:
             glyph = Point(x, y)
         else:
-            from spatialpandas import GeoDataFrame
-            from spatialpandas.dask import DaskGeoDataFrame
-            if isinstance(source, DaskGeoDataFrame):
+            if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
                 # Downselect partitions to those that may contain points in viewport
                 x_range = self.x_range if self.x_range is not None else (None, None)
                 y_range = self.y_range if self.y_range is not None else (None, None)
                 source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-            elif not isinstance(source, GeoDataFrame):
+            elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+                pass
+            else:
                 raise ValueError(
                     "source must be an instance of spatialpandas.GeoDataFrame or \n"
                     "spatialpandas.dask.DaskGeoDataFrame.\n"
@@ -354,14 +359,14 @@ class Canvas(object):
             line_width = 1.0
 
         if geometry is not None:
-            from spatialpandas import GeoDataFrame
-            from spatialpandas.dask import DaskGeoDataFrame
-            if isinstance(source, DaskGeoDataFrame):
+            if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
                 # Downselect partitions to those that may contain lines in viewport
                 x_range = self.x_range if self.x_range is not None else (None, None)
                 y_range = self.y_range if self.y_range is not None else (None, None)
                 source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-            elif not isinstance(source, GeoDataFrame):
+            elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+                pass
+            else:
                 raise ValueError(
                     "source must be an instance of spatialpandas.GeoDataFrame or \n"
                     "spatialpandas.dask.DaskGeoDataFrame.\n"
@@ -733,14 +738,14 @@ The axis argument to Canvas.area must be 0 or 1
         """
         from .glyphs import PolygonGeom
         from .reductions import any as any_rdn
-        from spatialpandas import GeoDataFrame
-        from spatialpandas.dask import DaskGeoDataFrame
-        if isinstance(source, DaskGeoDataFrame):
+        if spatialpandas and isinstance(source, spatialpandas.dask.DaskGeoDataFrame):
             # Downselect partitions to those that may contain polygons in viewport
             x_range = self.x_range if self.x_range is not None else (None, None)
             y_range = self.y_range if self.y_range is not None else (None, None)
             source = source.cx_partitions[slice(*x_range), slice(*y_range)]
-        elif not isinstance(source, GeoDataFrame):
+        elif spatialpandas and isinstance(source, spatialpandas.GeoDataFrame):
+            pass
+        else:
             raise ValueError(
                 "source must be an instance of spatialpandas.GeoDataFrame or \n"
                 "spatialpandas.dask.DaskGeoDataFrame.\n"

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -19,6 +19,11 @@ except ImportError:
     cudf = None
     cuda_args = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 # This Enum should eventually be replaced with attributes
 # and/or member functions of Reduction classes.
@@ -513,6 +518,7 @@ class LinesAxis1Ragged(_PointLike, _AntiAliasedLine):
 
 
 class LineAxis1Geometry(_GeometryLike, _AntiAliasedLine):
+    # spatialpandas must be available if a LineAxis1Geometry object is created.
 
     @property
     def geom_dtypes(self):

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -15,6 +15,11 @@ except Exception:
     cudf = None
     cuda_args = None
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 def values(s):
     if isinstance(s, cudf.Series):
@@ -41,8 +46,11 @@ class _GeometryLike(Glyph):
 
     @property
     def geom_dtypes(self):
-        from spatialpandas.geometry import GeometryDtype
-        return (GeometryDtype,)
+        if spatialpandas:
+            from spatialpandas.geometry import GeometryDtype
+            return (GeometryDtype,)
+        else:
+            return ()  # Empty tuple
 
     def validate(self, in_dshape):
         if not isinstance(in_dshape[str(self.geometry)], self.geom_dtypes):
@@ -212,6 +220,7 @@ class Point(_PointLike):
 
 
 class MultiPointGeometry(_GeometryLike):
+    # spatialpandas must be available if a MultiPointGeometry object is created.
 
     @property
     def geom_dtypes(self):

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -5,8 +5,15 @@ from datashader.glyphs.line import _build_map_onto_pixel_for_line
 from datashader.glyphs.points import _GeometryLike
 from datashader.utils import ngjit
 
+try:
+    import spatialpandas
+except Exception:
+    spatialpandas = None
+
 
 class PolygonGeom(_GeometryLike):
+    # spatialpandas must be available if a PolygonGeom object is created.
+
     @property
     def geom_dtypes(self):
         from spatialpandas.geometry import PolygonDtype, MultiPolygonDtype

--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -336,7 +336,7 @@ def tile_previewer(full_extent, tileset_url,
         from bokeh.io import output_file, save
         from os import path
     except ImportError:
-        raise ImportError('conda install bokeh to enable creation of simple tile viewer')
+        raise ImportError('install bokeh to enable creation of simple tile viewer')
 
     if output_dir:
         output_file(filename=path.join(output_dir, filename),
@@ -388,7 +388,7 @@ class S3TileRenderer(TileRenderer):
         try:
             import boto3
         except ImportError:
-            raise ImportError('conda install boto3 to enable rendering to S3')
+            raise ImportError('install boto3 to enable rendering to S3')
 
         try:
             from urlparse import urlparse

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -18,7 +18,6 @@ import pandas as pd
 import dask.dataframe as dd
 import numpy as np
 import datashader as ds
-import bcolz
 import feather
 import fastparquet as fp
 
@@ -108,7 +107,7 @@ def benchmark(fn, args, filetype=None):
 
 
 
-read = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","bcolz","feather","h5","csv"]])
+read = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","feather","h5","csv"]])
 
 def read_csv_dask(filepath, usecols=None):
     # Pandas writes CSV files out as a single file
@@ -123,7 +122,6 @@ def read_feather_dask(filepath):
     df = feather.read_dataframe(filepath, columns=p.columns)
     return dd.from_pandas(df, npartitions=p.n_workers)
 read["feather"]      ["dask"] = lambda filepath,p,filetype:  benchmark(read_feather_dask, (filepath,), filetype)
-read["bcolz"]        ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.from_bcolz, (filepath, Kwargs(chunksize=1000000)), filetype)
 read["parq"]         ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
 read["gz.parq"]      ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
 read["snappy.parq"]  ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
@@ -138,9 +136,6 @@ def read_csv_pandas(filepath, usecols=None):
 read["csv"]         ["pandas"] = lambda filepath,p,filetype:  benchmark(read_csv_pandas, (filepath, Kwargs(usecols=p.columns)), filetype)
 read["h5"]          ["pandas"] = lambda filepath,p,filetype:  benchmark(pd.read_hdf, (filepath, p.base, Kwargs(columns=p.columns)), filetype)
 read["feather"]     ["pandas"] = lambda filepath,p,filetype:  benchmark(feather.read_dataframe, (filepath,), filetype)
-def read_bcolz_pandas(filepath, chunksize=None):
-    return bcolz.ctable(rootdir=filepath).todataframe(columns=p.columns)
-read["bcolz"]       ["pandas"]   = lambda filepath,p,filetype:  benchmark(read_bcolz_pandas, (filepath, Kwargs(chunksize=1000000)), filetype)
 def read_parq_pandas(filepath):
     return fp.ParquetFile(filepath).to_pandas()
 read["parq"]        ["pandas"] = lambda filepath,p,filetype:  benchmark(read_parq_pandas, (filepath,), filetype)
@@ -148,13 +143,10 @@ read["gz.parq"]     ["pandas"] = lambda filepath,p,filetype:  benchmark(read_par
 read["snappy.parq"] ["pandas"] = lambda filepath,p,filetype:  benchmark(read_parq_pandas, (filepath,), filetype)
 
 
-write = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","bcolz","feather","h5","csv"]])
+write = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","feather","h5","csv"]])
 
 write["csv"]          ["dask"]   = lambda df,filepath,p:  benchmark(df.to_csv, (filepath.replace(".csv","*.csv"), Kwargs(index=False)))
 write["h5"]           ["dask"]   = lambda df,filepath,p:  benchmark(df.to_hdf, (filepath, p.base))
-def write_bcolz_dask(filepath, df):
-    return bcolz.ctable.fromdataframe(df.compute(), rootdir=filepath)
-write["bcolz"]        ["dask"] = lambda df,filepath,p:  benchmark(write_bcolz_dask, (filepath, df))
 def write_feather_dask(filepath, df):
     return feather.write_dataframe(df.compute(), filepath)
 write["feather"]      ["dask"] = lambda df,filepath,p:  benchmark(write_feather_dask, (filepath, df))
@@ -164,7 +156,6 @@ write["gz.parq"]      ["dask"]   = lambda df,filepath,p:  benchmark(dd.to_parque
 
 write["csv"]          ["pandas"] = lambda df,filepath,p:  benchmark(df.to_csv, (filepath, Kwargs(index=False)))
 write["h5"]           ["pandas"] = lambda df,filepath,p:  benchmark(df.to_hdf, (filepath, Kwargs(key=p.base, format='table')))
-write["bcolz"]        ["pandas"] = lambda df,filepath,p:  benchmark(bcolz.ctable.fromdataframe, (df, Kwargs(rootdir=filepath)))
 write["feather"]      ["pandas"] = lambda df,filepath,p:  benchmark(feather.write_dataframe, (df, filepath))
 write["parq"]         ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(**p.parq_opts)))
 write["gz.parq"]      ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(compression='GZIP', **p.parq_opts)))

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -27,7 +27,6 @@ test -n "$3" && set -x
 ${timer} python filetimes.py ${1}.parq         dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.snappy.parq  dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.gz.parq      dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
-${timer} python filetimes.py ${1}.bcolz        dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.h5           dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.csv          dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.feather      dask    census easting northing race ${3:+--debug} ${2:+--cache=$2}
@@ -35,7 +34,6 @@ ${timer} python filetimes.py ${1}.feather      dask    census easting northing r
 ${timer} python filetimes.py ${1}.parq         pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.snappy.parq  pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.gz.parq      pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
-${timer} python filetimes.py ${1}.bcolz        pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.h5           pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.csv          pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.feather      pandas  census easting northing race ${3:+--debug} ${2:+--cache=$2}

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -3,7 +3,6 @@ dependencies:
 - bokeh
 - matplotlib
 - jupyter
-- bcolz=1.1.2=np112py35_0
 - bokeh::datashader=0.4.0=py35_0
 - conda-forge::feather-format=0.3.1=py35_1
 - dask=0.14.3=py35_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "param >=1.7.0",
-    "pyct >=0.4.4",
-    "setuptools >=30.3.0"
+    "param",
+    "pyct",
+    "setuptools"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = [
     "param",
     "pyct",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
-    'colorcet',
     'dask',
     'datashape',
     'numba >=0.51',
@@ -23,7 +22,7 @@ install_requires = [
 ]
 
 examples = [
-    'bokeh',
+    'colorcet',
     'geopandas',
     'holoviews',
     'matplotlib',
@@ -55,13 +54,11 @@ extras_require = {
         'streamz',
         ### conda only below here
         'fastparquet',
-        'geopandas',
         'graphviz',
         'python-graphviz',
         'python-snappy',
         'rasterio',
         'snappy',
-        'spatialpandas',
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,20 @@ import pyct.build
 
 install_requires = [
     'dask',
-    'datashape >=0.5.1',
+    'datashape',
     'numba >=0.51',
-    'pandas >=0.24.1',
-    'pillow >=3.1.1',
-    'xarray >=0.9.6',
-    'colorcet >=0.9.0',
-    'param >=1.6.1',
-    'pyct >=0.4.5',
+    'pandas',
+    'pillow',
+    'xarray',
+    'colorcet',
+    'param',
+    'pyct',
     'requests',
     'scipy',
 ]
 
 examples = [
-    'holoviews >=1.10.0',
+    'holoviews',
     'scikit-image',
     'bokeh',
     'matplotlib',
@@ -33,15 +33,15 @@ examples = [
 
 extras_require = {
     'tests': [
-        'pytest >=3.9.3',
-        'pytest-benchmark >=3.0.0',
+        'pytest',
+        'pytest-benchmark',
         'pytest-cov',
         'codecov',
         'flake8',
         'nbconvert',
         'nbsmoke[verify] >0.5',
-        'fastparquet >=0.1.6',  # optional dependency
-        'holoviews >=1.10.0',
+        'fastparquet',  # optional dependency
+        'holoviews',
         'bokeh',
         'pyarrow',
         'netcdf4',
@@ -51,8 +51,8 @@ extras_require = {
     ],
     'examples': examples,
     'examples_extra': examples + [
-        'networkx >=2.0',
-        'streamz >=0.2.0',
+        'networkx',
+        'streamz',
         ### conda only below here
         'graphviz',
         'python-graphviz',

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,19 @@ install_requires = [
     'dask',
     'datashape',
     'numba >=0.51',
+    'numpy',
     'pandas',
     'param',
     'pillow',
     'pyct',
     'requests',
     'scipy',
+    'toolz',
     'xarray',
 ]
 
 examples = [
+    'bokeh',
     'colorcet',
     'geopandas',
     'holoviews',
@@ -32,11 +35,9 @@ examples = [
 
 extras_require = {
     'tests': [
-        'bokeh',
         'codecov',
         'fastparquet',  # optional dependency
         'flake8',
-        'holoviews',
         'nbconvert',
         'nbsmoke[verify] >0.5',
         'netcdf4',

--- a/setup.py
+++ b/setup.py
@@ -9,67 +9,67 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
+    'colorcet',
     'dask',
     'datashape',
     'numba >=0.51',
     'pandas',
-    'pillow',
-    'xarray',
-    'colorcet',
     'param',
+    'pillow',
     'pyct',
     'requests',
     'scipy',
+    'xarray',
 ]
 
 examples = [
-    'holoviews',
-    'scikit-image',
     'bokeh',
-    'matplotlib',
     'geopandas',
+    'holoviews',
+    'matplotlib',
+    'scikit-image',
     'spatialpandas',
 ]
 
 extras_require = {
     'tests': [
+        'bokeh',
+        'codecov',
+        'fastparquet',  # optional dependency
+        'flake8',
+        'holoviews',
+        'nbconvert',
+        'nbsmoke[verify] >0.5',
+        'netcdf4',
+        'pyarrow',
         'pytest',
         'pytest-benchmark',
         'pytest-cov',
-        'codecov',
-        'flake8',
-        'nbconvert',
-        'nbsmoke[verify] >0.5',
-        'fastparquet',  # optional dependency
-        'holoviews',
-        'bokeh',
-        'pyarrow',
-        'netcdf4',
-        'spatialpandas',
-        'rioxarray',
         'rasterio',
+        'rioxarray',
+        'spatialpandas',
     ],
     'examples': examples,
     'examples_extra': examples + [
         'networkx',
         'streamz',
         ### conda only below here
+        'fastparquet',
+        'geopandas',
         'graphviz',
         'python-graphviz',
-        'fastparquet',
         'python-snappy',
         'rasterio',
         'snappy',
         'spatialpandas',
-        'geopandas',
     ]
 }
 
 extras_require['doc'] = extras_require['examples_extra'] + [
     'nbsite >=0.7.1',
+    'numpydoc',
     'pydata-sphinx-theme <0.9.0',
     'sphinx-copybutton',
-    'numpydoc',
 ]
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ setup_args = dict(
 )
 
 if __name__ == '__main__':
+
+
+    print("VERSION", param.version.get_setup_version(__file__,"datashader",archive_commit="$Format:%h$"))
+
+
     example_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'datashader','examples')
     if 'develop' not in sys.argv:


### PR DESCRIPTION
Closes #1112.

Significant changes here are:

1. `spatialpandas` is not a compulsory dependency (it hasn't been for a while) so I have modified the `import spatialpandas` code to gracefully handle the situation of it not being available.
2. I've removed `colorcet` as a compulsory dependency as it is not used anywhere in the code other than the tests and examples. I think this is the correct approach, but it may impact downstream projects which depend on it being included with `datashader`.
3. I've added a github action to test using `pip` (via the `pyctdev` `doit ecosystem=pip` approach) so that we are automatically testing both `pip` and `conda` installations.

I also removed `bcolz` as it is no longer maintained (https://github.com/Blosc/bcolz) but it is only used in `filetimes.py`. There are other possible removals here but I intend to replace the benchmarking code with a full `asv` benchmarking suite so I will address the other `filetimes.py` changes then.