### PR TITLE
Remove nbformat version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require = {
         'fastparquet',  # optional dependency
         'flake8',
         'nbconvert',
-        'nbformat <=5.4.0',
         'nbsmoke[verify] >0.5',
         'netcdf4',
         'pyarrow',


### PR DESCRIPTION
The `nbformat` version pin introduced in PR #1125 is no longer needed as the underlying problem has been fixed in https://github.com/pyviz-dev/nbsmoke/pull/63 (thanks @maximlt).

I am removing the `nbformat` dependency completely as that is how it was before the version pin. The dependency is picked up via `nbconvert` and `nbsmoke`.