### PR TITLE
Consistent test_gpu flag

### DIFF
--- a/datashader/tests/benchmarks/test_canvas.py
+++ b/datashader/tests/benchmarks/test_canvas.py
@@ -5,10 +5,7 @@ import pandas as pd
 
 import datashader as ds
 
-if "DATASHADER_TEST_GPU" in os.environ:
-    test_gpu = bool(int(os.environ["DATASHADER_TEST_GPU"]))
-else:
-    test_gpu = None
+test_gpu = bool(int(os.getenv("DATASHADER_TEST_GPU", 0)))
 
 
 @pytest.fixture
@@ -35,8 +32,7 @@ def test_points(benchmark, time_series):
     benchmark(cvs.points, time_series, 'x', 'y')
 
 
-@pytest.mark.skipif(test_gpu is None, reason="DATASHADER_TEST_GPU not in environment")
-@pytest.mark.skipif(test_gpu is False, reason="DATASHADER_TEST_GPU is set to False")
+@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
 @pytest.mark.benchmark(group="canvas")
 def test_line_gpu(benchmark, time_series):
     from cudf import from_pandas
@@ -45,8 +41,7 @@ def test_line_gpu(benchmark, time_series):
     benchmark(cvs.line, time_series, 'x', 'y')
 
 
-@pytest.mark.skipif(test_gpu is None, reason="DATASHADER_TEST_GPU not in environment")
-@pytest.mark.skipif(test_gpu is False, reason="DATASHADER_TEST_GPU is set to False")
+@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
 @pytest.mark.benchmark(group="canvas")
 def test_points_gpu(benchmark, time_series):
     from cudf import from_pandas

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -27,10 +27,7 @@ from datashader.tests.test_pandas import (
 
 config.set(scheduler='synchronous')
 
-if "DATASHADER_TEST_GPU" in os.environ:
-    test_gpu = bool(int(os.environ["DATASHADER_TEST_GPU"]))
-else:
-    test_gpu = None
+test_gpu = bool(int(os.getenv("DATASHADER_TEST_GPU", 0)))
 
 df_pd = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                       'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
@@ -62,7 +59,7 @@ try:
     import cupy
     import dask_cudf
 
-    if test_gpu is False:
+    if not test_gpu:
         # GPU testing disabled even though cudf/cupy are available
         raise ImportError
 
@@ -109,7 +106,7 @@ def floats(n):
 
 
 def test_gpu_dependencies():
-    if test_gpu is True and cudf is None:
+    if test_gpu and cudf is None:
         pytest.fail(
             "cudf, cupy, and/or dask_cudf not available and DATASHADER_TEST_GPU=1"
         )

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -29,10 +29,7 @@ df_pd.at[2,'f32'] = nan
 df_pd.at[2,'f64'] = nan
 dfs_pd = [df_pd]
 
-if "DATASHADER_TEST_GPU" in os.environ:
-    test_gpu = bool(int(os.environ["DATASHADER_TEST_GPU"]))
-else:
-    test_gpu = None
+test_gpu = bool(int(os.getenv("DATASHADER_TEST_GPU", 0)))
 
 
 try:
@@ -135,12 +132,11 @@ def values(s):
 
 
 def test_gpu_dependencies():
-    if test_gpu is True and cudf is None:
+    if test_gpu and cudf is None:
         pytest.fail("cudf and/or cupy not available and DATASHADER_TEST_GPU=1")
 
 
-@pytest.mark.skipif(test_gpu is None, reason="DATASHADER_TEST_GPU not in environment")
-@pytest.mark.skipif(test_gpu is False, reason="DATASHADER_TEST_GPU is set to False")
+@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
 def test_cudf_concat():
     # Testing if a newer version of cuDF implements the possibility to
     # concatenate multiple columns with the same name.


### PR DESCRIPTION
Fixes #1130.

This simplifies the `test_gpu` flag so that it is boolean. Previously it could be `True`, `False` or `None` (meaning unspecified) and the `None` option was supposed to behave the same as `False` but with different test skipped messages. But it wasn't handled consistently, now it is. It still defaults to not running GPU tests. I am not sure this is the best default, but it can be dealt with in a later PR.

On a system with a GPU and with `cupy` and `cudf` installed, running the tests in either of these ways runs exactly the same tests (i.e. ignores the all GPU tests):
```
pytest datashader/tests
DATASHADER_TEST_GPU=0 pytest datashader/tests
```
and to run all tests including GPU ones use
```
DATASHADER_TEST_GPU=1 pytest datashader/tests
```
 
Also tested all 3 options in an environment without `cupy` and `cudf` installed, and if you set `DATASHADER_TEST_GPU=1` then the `test_gpu_dependencies` test fails as expected.

After this PR, all tests run on CPU and GPU on my dev machine (Ubuntu 22.04 x86_64, Nvidia Quadro T1000) with the exception of that identified in issue #1131, which can be manually disabled using the `-k "not log_axis_line"` command-line argument.