### PR TITLE
Restore colorcet as compulsory dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import pyct.build
 ########## dependencies ##########
 
 install_requires = [
+    'colorcet',
     'dask',
     'datashape',
     'numba >=0.51',
@@ -25,7 +26,6 @@ install_requires = [
 
 examples = [
     'bokeh',
-    'colorcet',
     'geopandas',
     'holoviews',
     'matplotlib',
@@ -123,11 +123,6 @@ setup_args = dict(
 )
 
 if __name__ == '__main__':
-
-
-    print("VERSION", param.version.get_setup_version(__file__,"datashader",archive_commit="$Format:%h$"))
-
-
     example_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'datashader','examples')
     if 'develop' not in sys.argv:


### PR DESCRIPTION
As discussed in PR #1117, this restores `colorcet` as a compulsory dependency.