### PR TITLE
Pin nbformat to 5.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ extras_require = {
         'fastparquet',  # optional dependency
         'flake8',
         'nbconvert',
+        'nbformat <=5.4.0',
         'nbsmoke[verify] >0.5',
         'netcdf4',
         'pyarrow',


### PR DESCRIPTION
CI is failing on linting the example notebooks with `nbformat` 5.5.0 and 5.6.0. Pinning to 5.4.0 temporarily to pass CI.