### PR TITLE
Refactor stage 2 aggregation for antialiased lines

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -15,7 +15,7 @@ __all__ = ['compile_components']
 
 @memoize
 def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
-    """Given a ``Aggregation`` object and a schema, return 5 sub-functions
+    """Given an ``Aggregation`` object and a schema, return 5 sub-functions
     and information on how to perform the second stage aggregation if
     antialiasing is requested,
 

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -15,7 +15,7 @@ __all__ = ['compile_components']
 
 @memoize
 def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
-    """Given a ``Aggregation`` object and a schema, return 5 sub-functions.
+    """Given a ``Aggregation`` object and a schema, return 6 sub-functions.
 
     Parameters
     ----------
@@ -46,6 +46,11 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     ``finalize(aggs)``
         Given a tuple of base numpy arrays, returns the finalized ``DataArray``
         or ``Dataset``.
+
+    ###########antialias_stage_2()``
+     ##########   If using antialiased lines, returns a tuple of the ``AntialiasCombination``
+     #########   values corresponding to the aggs. If not using antialiased lines then
+     ###########   antialias_combinations will be None so do not call.
     """
     reds = list(traverse_aggregation(agg))
 
@@ -65,7 +70,12 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     combine = make_combine(bases, dshapes, temps, antialias)
     finalize = make_finalize(bases, agg, schema, cuda)
 
-    return create, info, append, combine, finalize
+    if antialias:
+        antialias_stage_2 = make_antialias_stage_2(reds, bases)
+    else:
+        antialias_stage_2 = None
+
+    return create, info, append, combine, finalize, antialias_stage_2
 
 
 def traverse_aggregation(agg):
@@ -195,3 +205,23 @@ def make_finalize(bases, agg, schema, cuda):
         return finalize
     else:
         return agg._build_finalize(schema)
+
+
+def make_antialias_stage_2(reds, bases):
+    # Only called if antialias is True.
+
+    self_intersect = False  # Need to walk reductions for this...
+
+  #  antialias_combinations = tuple(concat(b._antialias_combination(self_intersect) for b in bases))
+    print("MAKE ANTIALIAS STAGE 2", bases)
+   # # Needs to return a function that, when called, returns the tuple....
+
+    def antialias_stage_2(cuda):
+        print("CALLED")
+        #import pdb; pdb.set_trace()
+        #a = (b._antialias_combination(self_intersect, cuda) for b in bases)
+        #ret = tuple(concat(a))
+        #return ret
+        return tuple(zip(*concat(b._antialias_stage_2(self_intersect, cuda) for b in bases)))
+
+    return antialias_stage_2

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -225,10 +225,8 @@ def make_antialias_stage_2(reds, bases):
     # Warn if requested both self_intersect=True and self_intersect=False???????
 
 
-    print("MAKE ANTIALIAS STAGE 2", bases)
 
     def antialias_stage_2(array_module):
-        print("CALLED")
         return tuple(zip(*concat(b._antialias_stage_2(self_intersect, array_module) for b in bases)))
 
     return antialias_stage_2

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -339,8 +339,7 @@ class Canvas(object):
         """
         from .glyphs import (LineAxis0, LinesAxis1, LinesAxis1XConstant,
                              LinesAxis1YConstant, LineAxis0Multi,
-                             LinesAxis1Ragged, LineAxis1Geometry,
-                             AntialiasCombination)
+                             LinesAxis1Ragged, LineAxis1Geometry)
 
         validate_xy_or_geometry('Line', x, y, geometry)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -433,27 +433,15 @@ The axis argument to Canvas.line must be 0 or 1
         glyph.antialiased = (line_width > 0)
 
         if glyph.antialiased:
-            # Eventually this should be replaced with attributes and/or
-            # member functions of Reduction classes.
+            # This is required to identify and report use of reductions that do
+            # not yet support antialiasing.
             non_cat_agg = agg
             if isinstance(non_cat_agg, rd.by):
                 non_cat_agg = non_cat_agg.reduction
 
-            antialias_combination = AntialiasCombination.NONE
-            if isinstance(non_cat_agg, (rd.any, rd.max)):
-                antialias_combination = AntialiasCombination.MAX
-            elif isinstance(non_cat_agg, rd.min):
-                antialias_combination = AntialiasCombination.MIN
-            elif isinstance(non_cat_agg, (rd.count, rd.sum)):
-                if non_cat_agg.self_intersect:
-                    antialias_combination = AntialiasCombination.SUM_1AGG
-                else:
-                    antialias_combination = AntialiasCombination.SUM_2AGG
-            else:
+            if not isinstance(non_cat_agg, (rd.any, rd.count, rd.max, rd.min, rd.sum)):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")
-
-            glyph.set_antialias_combination(antialias_combination)
 
         return bypixel(source, self, glyph, agg, antialias=glyph.antialiased)
 

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -70,11 +70,11 @@ def default(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize = \
+    create, info, append, combine, finalize, antialias_stage_2 = \
         compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     # Here be dragons
     # Get the dataframe graph
@@ -185,11 +185,11 @@ def line(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize = \
+    create, info, append, combine, finalize, antialias_stage_2 = \
         compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     def chunk(df, df2=None):
         plot_start = True

--- a/datashader/data_libraries/dask_xarray.py
+++ b/datashader/data_libraries/dask_xarray.py
@@ -59,11 +59,11 @@ def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize = \
+    create, info, append, combine, finalize, antialias_stage_2 = \
         compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     # Build chunk indices for coordinates
     chunk_inds = {}
@@ -138,11 +138,11 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize = \
+    create, info, append, combine, finalize, antialias_stage_2 = \
         compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     # Build chunk indices for coordinates
     chunk_inds = {}
@@ -229,11 +229,11 @@ def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize = \
+    create, info, append, combine, finalize, antialias_stage_2 = \
         compile_components(summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     x_coord_name = glyph.x
     y_coord_name = glyph.y

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -29,13 +29,6 @@ def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=Fal
         summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    if antialias:
-        if cuda:
-            import cupy
-            array_module = cupy
-        else:
-            array_module = np
-        antialias_stage_2 = antialias_stage_2(array_module)
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     x_range = canvas.x_range or glyph.compute_x_bounds(source)

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 
 from datashader.core import bypixel

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 
 from datashader.core import bypixel
@@ -24,11 +25,18 @@ glyph_dispatch = Dispatcher()
 @glyph_dispatch.register(_GeometryLike)
 @glyph_dispatch.register(_AreaToLineLike)
 def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=False):
-    create, info, append, _, finalize = compile_components(
+    create, info, append, _, finalize, antialias_stage_2 = compile_components(
         summary, schema, glyph, antialias=antialias, cuda=cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    if antialias:
+        if cuda:
+            import cupy
+            array_module = cupy
+        else:
+            array_module = np
+        antialias_stage_2 = antialias_stage_2(array_module)
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     x_range = canvas.x_range or glyph.compute_x_bounds(source)
     y_range = canvas.y_range or glyph.compute_y_bounds(source)

--- a/datashader/enums.py
+++ b/datashader/enums.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from enum import Enum
+
+# This Enum should eventually be replaced with attributes
+# and/or member functions of Reduction classes.
+class AntialiasCombination(Enum):
+    NONE = 0
+    SUM_1AGG = 1
+    SUM_2AGG = 2
+    MIN = 3
+    MAX = 4
+    

--- a/datashader/enums.py
+++ b/datashader/enums.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 from enum import Enum
 
 
-# This Enum should eventually be replaced with attributes
-# and/or member functions of Reduction classes.
+# Enum used to specify how the second stage aggregation is performed
+# for 2-stage antialiased lines.
 class AntialiasCombination(Enum):
-    NONE = 0        ##################### may not be needed
     SUM_1AGG = 1
     SUM_2AGG = 2
     MIN = 3

--- a/datashader/enums.py
+++ b/datashader/enums.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from enum import Enum
 
+
 # This Enum should eventually be replaced with attributes
 # and/or member functions of Reduction classes.
 class AntialiasCombination(Enum):
-    NONE = 0
+    NONE = 0        ##################### may not be needed
     SUM_1AGG = 1
     SUM_2AGG = 2
     MIN = 3
     MAX = 4
-    

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -98,7 +98,7 @@ class AreaToZeroAxis0(_PointLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -182,7 +182,7 @@ class AreaToLineAxis0(_AreaToLineLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -274,7 +274,7 @@ class AreaToZeroAxis0Multi(_PointLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -365,7 +365,7 @@ class AreaToLineAxis0Multi(_AreaToLineLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -472,7 +472,7 @@ class AreaToZeroAxis1(_PointLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -580,7 +580,7 @@ class AreaToLineAxis1(_AreaToLineLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -649,7 +649,7 @@ class AreaToZeroAxis1XConstant(AreaToZeroAxis1):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -728,7 +728,7 @@ class AreaToLineAxis1XConstant(AreaToLineAxis1):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -797,7 +797,7 @@ class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
                 self.compute_y_bounds())
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -865,7 +865,7 @@ class AreaToLineAxis1YConstant(AreaToLineAxis1):
                 self.compute_y_bounds())
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -950,7 +950,7 @@ class AreaToZeroAxis1Ragged(_PointLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(
@@ -1030,7 +1030,7 @@ class AreaToLineAxis1Ragged(_AreaToLineLike):
                 self.maybe_expand_bounds(y_extents))
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_trapezoid_y = _build_draw_trapezoid_y(

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -26,7 +26,8 @@ except Exception:
 
 
 def _two_stage_agg(antialias_stage_2):
-    if antialias_stage_2 is None:
+    """Information used to perform the correct stage 2 aggregation."""
+    if not antialias_stage_2:
         # Not using antialiased lines, doesn't matter what is returned.
         return False, False
 

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -25,15 +25,18 @@ except Exception:
     spatialpandas = None
 
 
-def _use_2_stage_agg(antialias_stage_2):
+def _two_stage_agg(antialias_stage_2):
     if antialias_stage_2 is None:
         # Not using antialiased lines, doesn't matter what is returned.
-        return False
+        return False, False
 
     if len(antialias_stage_2[0]) > 1:
         raise NotImplementedError("Currently only support single antialiased reductions")
     comb = antialias_stage_2[0][0]
-    return comb in (AntialiasCombination.SUM_2AGG, AntialiasCombination.MIN)
+
+    overwrite = comb != AntialiasCombination.SUM_1AGG
+    use_2_stage_agg = comb in (AntialiasCombination.SUM_2AGG, AntialiasCombination.MIN)
+    return overwrite, use_2_stage_agg
 
 
 class _AntiAliasedLine(object):
@@ -63,9 +66,9 @@ class LineAxis0(_PointLike, _AntiAliasedLine):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu, extend_cuda = _build_extend_line_axis0(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -152,9 +155,9 @@ class LineAxis0Multi(_PointLike, _AntiAliasedLine):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu, extend_cuda = _build_extend_line_axis0_multi(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -264,9 +267,9 @@ class LinesAxis1(_PointLike, _AntiAliasedLine):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu, extend_cuda = _build_extend_line_axis1_none_constant(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -335,9 +338,9 @@ class LinesAxis1XConstant(LinesAxis1):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu, extend_cuda = _build_extend_line_axis1_x_constant(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -407,9 +410,9 @@ class LinesAxis1YConstant(LinesAxis1):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu, extend_cuda = _build_extend_line_axis1_y_constant(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -485,9 +488,9 @@ class LinesAxis1Ragged(_PointLike, _AntiAliasedLine):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         extend_cpu = _build_extend_line_axis1_ragged(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -532,9 +535,9 @@ class LineAxis1Geometry(_GeometryLike, _AntiAliasedLine):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(
             x_mapper, y_mapper, antialias)
-        use_2_stage_agg = _use_2_stage_agg(antialias_stage_2)
+        overwrite, use_2_stage_agg = _two_stage_agg(antialias_stage_2)
         draw_segment = _build_draw_segment(
-            append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg
+            append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite
         )
         perform_extend_cpu = _build_extend_line_axis1_geometry(
             draw_segment, expand_aggs_and_cols, use_2_stage_agg
@@ -709,10 +712,16 @@ def _build_full_antialias(expand_aggs_and_cols):
     """Specialize antialiased line drawing algorithm for a given append/axis combination"""
     @ngjit
     @expand_aggs_and_cols
-    def _full_antialias(line_width, use_2_stage_agg, i, x0, x1, y0, y1,
+    def _full_antialias(line_width, overwrite, i, x0, x1, y0, y1,
                         segment_start, segment_end, xm, ym, append,
                         nx, ny, buffer, *aggs_and_cols):
-        """Draw an antialiased line segment."""
+        """Draw an antialiased line segment.
+
+        If overwrite=True can overwrite each pixel multiple times because
+        using max for the overwriting.  If False can only write each pixel
+        once per segment and its previous segment.
+        Argument xm, ym are only valid if overwrite and segment_start are False.
+        """
         if x0 == x1 and y0 == y1:
             return
 
@@ -786,12 +795,6 @@ def _build_full_antialias(expand_aggs_and_cols):
             lowindex = 0 if x0 > x1 else 1
         else:
             lowindex = 0 if x1 > x0 else 1
-
-        # If True can overwrite each pixel multiple times because using max for
-        # the overwriting.  If False can only write each pixel once per segment
-        # and its previous segment.
-        # Argument xm, ym are only valid if overwrite and segment_start are False.
-        overwrite = use_2_stage_agg
 
         if not overwrite and not segment_start:
             prev_alongx = x0 - xm
@@ -909,7 +912,7 @@ def _build_bresenham(expand_aggs_and_cols):
                 append(i, x0, y0, *aggs_and_cols)
     return _bresenham
 
-def _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols, line_width, use_2_stage_agg):
+def _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols, line_width, overwrite):
     """Specialize a line plotting kernel for a given append/axis combination"""
 
     if line_width > 0.0:
@@ -965,7 +968,7 @@ def _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols, line_width
                         sx, tx, sy, ty, xmin, xmax, ymin, ymax, xm, ym)
                 nx = round((xmax - xmin)*sx)
                 ny = round((ymax - ymin)*sy)
-                _full_antialias(line_width, use_2_stage_agg, i, x0_2, x1_2, y0_2, y1_2,
+                _full_antialias(line_width, overwrite, i, x0_2, x1_2, y0_2, y1_2,
                                 segment_start, segment_end, xm_2, ym_2, append,
                                 nx, ny, buffer, *aggs_and_cols)
             else:
@@ -1736,6 +1739,11 @@ def _build_extend_line_axis1_geometry(draw_segment, expand_aggs_and_cols, use_2_
         antialias_combinations, antialias_zeroes = antialias_stage_2
         n_aggs = len(antialias_combinations)
 
+        # This uses a different approach to the other line classes because the
+        # use of eligible_inds means we don't know which is the last polygon
+        # or how many there are without walking the eligible_inds.
+        accum_aggs = [aggs[m].copy() for m in range(n_aggs)]
+
         for i in eligible_inds:
             if missing[i]:
                 continue
@@ -1780,15 +1788,9 @@ def _build_extend_line_axis1_geometry(draw_segment, expand_aggs_and_cols, use_2_
                                  segment_start, segment_end, x0, x1, y0, y1,
                                  0.0, 0.0, buffer, *aggs_and_cols)
 
-                if j == start0:
-                    accum_aggs = [aggs[k].copy() for k in range(n_aggs)]
-                else:
-                    for k in range(n_aggs):
-                        _combine_in_place(accum_aggs[k], aggs[k], antialias_combinations[k])
-
-                if j < stop0 - 1:
-                    for k in range(n_aggs):
-                        parallel_fill(aggs[k], antialias_zeroes[k])
+            for k in range(n_aggs):
+                _combine_in_place(accum_aggs[k], aggs[k], antialias_combinations[k])
+                parallel_fill(aggs[k], antialias_zeroes[k])
 
         for k in range(n_aggs):
             aggs[k][:] = accum_aggs[k][:]

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -158,7 +158,7 @@ class Point(_PointLike):
         Column names for the x and y coordinates of each point.
     """
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         x_name = self.x
         y_name = self.y
 
@@ -228,7 +228,7 @@ class MultiPointGeometry(_GeometryLike):
         return PointDtype, MultiPointDtype
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         geometry_name = self.geometry
 
         @ngjit

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -20,7 +20,7 @@ class PolygonGeom(_GeometryLike):
         return PolygonDtype, MultiPolygonDtype
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         expand_aggs_and_cols = self.expand_aggs_and_cols(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         draw_polygon = _build_draw_polygon(

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -105,7 +105,7 @@ class QuadMeshRectilinear(_QuadMeshLike):
         return infer_interval_breaks(centers)
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         x_name = self.x
         y_name = self.y
         name = self.name
@@ -257,7 +257,7 @@ class QuadMeshRaster(QuadMeshRectilinear):
         return upsample_width, upsample_height
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         x_name = self.x
         y_name = self.y
         name = self.name
@@ -431,7 +431,7 @@ class QuadMeshCurvilinear(_QuadMeshLike):
         return breaks
 
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         x_name = self.x
         y_name = self.y
         name = self.name

--- a/datashader/glyphs/trimesh.py
+++ b/datashader/glyphs/trimesh.py
@@ -62,7 +62,7 @@ class Triangles(_PolygonLike):
         Column names of x, y, and (optional) z coordinates of each vertex.
     """
     @memoize
-    def _build_extend(self, x_mapper, y_mapper, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         draw_triangle, draw_triangle_interp = _build_draw_triangle(append)
         map_onto_pixel = _build_map_onto_pixel_for_triangle(x_mapper, y_mapper)
         extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -248,7 +248,9 @@ class Reduction(Expr):
 
     def _antialias_stage_2(self, self_intersect, array_module):
         # Only called if using antialiased lines. Overridden in derived classes.
-        raise NotImplementedError(f"{type(self)}._antialias_combination is not defined")
+        # Returns a tuple containing an item for each constituent reduction.
+        # Each item is (AntialiasCombination, zero_value)).
+        raise NotImplementedError(f"{type(self)}._antialias_stage_2 is not defined")
 
     def _build_bases(self, cuda=False):
         return (self,)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -570,6 +570,9 @@ class any(OptionalFieldReduction):
     def out_dshape(self, in_dshape, antialias):
         return dshape(ct.float32) if antialias else dshape(ct.bool_)
 
+    def _antialias_stage_2(self, self_intersect, array_module):
+        return ((AntialiasCombination.MAX, array_module.nan),)
+
     # CPU append functions
     @staticmethod
     @ngjit
@@ -735,6 +738,12 @@ class sum(SelfIntersectingFloatingReduction):
         Name of the column to aggregate over. Column data type must be numeric.
         ``NaN`` values in the column are skipped.
     """
+    def _antialias_stage_2(self, self_intersect, array_module):
+        if self_intersect:
+            return ((AntialiasCombination.SUM_1AGG, array_module.nan),)
+        else:
+            return ((AntialiasCombination.SUM_2AGG, array_module.nan),)
+
     def _build_bases(self, cuda=False):
         if cuda:
             return (_sum_zero(self.column), any(self.column))
@@ -834,6 +843,9 @@ class min(FloatingReduction):
         Name of the column to aggregate over. Column data type must be numeric.
         ``NaN`` values in the column are skipped.
     """
+    def _antialias_stage_2(self, self_intersect, array_module):
+        return ((AntialiasCombination.MIN, array_module.nan),)
+
     # CPU append functions
     @staticmethod
     @ngjit
@@ -870,6 +882,9 @@ class max(FloatingReduction):
         Name of the column to aggregate over. Column data type must be numeric.
         ``NaN`` values in the column are skipped.
     """
+    def _antialias_stage_2(self, self_intersect, array_module):
+        return ((AntialiasCombination.MAX, array_module.nan),)
+
     # CPU append functions
     @staticmethod
     @ngjit

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from datashader.glyphs import Glyph
 from datashader.glyphs.line import _build_draw_segment, \
-    _build_map_onto_pixel_for_line, AntialiasCombination
+    _build_map_onto_pixel_for_line
 from datashader.utils import ngjit
 
 mapper = ngjit(lambda x: x)
@@ -23,7 +23,7 @@ def draw_line():
 
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
     return _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols,
-                               False, AntialiasCombination.NONE)
+                               0, False)
 
 
 @pytest.mark.benchmark(group="draw_line")

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -3,8 +3,7 @@ import pytest
 
 from datashader.glyphs import Glyph
 from datashader.glyphs.line import (
-    _build_draw_segment, _build_extend_line_axis0, _build_map_onto_pixel_for_line,
-    AntialiasCombination
+    _build_draw_segment, _build_extend_line_axis0, _build_map_onto_pixel_for_line
 )
 from datashader.utils import ngjit
 
@@ -19,8 +18,8 @@ def extend_line():
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
     draw_line = _build_draw_segment(append, map_onto_pixel,
-                                    expand_aggs_and_cols, False, AntialiasCombination.NONE)
-    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols, AntialiasCombination.NONE)[0]
+                                    expand_aggs_and_cols, 0, False)
+    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols, False)[0]
 
 
 @pytest.mark.parametrize('high', [0, 10**5])

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -11,7 +11,6 @@ from datashader.glyphs.line import (
     _build_map_onto_pixel_for_line,
     _build_draw_segment,
     _build_extend_line_axis0,
-    AntialiasCombination,
 )
 from datashader.glyphs.trimesh import(
     _build_map_onto_pixel_for_triangle,
@@ -55,9 +54,8 @@ map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 # Line rasterization
 expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1, False)
 _draw_segment = _build_draw_segment(append, map_onto_pixel_for_line,
-                                    expand_aggs_and_cols, 0, AntialiasCombination.NONE)
-extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols,
-                                          AntialiasCombination.NONE)
+                                    expand_aggs_and_cols, 0, False)
+extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols, False)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)


### PR DESCRIPTION
This PR refactors the second stage aggregation for antialiased lines so that the mathematical aggregation operations are passed into the line rendering functions from the `Reduction` classes, and in such a way that multiple reductions can be supported. There is no functional change from the end users point of view.

This is the final set of changes required before issue #1133 can be implemented for antialiased lines on the CPU.

Implementation details

- An `antialias_stage_2` tuple is created from the supplied `Reductions` and passed into the line rendering functions. This tuple contains one item per `Reduction`, and each item is a 2-tuple of `AntialiasCombination` (an enum specifying the mathematical combination operator) and a `zero_value` which is the initial value of the aggregation (currently only `np.nan` but will be `0` for e.g. `_sum_zero`).