### PR TITLE
Add cudf, dask and dask-cudf Canvas.line benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,6 +46,21 @@ asv dev
 instead of `asv run`.
 
 
+Running cuDF and Dask-cuDF benchmarks
+-------------------------------------
+
+Benchmarks that use `pandas` and `dask` DataFrames are always run whereas those that use `cudf` and `dask-cudf` are only run if the required libraries are installed and appropriate GPU hardware is available. Because installing the required libraries is non-trivial it is recommended to run the benchmarks in your default `cudf`-enabled development environment rather than allow `asv` to create new environments specifically for the benchmarking.
+
+Before running `cudf` and `dask-cudf` benchmarks you should first check that you can run the Datashader `pytest` test suite as debugging your environment is much easier using `pytest` than `asv`.
+
+The `asv` command to run all benchmarks using your default development environment is:
+```
+asv run --python=same --launch-method spawn
+```
+
+The `--launch-method spawn` is recommended to avoid problems in accessing the GPU from subprocesses which is how `asv` runs individual isolated benchmarks.
+
+
 Adding new benchmarks
 ---------------------
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -43,7 +43,7 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    //"environment_type": "virtualenv",
+    "environment_type": "conda",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class DataLibrary(Enum):
+    PandasDF = 1
+    DaskDF = 2
+    CuDF = 3
+    DaskCuDF = 4

--- a/benchmarks/benchmarks/line.py
+++ b/benchmarks/benchmarks/line.py
@@ -44,13 +44,13 @@ class Line:
             if cudf:
                 self.df = cudf.DataFrame.from_pandas(self.df)
             else:
-                raise NotImplementedError(f"CuDF not available")
+                raise NotImplementedError("CuDF not available")
         elif data_library == DataLibrary.DaskCuDF:
             if dask_cudf:
                 cdf = cudf.DataFrame.from_pandas(self.df)
                 self.df = dask_cudf.from_cudf(cdf, npartitions=4)
             else:
-                raise NotImplementedError(f"Dask-cuDF not available")
+                raise NotImplementedError("Dask-cuDF not available")
         else:
             raise NotImplementedError(f"data_library {data_library} not supported in this test")
 

--- a/benchmarks/benchmarks/line.py
+++ b/benchmarks/benchmarks/line.py
@@ -1,13 +1,28 @@
+import dask.dataframe as dd
 import datashader as ds
 import numpy as np
 import pandas as pd
+from .common import DataLibrary
+
+try:
+    import cudf
+except:
+    cudf = None
+
+try:
+    import dask_cudf
+except:
+    dask_cudf = None
 
 
 class Line:
-    param_names = ("line_count", "line_width", "self_intersect")
-    params = ([1000, 10000], [0, 1, 2], [False, True])
+    param_names = ("data_library", "line_count", "line_width", "self_intersect")
+    params = (
+        [DataLibrary.PandasDF, DataLibrary.DaskDF, DataLibrary.CuDF, DataLibrary.DaskCuDF],
+        [1000, 10000], [0, 1, 2], [False, True],
+    )
 
-    def setup(self, line_count, line_width, self_intersect):
+    def setup(self, data_library, line_count, line_width, self_intersect):
         canvas_size = 1000
         points_per_line = 10
 
@@ -21,9 +36,29 @@ class Line:
         )
         self.df = pd.DataFrame(y)
 
-    def time_LinesAxis1XConstant(self, line_count, line_width, self_intersect):
-        if line_width == 0.0 and not self_intersect:
+        if data_library == DataLibrary.PandasDF:
+            pass
+        elif data_library == DataLibrary.DaskDF:
+            self.df = dd.from_pandas(self.df, npartitions=4)
+        elif data_library == DataLibrary.CuDF:
+            if cudf:
+                self.df = cudf.DataFrame.from_pandas(self.df)
+            else:
+                raise NotImplementedError(f"CuDF not available")
+        elif data_library == DataLibrary.DaskCuDF:
+            if dask_cudf:
+                cdf = cudf.DataFrame.from_pandas(self.df)
+                self.df = dask_cudf.from_cudf(cdf, npartitions=4)
+            else:
+                raise NotImplementedError(f"Dask-cuDF not available")
+        else:
+            raise NotImplementedError(f"data_library {data_library} not supported in this test")
+
+    def time_LinesAxis1XConstant(self, data_library, line_count, line_width, self_intersect):
+        if line_width == 0 and not self_intersect:
             raise NotImplementedError  # Same as line_width=0, self_intersect=False
+        elif line_width > 0 and data_library not in [DataLibrary.PandasDF, DataLibrary.DaskDF]:
+            raise NotImplementedError  # Antialiased lines only work on CPU not GPU
 
         agg = ds.count(self_intersect=self_intersect)
         self.canvas.line(


### PR DESCRIPTION
This PR adds `cudf`, `dask` and `dask-cudf` benchmarks to the existing `pandas` `Canvas.line` benchmarks. The `cudf` and `dask-cudf` benchmarks are only run if you have the required libraries installed, and in turn those libraries can only be installed if you have appropriate CUDA hardware available.

Outline of process to install required libraries:

1.  Identify the version of your graphics card driver and also the CUDA version it supports using e.g. `nvidia-smi`. The versions should be something like `470.141.03` and `11.5`.
2. Navigate to https://rapids.ai/start.html, scroll down to Step 1 and check that the versions you have are supported by RAPIDS.
3.  Scroll down to Step 3, input your CUDA version and required Python version, and select the `cuDF` package. This gives you a `conda create` command to use. Note that this does not include `dask-cudf`, so explicitly append it to the `conda create` command if you wish to use it.
4.  Create the `conda` environment using this command. It can take quite a while to resolve dependencies and download and install the required packages.
5.  Install datashader into this environment using `pip install -ve .[tests]`.
6.  Check that the datashader test suite passes using `DATASHADER_TEST_GPU=1 pytest datashader/tests`.
7. Now you can run the benchmarking suite following the notes in `benchmarks/README.md`.

Note that the size of the benchmark problems is not sufficient to justify the use of `dask` and/or `cudf`. They are not yet intended to fully benchmark the performance of the whole library but are instead intended to check that code changes do not have a detrimental effect on individual algorithm performance. This is important in the short term as there is work underway to simplify the `Numba` code within `Datashader` so that it is easier to understand and maintain, but these simplifications will only be acceptable if they do not slow down the code.