### PR TITLE
Fit antialiased line code within usual numba/dask framework

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -14,7 +14,7 @@ __all__ = ['compile_components']
 
 
 @memoize
-def compile_components(agg, schema, glyph, cuda=False):
+def compile_components(agg, schema, glyph, cuda=False, antialias=False):
     """Given a ``Aggregation`` object and a schema, return 5 sub-functions.
 
     Parameters
@@ -53,7 +53,7 @@ def compile_components(agg, schema, glyph, cuda=False):
     bases = list(unique(concat(r._build_bases(cuda) for r in reds)))
     dshapes = [b.out_dshape(schema) for b in bases]
     # List of tuples of (append, base, input columns, temps)
-    calls = [_get_call_tuples(b, d, schema, cuda) for (b, d) in zip(bases, dshapes)]
+    calls = [_get_call_tuples(b, d, schema, cuda, antialias) for (b, d) in zip(bases, dshapes)]
     # List of unique column names needed
     cols = list(unique(concat(pluck(2, calls))))
     # List of temps needed
@@ -78,8 +78,8 @@ def traverse_aggregation(agg):
         yield agg
 
 
-def _get_call_tuples(base, dshape, schema, cuda):
-    return (base._build_append(dshape, schema, cuda),
+def _get_call_tuples(base, dshape, schema, cuda, antialias):
+    return (base._build_append(dshape, schema, cuda, antialias),
             (base,), base.inputs, base._build_temps(cuda))
 
 

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -51,7 +51,8 @@ def compile_components(agg, schema, glyph, cuda=False, antialias=False):
 
     # List of base reductions (actually computed)
     bases = list(unique(concat(r._build_bases(cuda) for r in reds)))
-    dshapes = [b.out_dshape(schema) for b in bases]
+    dshapes = [b.out_dshape(schema, antialias) for b in bases]
+    print("DSHAPES", dshapes)
     # List of tuples of (append, base, input columns, temps)
     calls = [_get_call_tuples(b, d, schema, cuda, antialias) for (b, d) in zip(bases, dshapes)]
     # List of unique column names needed
@@ -147,6 +148,8 @@ def make_append(bases, cols, calls, glyph, categorical):
         code = ('def append({0}, x, y, {1}):\n'
                 '    {2}'
                 ).format(subscript, ', '.join(signature), '\n    '.join(body))
+    print("CODE", code)  # If aa, need another aa_factor in range 0 to 1 to combine with field...
+                         # but can call the same reduction.append in the end anyway.
     exec(code, namespace)
     return ngjit(namespace['append'])
 

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -52,7 +52,6 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     # List of base reductions (actually computed)
     bases = list(unique(concat(r._build_bases(cuda) for r in reds)))
     dshapes = [b.out_dshape(schema, antialias) for b in bases]
-    print("DSHAPES", dshapes)
     # List of tuples of (append, base, input columns, temps)
     calls = [_get_call_tuples(b, d, schema, cuda, antialias) for (b, d) in zip(bases, dshapes)]
     # List of unique column names needed
@@ -159,7 +158,6 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
         code = ('def append({0}, x, y, {1}):\n'
                 '    {2}'
                 ).format(subscript, ', '.join(signature), '\n    '.join(body))
-    print("CODE", code)
     exec(code, namespace)
     return ngjit(namespace['append'])
 
@@ -170,7 +168,6 @@ def make_combine(bases, dshapes, temps, antialias):
              for (b, d, t) in zip(bases, dshapes, temps)]
 
     def combine(base_tuples):
-        print("COMBINE")
         bases = tuple(np.stack(bs) for bs in zip(*base_tuples))
         return tuple(f(*get(inds, bases)) for (f, inds) in calls)
 

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -63,7 +63,7 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     create = make_create(bases, dshapes, cuda)
     info = make_info(cols)
     append = make_append(bases, cols, calls, glyph, isinstance(agg, by), antialias)
-    combine = make_combine(bases, dshapes, temps)
+    combine = make_combine(bases, dshapes, temps, antialias)
     finalize = make_finalize(bases, agg, schema, cuda)
 
     return create, info, append, combine, finalize
@@ -164,9 +164,9 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
     return ngjit(namespace['append'])
 
 
-def make_combine(bases, dshapes, temps):
+def make_combine(bases, dshapes, temps, antialias):
     arg_lk = dict((k, v) for (v, k) in enumerate(bases))
-    calls = [(b._build_combine(d), [arg_lk[i] for i in (b,) + t])
+    calls = [(b._build_combine(d, antialias), [arg_lk[i] for i in (b,) + t])
              for (b, d, t) in zip(bases, dshapes, temps)]
 
     def combine(base_tuples):

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -14,7 +14,7 @@ __all__ = ['compile_components']
 
 
 @memoize
-def compile_components(agg, schema, glyph, cuda=False, antialias=False):
+def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     """Given a ``Aggregation`` object and a schema, return 5 sub-functions.
 
     Parameters
@@ -142,15 +142,15 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
     body = ['{0} = {1}[y, x]'.format(name, arg_lk[agg])
             for agg, name in local_lk.items()] + body
 
-    if antialias:
-        signature.insert(0, "aa_factor")
-
     # Categorical aggregate arrays need to be unpacked
     if categorical:
         col_index = '' if isinstance(cols[0], category_codes) else '[0]'
         cat_var = 'cat = int({0}[{1}]{2})'.format(signature[-1], subscript, col_index)
         aggs = ['{0} = {0}[:, :, cat]'.format(s) for s in signature[:len(calls)]]
         body = [cat_var] + aggs + body
+
+    if antialias:
+        signature.insert(0, "aa_factor")
 
     if ndims is None:
         code = ('def append(x, y, {0}):\n'

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -170,6 +170,7 @@ def make_combine(bases, dshapes, temps):
              for (b, d, t) in zip(bases, dshapes, temps)]
 
     def combine(base_tuples):
+        print("COMBINE")
         bases = tuple(np.stack(bs) for bs in zip(*base_tuples))
         return tuple(f(*get(inds, bases)) for (f, inds) in calls)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -456,7 +456,7 @@ The axis argument to Canvas.line must be 0 or 1
             # Switch agg to floating point.
             agg = rd._reduction_to_floating_point(agg)
 
-        return bypixel(source, self, glyph, agg)
+        return bypixel(source, self, glyph, agg, antialias=(line_width > 0))
 
     def area(self, source, x, y, agg=None, axis=0, y_stack=None):
         """Compute a reduction by pixel, mapping data to pixels as a filled
@@ -1236,7 +1236,7 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         self.y_axis.validate(self.y_range)
 
 
-def bypixel(source, canvas, glyph, agg):
+def bypixel(source, canvas, glyph, agg, antialias=False):
     """Compute an aggregate grouped by pixel sized bins.
 
     Aggregate input data ``source`` into a grid with shape and axis matching
@@ -1261,7 +1261,7 @@ def bypixel(source, canvas, glyph, agg):
     # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
     with np.warnings.catch_warnings():
         np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
-        return bypixel.pipeline(source, schema, canvas, glyph, agg)
+        return bypixel.pipeline(source, schema, canvas, glyph, agg, antialias)
 
 
 def _bypixel_sanitise(source, glyph, agg):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -421,14 +421,6 @@ See docstring for more information on valid usage""".format(
 The axis argument to Canvas.line must be 0 or 1
     Received: {axis}""".format(axis=axis))
 
-        if (line_width > 0 and ((cudf and isinstance(source, cudf.DataFrame)) or
-                               (dask_cudf and isinstance(source, dask_cudf.DataFrame)))):
-            import warnings
-            warnings.warn(
-                "Antialiased lines are not supported for CUDA-backed sources, "
-                "so reverting to line_width=0")
-            line_width = 0
-
         glyph.set_line_width(line_width)
         glyph.antialiased = (line_width > 0)
 
@@ -458,7 +450,7 @@ The axis argument to Canvas.line must be 0 or 1
             # Switch agg to floating point.
             #############agg = rd._reduction_to_floating_point(agg)
 
-        return bypixel(source, self, glyph, agg, antialias=(line_width > 0))
+        return bypixel(source, self, glyph, agg, antialias=glyph.antialiased)
 
     def area(self, source, x, y, agg=None, axis=0, y_stack=None):
         """Compute a reduction by pixel, mapping data to pixels as a filled

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -431,6 +431,8 @@ The axis argument to Canvas.line must be 0 or 1
             if isinstance(non_cat_agg, rd.by):
                 non_cat_agg = non_cat_agg.reduction
 
+            ################### This can be much simpler, just needs to be the 2nd-order combine
+            ################### that is peculiar to antialiased lines.
             antialias_combination = AntialiasCombination.NONE
             if isinstance(non_cat_agg, (rd.any, rd.max)):
                 antialias_combination = AntialiasCombination.MAX
@@ -447,8 +449,7 @@ The axis argument to Canvas.line must be 0 or 1
 
             glyph.set_antialias_combination(antialias_combination)
 
-            # Switch agg to floating point.
-            #############agg = rd._reduction_to_floating_point(agg)
+        print("Line:", type(glyph), glyph.antialiased, glyph._line_width)
 
         return bypixel(source, self, glyph, agg, antialias=glyph.antialiased)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -454,7 +454,7 @@ The axis argument to Canvas.line must be 0 or 1
             glyph.set_antialias_combination(antialias_combination)
 
             # Switch agg to floating point.
-            agg = rd._reduction_to_floating_point(agg)
+            #############agg = rd._reduction_to_floating_point(agg)
 
         return bypixel(source, self, glyph, agg, antialias=(line_width > 0))
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -430,7 +430,9 @@ The axis argument to Canvas.line must be 0 or 1
             line_width = 0
 
         glyph.set_line_width(line_width)
-        if line_width > 0:
+        glyph.antialiased = (line_width > 0)
+
+        if glyph.antialiased:
             # Eventually this should be replaced with attributes and/or
             # member functions of Reduction classes.
             non_cat_agg = agg

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1232,7 +1232,7 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         self.y_axis.validate(self.y_range)
 
 
-def bypixel(source, canvas, glyph, agg, antialias=False):
+def bypixel(source, canvas, glyph, agg, *, antialias=False):
     """Compute an aggregate grouped by pixel sized bins.
 
     Aggregate input data ``source`` into a grid with shape and axis matching
@@ -1257,7 +1257,7 @@ def bypixel(source, canvas, glyph, agg, antialias=False):
     # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
     with np.warnings.catch_warnings():
         np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
-        return bypixel.pipeline(source, schema, canvas, glyph, agg, antialias)
+        return bypixel.pipeline(source, schema, canvas, glyph, agg, antialias=antialias)
 
 
 def _bypixel_sanitise(source, glyph, agg):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -421,6 +421,14 @@ See docstring for more information on valid usage""".format(
 The axis argument to Canvas.line must be 0 or 1
     Received: {axis}""".format(axis=axis))
 
+        if (line_width > 0 and ((cudf and isinstance(source, cudf.DataFrame)) or
+                               (dask_cudf and isinstance(source, dask_cudf.DataFrame)))):
+            import warnings
+            warnings.warn(
+                "Antialiased lines are not supported for CUDA-backed sources, "
+                "so reverting to line_width=0")
+            line_width = 0
+
         glyph.set_line_width(line_width)
         glyph.antialiased = (line_width > 0)
 
@@ -431,8 +439,6 @@ The axis argument to Canvas.line must be 0 or 1
             if isinstance(non_cat_agg, rd.by):
                 non_cat_agg = non_cat_agg.reduction
 
-            ################### This can be much simpler, just needs to be the 2nd-order combine
-            ################### that is peculiar to antialiased lines.
             antialias_combination = AntialiasCombination.NONE
             if isinstance(non_cat_agg, (rd.any, rd.max)):
                 antialias_combination = AntialiasCombination.MAX
@@ -448,9 +454,6 @@ The axis argument to Canvas.line must be 0 or 1
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")
 
             glyph.set_antialias_combination(antialias_combination)
-            print("GLYPH ANTIALIAS_COMBINATION", antialias_combination)
-
-        print("Line:", type(glyph), glyph.antialiased, glyph._line_width)
 
         return bypixel(source, self, glyph, agg, antialias=glyph.antialiased)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -448,6 +448,7 @@ The axis argument to Canvas.line must be 0 or 1
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")
 
             glyph.set_antialias_combination(antialias_combination)
+            print("GLYPH ANTIALIAS_COMBINATION", antialias_combination)
 
         print("Line:", type(glyph), glyph.antialiased, glyph._line_width)
 

--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -5,5 +5,5 @@ import cudf
 
 
 @bypixel.pipeline.register(cudf.DataFrame)
-def cudf_pipeline(df, schema, canvas, glyph, summary, antialias=False):
-    return default(glyph, df, schema, canvas, summary, antialias, cuda=True)
+def cudf_pipeline(df, schema, canvas, glyph, summary, *, antialias=False):
+    return default(glyph, df, schema, canvas, summary, antialias=antialias, cuda=True)

--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -5,5 +5,5 @@ import cudf
 
 
 @bypixel.pipeline.register(cudf.DataFrame)
-def cudf_pipeline(df, schema, canvas, glyph, summary):
-    return default(glyph, df, schema, canvas, summary, cuda=True)
+def cudf_pipeline(df, schema, canvas, glyph, summary, antialias=False):
+    return default(glyph, df, schema, canvas, summary, antialias, cuda=True)

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -18,8 +18,8 @@ __all__ = ()
 
 
 @bypixel.pipeline.register(dd.DataFrame)
-def dask_pipeline(df, schema, canvas, glyph, summary, cuda=False):
-    dsk, name = glyph_dispatch(glyph, df, schema, canvas, summary, cuda=cuda)
+def dask_pipeline(df, schema, canvas, glyph, summary, *, antialias=False, cuda=False):
+    dsk, name = glyph_dispatch(glyph, df, schema, canvas, summary, antialias=antialias, cuda=cuda)
 
     # Get user configured scheduler (if any), or fall back to default
     # scheduler for dask DataFrame
@@ -66,12 +66,12 @@ glyph_dispatch = Dispatcher()
 
 
 @glyph_dispatch.register(Glyph)
-def default(glyph, df, schema, canvas, summary, cuda=False):
+def default(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
 
     # Compile functions
     create, info, append, combine, finalize = \
-        compile_components(summary, schema, glyph, cuda=cuda)
+        compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
@@ -176,7 +176,7 @@ def default(glyph, df, schema, canvas, summary, cuda=False):
 
 
 @glyph_dispatch.register(LineAxis0)
-def line(glyph, df, schema, canvas, summary, cuda=False):
+def line(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     if cuda:
         from cudf import concat
     else:
@@ -186,7 +186,7 @@ def line(glyph, df, schema, canvas, summary, cuda=False):
 
     # Compile functions
     create, info, append, combine, finalize = \
-        compile_components(summary, schema, glyph, cuda=cuda)
+        compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)

--- a/datashader/data_libraries/dask_cudf.py
+++ b/datashader/data_libraries/dask_cudf.py
@@ -5,5 +5,5 @@ import dask_cudf
 
 
 @bypixel.pipeline.register(dask_cudf.DataFrame)
-def dask_cudf_pipeline(df, schema, canvas, glyph, summary):
-    return dask_pipeline(df, schema, canvas, glyph, summary, cuda=True)
+def dask_cudf_pipeline(df, schema, canvas, glyph, summary, *, antialias=False):
+    return dask_pipeline(df, schema, canvas, glyph, summary, antialias=antialias, cuda=True)

--- a/datashader/data_libraries/dask_xarray.py
+++ b/datashader/data_libraries/dask_xarray.py
@@ -13,8 +13,9 @@ from dask.array.overlap import overlap
 dask_glyph_dispatch = Dispatcher()
 
 
-def dask_xarray_pipeline(glyph, xr_ds, schema, canvas, summary, cuda):
-    dsk, name = dask_glyph_dispatch(glyph, xr_ds, schema, canvas, summary, cuda=cuda)
+def dask_xarray_pipeline(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=False):
+    dsk, name = dask_glyph_dispatch(
+        glyph, xr_ds, schema, canvas, summary, antialias=antialias, cuda=cuda)
 
     # Get user configured scheduler (if any), or fall back to default
     # scheduler for dask DataFrame
@@ -54,12 +55,12 @@ def shape_bounds_st_and_axis(xr_ds, canvas, glyph):
     return shape, bounds, st, axis
 
 
-def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, cuda):
+def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
     create, info, append, combine, finalize = \
-        compile_components(summary, schema, glyph, cuda=cuda)
+        compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
@@ -133,12 +134,12 @@ def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, cuda):
     return dsk, name
 
 
-def dask_raster(glyph, xr_ds, schema, canvas, summary, cuda):
+def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
     create, info, append, combine, finalize = \
-        compile_components(summary, schema, glyph, cuda=cuda)
+        compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
@@ -224,12 +225,12 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, cuda):
     return dsk, name
 
 
-def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, cuda):
+def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
     create, info, append, combine, finalize = \
-        compile_components(summary, schema, glyph, cuda=cuda)
+        compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -13,8 +13,8 @@ __all__ = ()
 
 
 @bypixel.pipeline.register(pd.DataFrame)
-def pandas_pipeline(df, schema, canvas, glyph, summary, antialias=False):
-    return glyph_dispatch(glyph, df, schema, canvas, summary, antialias)
+def pandas_pipeline(df, schema, canvas, glyph, summary, *, antialias=False):
+    return glyph_dispatch(glyph, df, schema, canvas, summary, antialias=antialias)
 
 
 glyph_dispatch = Dispatcher()
@@ -23,8 +23,9 @@ glyph_dispatch = Dispatcher()
 @glyph_dispatch.register(_PointLike)
 @glyph_dispatch.register(_GeometryLike)
 @glyph_dispatch.register(_AreaToLineLike)
-def default(glyph, source, schema, canvas, summary, antialias, cuda=False):
-    create, info, append, _, finalize = compile_components(summary, schema, glyph, cuda, antialias)
+def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=False):
+    create, info, append, _, finalize = compile_components(
+        summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -13,8 +13,8 @@ __all__ = ()
 
 
 @bypixel.pipeline.register(pd.DataFrame)
-def pandas_pipeline(df, schema, canvas, glyph, summary):
-    return glyph_dispatch(glyph, df, schema, canvas, summary)
+def pandas_pipeline(df, schema, canvas, glyph, summary, antialias=False):
+    return glyph_dispatch(glyph, df, schema, canvas, summary, antialias)
 
 
 glyph_dispatch = Dispatcher()
@@ -23,8 +23,8 @@ glyph_dispatch = Dispatcher()
 @glyph_dispatch.register(_PointLike)
 @glyph_dispatch.register(_GeometryLike)
 @glyph_dispatch.register(_AreaToLineLike)
-def default(glyph, source, schema, canvas, summary, cuda=False):
-    create, info, append, _, finalize = compile_components(summary, schema, glyph, cuda)
+def default(glyph, source, schema, canvas, summary, antialias, cuda=False):
+    create, info, append, _, finalize = compile_components(summary, schema, glyph, cuda, antialias)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)

--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -15,13 +15,15 @@ glyph_dispatch = Dispatcher()
 
 
 @bypixel.pipeline.register(xr.Dataset)
-def xarray_pipeline(xr_ds, schema, canvas, glyph, summary):
+def xarray_pipeline(xr_ds, schema, canvas, glyph, summary, *, antialias=False):
     cuda = cupy and isinstance(xr_ds[glyph.name].data, cupy.ndarray)
     if not xr_ds.chunks:
-        return glyph_dispatch(glyph, xr_ds, schema, canvas, summary, cuda)
+        return glyph_dispatch(
+            glyph, xr_ds, schema, canvas, summary, antialias=antialias, cuda=cuda)
     else:
         from datashader.data_libraries.dask_xarray import dask_xarray_pipeline
-        return dask_xarray_pipeline(glyph, xr_ds, schema, canvas, summary, cuda)
+        return dask_xarray_pipeline(
+            glyph, xr_ds, schema, canvas, summary, antialias=antialias, cuda=cuda)
 
 
 # Default to default pandas implementation

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -22,6 +22,8 @@ except Exception:
 class Glyph(Expr):
     """Base class for glyphs."""
 
+    antialiased = False
+
     @property
     def ndims(self):
         """
@@ -130,10 +132,10 @@ class Glyph(Expr):
         function
             Decorator function
         """
-        return self._expand_aggs_and_cols(append, self.ndims)
+        return self._expand_aggs_and_cols(append, self.ndims, self.antialiased)
 
     @staticmethod
-    def _expand_aggs_and_cols(append, ndims):
+    def _expand_aggs_and_cols(append, ndims, antialiased):
         if os.environ.get('NUMBA_DISABLE_JIT', None):
             # If the NUMBA_DISABLE_JIT environment is set, then we return an
             # identity decorator (one that return function unchanged).
@@ -158,10 +160,14 @@ class Glyph(Expr):
         xy_arglen = 2
 
         # We will also subtract the number of dimensions in this glyph,
-        # becuase that's how many data index arguments are passed to append
+        # because that's how many data index arguments are passed to append
         dim_arglen = (ndims or 0)
 
         # The remaining arguments are for aggregates and columns
         aggs_and_cols_len = append_arglen - xy_arglen - dim_arglen
+
+        # Antialiased append() calls also take aa_factor argument
+        if antialiased:
+            aggs_and_cols_len -= 1
 
         return expand_varargs(aggs_and_cols_len)

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -878,7 +878,7 @@ def _build_full_antialias(expand_aggs_and_cols):
                         correction = value - prev_value
                         xx, yy = (y, x) if flip_xy else (x, y)
                         append(i, xx, yy, correction, *aggs_and_cols)
-                        #if isnull(agg[yy, xx]):
+                        #if isnull(agg[yy, xx]):   # cannot be null of course as is a correction!!!!!
                         #    agg[yy, xx] = correction
                         #else:
                         #    agg[yy, xx] += correction

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -918,8 +918,12 @@ def _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols, line_width
                         antialias_combination):
     """Specialize a line plotting kernel for a given append/axis combination"""
 
-    _bresenham = _build_bresenham(expand_aggs_and_cols)
-    _full_antialias = _build_full_antialias(expand_aggs_and_cols)
+    if line_width > 0.0:
+        _bresenham = None
+        _full_antialias = _build_full_antialias(expand_aggs_and_cols)
+    else:
+        _bresenham = _build_bresenham(expand_aggs_and_cols)
+        _full_antialias = None
 
     @ngjit
     @expand_aggs_and_cols

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -862,25 +862,10 @@ def _build_full_antialias(expand_aggs_and_cols):
                     prev_distance = abs((x-x0)*prev_rightx + (y-y0)*prev_righty)
                     prev_value = 1.0 - _linearstep(0.5*(line_width - aa), halfwidth, prev_distance)
                     prev_value *= scale
-                    if value > prev_value:
-                        correction = value - prev_value
-                        xx, yy = (y, x) if flip_xy else (x, y)
-                        append(i, xx, yy, correction, *aggs_and_cols)
-                        #if isnull(agg[yy, xx]):   # cannot be null of course as is a correction!!!!!
-                        #    agg[yy, xx] = correction
-                        #else:
-                        #    agg[yy, xx] += correction
-                elif value > 0.0:
+                    value = value - prev_value  # Correction from previous segment.
+                if value > 0.0:
                     xx, yy = (y, x) if flip_xy else (x, y)
                     append(i, xx, yy, value, *aggs_and_cols)
-                    #if antialias_combination == AntialiasCombination.SUM_1AGG:
-                    #    if isnull(agg[yy, xx]):
-                    #        agg[yy, xx] = value
-                    #    else:
-                    #        agg[yy, xx] += value
-                    #else:
-                    #    if isnull(agg[yy, xx]) or value > agg[yy, xx]:
-                    #        agg[yy, xx] = value
 
     return _full_antialias
 

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1394,8 +1394,6 @@ def _build_extend_line_axis1_ragged(
         draw_segment, expand_aggs_and_cols, antialias_combination
 ):
 
-    @ngjit
-    #@expand_aggs_and_cols
     def extend_cpu(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, workspace, *aggs_and_cols
     ):
@@ -1411,7 +1409,7 @@ def _build_extend_line_axis1_ragged(
         )
 
     @ngjit
-    #@expand_aggs_and_cols
+    @expand_aggs_and_cols
     def extend_cpu_numba(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax,
             x_start_i, x_flat, y_start_i, y_flat, workspace, *aggs_and_cols
@@ -1467,8 +1465,6 @@ def _build_extend_line_axis1_ragged(
                              segment_start, segment_end, x0, x1, y0, y1,
                              xm, ym, workspace, *aggs_and_cols)
 
-    @ngjit
-    #@expand_aggs_and_cols
     def extend_cpu_antialias_2agg(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, workspace, *aggs_and_cols
     ):
@@ -1557,8 +1553,6 @@ def _build_extend_line_axis1_ragged(
 def _build_extend_line_axis1_geometry(
         draw_segment, expand_aggs_and_cols, antialias_combination
 ):
-    @ngjit
-    #@expand_aggs_and_cols
     def extend_cpu(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax,
             geometry, closed_rings, workspace, *aggs_and_cols
@@ -1590,7 +1584,7 @@ def _build_extend_line_axis1_geometry(
         )
 
     @ngjit
-    #@expand_aggs_and_cols
+    @expand_aggs_and_cols
     def extend_cpu_numba(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax,
             values, missing, offsets0, offsets1, eligible_inds,
@@ -1650,8 +1644,6 @@ def _build_extend_line_axis1_geometry(
                                  segment_start, segment_end, x0, x1, y0, y1,
                                  xm, ym, workspace, *aggs_and_cols)
 
-    @ngjit
-    #@expand_aggs_and_cols
     def extend_cpu_antialias_2agg(
             sx, tx, sy, ty, xmin, xmax, ymin, ymax,
             geometry, closed_rings, workspace, *aggs_and_cols

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -506,11 +506,11 @@ class LinesAxis1Ragged(_PointLike, _AntiAliasedLine):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
 
             xs = df[x_name].array
             ys = df[y_name].array
 
+            aggs_and_cols = aggs + info(df)
             # line may be clipped, then mapped to pixels
             extend_cpu(
                 sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, antialias, *aggs_and_cols
@@ -720,10 +720,7 @@ def _build_full_antialias(expand_aggs_and_cols):
     def _full_antialias(line_width, antialias_combination, i, x0, x1, y0, y1,
                         segment_start, segment_end, xm, ym, append,
                         nx, ny, workspace, *aggs_and_cols):
-        """Draw a line segment using Bresenham's algorithm
-        This method plots a line segment with integer coordinates onto a pixel
-        grid.
-        """
+        """Draw an antialiased line segment."""
         if x0 == x1 and y0 == y1:
             return
 
@@ -1082,7 +1079,7 @@ def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, antialias
         workspace = np.empty(8) if antialias else None
         null_value = np.nan
 
-        accum_agg = aggs_and_cols[0]   ############ Cannot do this if using expand_aggs_and_cols
+        accum_agg = aggs_and_cols[0]
         temp_agg = np.full_like(accum_agg, null_value, dtype=np.float32)
         temp_aggs_and_cols = (temp_agg,) + aggs_and_cols[1:]
 
@@ -1095,7 +1092,6 @@ def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, antialias
             for i in range(nrows - 1):
                 perform_extend_line(i, j, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
                                     plot_start, xs, ys, workspace, *temp_aggs_and_cols)
-                                    #plot_start, xs, ys, workspace, *aggs_and_cols)
 
             # Combined canvas/agg/reduction from above with the others.
             if j == 0:

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -358,6 +358,11 @@ class SelfIntersectingOptionalFieldReduction(OptionalFieldReduction):
 
         return super()._build_append(dshape, schema, cuda, antialias)
 
+    def _hashable_inputs(self):
+        # Reductions with different self_intersect attributes much have different hashes otherwise
+        # toolz.memoize will treat them as the same to give incorrect results.
+        return super()._hashable_inputs() + (self.self_intersect,)
+
 
 class count(SelfIntersectingOptionalFieldReduction):
     """Count elements in each bin, returning the result as a uint32.
@@ -702,6 +707,11 @@ class SelfIntersectingFloatingReduction(FloatingReduction):
                     return self._append_antialias_not_self_intersect
 
         return super()._build_append(dshape, schema, cuda, antialias)
+
+    def _hashable_inputs(self):
+        # Reductions with different self_intersect attributes much have different hashes otherwise
+        # toolz.memoize will treat them as the same to give incorrect results.
+        return super()._hashable_inputs() + (self.self_intersect,)
 
 
 class sum(SelfIntersectingFloatingReduction):

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -33,9 +33,9 @@ def test_draw_line_left_border(benchmark, draw_line):
     x1, y1 = (0, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
+              x0, x1, y0, y1, 0.0, 0.0, buffer, agg)
 
 
 @pytest.mark.benchmark(group="draw_line")
@@ -45,9 +45,9 @@ def test_draw_line_diagonal(benchmark, draw_line):
     x1, y1 = (n, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
+              x0, x1, y0, y1, 0.0, 0.0, buffer, agg)
 
 
 @pytest.mark.benchmark(group="draw_line")
@@ -57,6 +57,6 @@ def test_draw_line_offset(benchmark, draw_line):
     x1, y1 = (n, n//4-1)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
+              x0, x1, y0, y1, 0.0, 0.0, buffer, agg)

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -21,7 +21,7 @@ def draw_line():
     def append(i, x, y, agg):
         agg[y, x] += 1
 
-    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
     return _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols,
                                False, AntialiasCombination.NONE)
 
@@ -33,8 +33,9 @@ def test_draw_line_left_border(benchmark, draw_line):
     x1, y1 = (0, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
+    workspace = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, agg)
+              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
 
 
 @pytest.mark.benchmark(group="draw_line")
@@ -44,8 +45,9 @@ def test_draw_line_diagonal(benchmark, draw_line):
     x1, y1 = (n, n)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
+    workspace = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, agg)
+              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
 
 
 @pytest.mark.benchmark(group="draw_line")
@@ -55,5 +57,6 @@ def test_draw_line_offset(benchmark, draw_line):
     x1, y1 = (n, n//4-1)
 
     agg = np.zeros((n+1, n+1), dtype='i4')
+    workspace = np.empty(0)
     benchmark(draw_line, 0, sx, tx, sy, ty, xmin, xmax, ymin, ymax, True, True,
-              x0, x1, y0, y1, 0.0, 0.0, agg)
+              x0, x1, y0, y1, 0.0, 0.0, workspace, agg)

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -35,9 +35,9 @@ def test_extend_line_uniform(benchmark, extend_line, low, high):
     ys = np.random.uniform(xmax + low, ymax + high, n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     benchmark(
-        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg
+        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg
     )
 
 
@@ -56,7 +56,7 @@ def test_extend_line_normal(benchmark, extend_line):
     ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     benchmark(
-        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg
+        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg
     )

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -17,7 +17,7 @@ def extend_line():
 
     mapper = ngjit(lambda x: x)
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
-    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
     draw_line = _build_draw_segment(append, map_onto_pixel,
                                     expand_aggs_and_cols, False, AntialiasCombination.NONE)
     return _build_extend_line_axis0(draw_line, expand_aggs_and_cols, AntialiasCombination.NONE)[0]
@@ -35,8 +35,9 @@ def test_extend_line_uniform(benchmark, extend_line, low, high):
     ys = np.random.uniform(xmax + low, ymax + high, n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
+    workspace = np.empty(0)
     benchmark(
-        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg
+        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg
     )
 
 
@@ -55,6 +56,7 @@ def test_extend_line_normal(benchmark, extend_line):
     ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
+    workspace = np.empty(0)
     benchmark(
-        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg
+        extend_line, sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg
     )

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1435,3 +1435,26 @@ def test_trimesh_dask_partitions(npartitions):
     ], dtype='i4')
     np.testing.assert_array_equal(
         np.flipud(agg.fillna(0).astype('i4').values)[:5], sol)
+
+
+@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('reduction,dtype,aa_dtype', [
+    (ds.any(), bool, np.float32),
+    (ds.count(), np.uint32, np.float32),
+    (ds.max("f64"), np.float64, np.float64),
+    (ds.min("f64"), np.float64, np.float64),
+    (ds.sum("f64"), np.float64, np.float64),
+])
+def test_combine_dtype(ddf, reduction, dtype, aa_dtype):
+    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
+        pytest.skip("antialiased lines not supported with cudf")
+
+    cvs = ds.Canvas(plot_width=10, plot_height=10)
+
+    # Non-antialiased lines
+    agg = cvs.line(ddf, 'x', 'y', line_width=0, agg=reduction)
+    assert agg.dtype == dtype
+
+    # Antialiased lines
+    agg = cvs.line(ddf, 'x', 'y', line_width=1, agg=reduction)
+    assert agg.dtype == aa_dtype

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -53,7 +53,7 @@ map_onto_pixel_for_line = _build_map_onto_pixel_for_line(mapper, mapper)
 map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 
 # Line rasterization
-expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
 _draw_segment = _build_draw_segment(append, map_onto_pixel_for_line,
                                     expand_aggs_and_cols, 0, AntialiasCombination.NONE)
 extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols,
@@ -78,9 +78,10 @@ def draw_segment(x0, y0, x1, y1, i, segment_start, agg):
     """
     sx, tx, sy, ty = 1, 0, 1, 0
     xmin, xmax, ymin, ymax = 0, 5, 0, 5
+    workspace = np.empty(0)
     _draw_segment(
         i, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
-        segment_start, False, x0, x1, y0, y1, 0.0, 0.0, agg)
+        segment_start, False, x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
 
 
 def draw_trapezoid(x0, x1, y0, y1, y2, y3, i, trapezoid_start, stacked, agg):
@@ -195,12 +196,13 @@ def test_extend_lines():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, agg)
+    workspace = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, workspace, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = True
     out[2, 3] += 1
     agg = new_agg()
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
     np.testing.assert_equal(agg, out)
 
     xs = np.array([2, 1, 0, -1, -4, -1, -100, -1, 2])
@@ -211,7 +213,7 @@ def test_extend_lines():
                     [1, 1, 0, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
     np.testing.assert_equal(agg, out)
 
 
@@ -221,7 +223,8 @@ def test_extend_lines_all_out_of_bounds():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg)
+    workspace = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
     assert agg.sum() == 0
 
 
@@ -231,7 +234,8 @@ def test_extend_lines_nan():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg)
+    workspace = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
     out = np.diag([1, 1, 0, 1, 0])
     np.testing.assert_equal(agg, out)
 
@@ -243,7 +247,8 @@ def test_extend_lines_exact_bounds():
     agg = np.zeros((4, 4), dtype='i4')
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, agg)
+    workspace = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
     out = np.array([[2, 1, 1, 1],
                     [1, 0, 0, 1],
                     [1, 0, 0, 1],
@@ -251,7 +256,7 @@ def test_extend_lines_exact_bounds():
     np.testing.assert_equal(agg, out)
 
     agg = np.zeros((4, 4), dtype='i4')
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, workspace, agg)
     out = np.array([[1, 1, 1, 1],
                     [1, 0, 0, 1],
                     [1, 0, 0, 1],

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -78,10 +78,10 @@ def draw_segment(x0, y0, x1, y1, i, segment_start, agg):
     """
     sx, tx, sy, ty = 1, 0, 1, 0
     xmin, xmax, ymin, ymax = 0, 5, 0, 5
-    workspace = np.empty(0)
+    buffer = np.empty(0)
     _draw_segment(
         i, sx, tx, sy, ty, xmin, xmax, ymin, ymax,
-        segment_start, False, x0, x1, y0, y1, 0.0, 0.0, workspace, agg)
+        segment_start, False, x0, x1, y0, y1, 0.0, 0.0, buffer, agg)
 
 
 def draw_trapezoid(x0, x1, y0, y1, y2, y3, i, trapezoid_start, stacked, agg):
@@ -196,13 +196,13 @@ def test_extend_lines():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    workspace = np.empty(0)
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, workspace, agg)
+    buffer = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, buffer, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = True
     out[2, 3] += 1
     agg = new_agg()
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg)
     np.testing.assert_equal(agg, out)
 
     xs = np.array([2, 1, 0, -1, -4, -1, -100, -1, 2])
@@ -213,7 +213,7 @@ def test_extend_lines():
                     [1, 1, 0, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg)
     np.testing.assert_equal(agg, out)
 
 
@@ -223,8 +223,8 @@ def test_extend_lines_all_out_of_bounds():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    workspace = np.empty(0)
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
+    buffer = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg)
     assert agg.sum() == 0
 
 
@@ -234,8 +234,8 @@ def test_extend_lines_nan():
     agg = new_agg()
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    workspace = np.empty(0)
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
+    buffer = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg)
     out = np.diag([1, 1, 0, 1, 0])
     np.testing.assert_equal(agg, out)
 
@@ -247,8 +247,8 @@ def test_extend_lines_exact_bounds():
     agg = np.zeros((4, 4), dtype='i4')
     sx, tx, sy, ty = vt
     xmin, xmax, ymin, ymax = bounds
-    workspace = np.empty(0)
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, workspace, agg)
+    buffer = np.empty(0)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, True, buffer, agg)
     out = np.array([[2, 1, 1, 1],
                     [1, 0, 0, 1],
                     [1, 0, 0, 1],
@@ -256,7 +256,7 @@ def test_extend_lines_exact_bounds():
     np.testing.assert_equal(agg, out)
 
     agg = np.zeros((4, 4), dtype='i4')
-    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, workspace, agg)
+    extend_line(sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, False, buffer, agg)
     out = np.array([[1, 1, 1, 1],
                     [1, 0, 0, 1],
                     [1, 0, 0, 1],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2094,3 +2094,23 @@ def test_line_antialias_reduction_not_implemented(reduction):
 
     with pytest.raises(NotImplementedError):
         cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
+
+
+@pytest.mark.parametrize('reduction,dtype,aa_dtype', [
+    (ds.any(), bool, np.float32),
+    (ds.count(), np.uint32, np.float32),
+    (ds.max("value"), np.float64, np.float64),
+    (ds.min("value"), np.float64, np.float64),
+    (ds.sum("value"), np.float64, np.float64),
+])
+def test_reduction_dtype(reduction, dtype, aa_dtype):
+    cvs = ds.Canvas(plot_width=10, plot_height=10)
+    df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2]))
+
+    # Non-antialiased lines
+    agg = cvs.line(df, 'x', 'y', line_width=0, agg=reduction)
+    assert agg.dtype == dtype
+
+    # Antialiased lines
+    agg = cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
+    assert agg.dtype == aa_dtype

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2093,4 +2093,4 @@ def test_line_antialias_reduction_not_implemented(reduction):
     df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2]))
 
     with pytest.raises(NotImplementedError):
-        cvs.line(df, 'x', 'y', line_width=1, agg=reduction)    
+        cvs.line(df, 'x', 'y', line_width=1, agg=reduction)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -102,7 +102,7 @@ class Dispatcher(object):
     def __call__(self, head, *rest, **kwargs):
         # We dispatch first on type(head), and fall back to iterating through
         # the mro. This is significantly faster in the common case where
-        # type(head) is in the lookup, with only a small penalty on fall back.)
+        # type(head) is in the lookup, with only a small penalty on fall back.
         lk = self._lookup
         typ = type(head)
         if typ in lk:

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -102,7 +102,7 @@ class Dispatcher(object):
     def __call__(self, head, *rest, **kwargs):
         # We dispatch first on type(head), and fall back to iterating through
         # the mro. This is significantly faster in the common case where
-        # type(head) is in the lookup, with only a small penalty on fall back.
+        # type(head) is in the lookup, with only a small penalty on fall back.)
         lk = self._lookup
         typ = type(head)
         if typ in lk:


### PR DESCRIPTION
This PR modifies both the antialiased line implementation and the low level numba/dask framework code so that the former now works within the latter rather than having its own specific code path. This is necessary before:

1. Support for compound `Reduction`s with antialiased lines (issue #1133)
2. Antialiased lines on the GPU. This is part-implemented herein, but it turns out that compound `Reduction` support is needed first.

There is no functional change from the end user's point of view.

Catalogue of changes:

1. New `antialiased` kwarg for `compile_components()`, the various `make_*` functions, and the `pipeline` functions. The latter now have two optional bool args `antialias` and `cuda` so I have forced them to be kwargs to avoid potential ambiguity.
2. `Glyph` class stores a bool `antialias` attribute. This is only used within `_expand_aggs_and_cols` which is the function called when we use the `@expand_aggs_and_cols` decorator.
3. `antialias` flag passes through the various `Line` classes and line rendering functions in `line.py`.
4. `_full_antialias` now works with the `@expand_aggs_and_cols` decorator which is necessary for it to work on the GPU. 
5. `_full_antialias` takes a `workspace` which is an array (`numpy` or `cupy`) of length 8. CUDA cannot create arrays so it has to be passed in from outside the function, this should eventually (after other changes) give increased performance for all antialiased lines due to many fewer array allocations and deallocations.
6. Remove the `any_f32` and `count_f32` reductions completely.
7. Reduction classes modified so that their dtypes are not static. Now the same reduction can be used for antialiased and non-antialiased lines, and it will create the appropriately dtyped aggs and use the correct `append` functions. There are some refactors here that can be done in the future to reduce the duplication of the various `append` and `create` functions, but this PR is large enough as it is.