### PR TITLE
Raise NotImplementedError for antialiased line reductions not yet supported

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -442,10 +442,15 @@ The axis argument to Canvas.line must be 0 or 1
                 antialias_combination = AntialiasCombination.MAX
             elif isinstance(non_cat_agg, rd.min):
                 antialias_combination = AntialiasCombination.MIN
-            elif isinstance(non_cat_agg, (rd.count, rd.sum)) and non_cat_agg.self_intersect:
-                antialias_combination = AntialiasCombination.SUM_1AGG
+            elif isinstance(non_cat_agg, (rd.count, rd.sum)):
+                if non_cat_agg.self_intersect:
+                    antialias_combination = AntialiasCombination.SUM_1AGG
+                else:
+                    antialias_combination = AntialiasCombination.SUM_2AGG
             else:
-                antialias_combination = AntialiasCombination.SUM_2AGG
+                raise NotImplementedError(
+                    f"{type(non_cat_agg)} reduction not implemented for antialiased lines")
+
             glyph.set_antialias_combination(antialias_combination)
 
             # Switch agg to floating point.

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2082,3 +2082,15 @@ def test_line_antialias_duplicate_points(self_intersect):
                              agg=ds.count(self_intersect=self_intersect))
 
     assert_eq_xr(agg_no_duplicate, agg_duplicate)
+
+
+@pytest.mark.parametrize('reduction', [
+    ds.mean('value'), ds.std('value'), ds.summary(c=ds.count()), ds.var('value'),
+    ds.first('value'), ds.last('value')])
+def test_line_antialias_reduction_not_implemented(reduction):
+    # Issue #1133, detect and report reductions that are not implemented.
+    cvs = ds.Canvas(plot_width=10, plot_height=10)
+    df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2]))
+
+    with pytest.raises(NotImplementedError):
+        cvs.line(df, 'x', 'y', line_width=1, agg=reduction)    


### PR DESCRIPTION
This is an improvement to issue #1133 that raises a `NotImplementedError` when a reduction is used which is not yet supported for antialiased lines.

Eventually all of these reductions will be supported with antialiased lines.