### PR TITLE
Support compound reductions for antialiased lines on the CPU

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -61,7 +61,7 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     dshapes = [b.out_dshape(schema, antialias) for b in bases]
 
     # Information on how to perform second stage aggregation of antialiased lines,
-    # including whether antialiased lines self-intersect or not as need a single
+    # including whether antialiased lines self-intersect or not as we need a single
     # value for this even for a compound reduction. This is by default True, but
     # is False if a single constituent reduction requests it.
     if antialias:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -438,7 +438,10 @@ The axis argument to Canvas.line must be 0 or 1
             if isinstance(non_cat_agg, rd.by):
                 non_cat_agg = non_cat_agg.reduction
 
-            if not isinstance(non_cat_agg, (rd.any, rd.count, rd.max, rd.min, rd.sum)):
+            if not isinstance(non_cat_agg, (
+                rd.any, rd.count, rd.max, rd.min, rd.sum, rd.summary, rd._sum_zero,
+                rd.first, rd.last, rd.mean
+            )):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")
 

--- a/datashader/enums.py
+++ b/datashader/enums.py
@@ -9,3 +9,5 @@ class AntialiasCombination(Enum):
     SUM_2AGG = 2
     MIN = 3
     MAX = 4
+    FIRST = 5
+    LAST = 6

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -585,6 +585,30 @@ def isnull(val):
 
 
 @ngjit_parallel
+def nanfirst_in_place(ret, other):
+    """First of 2 arrays but taking nans into account.
+    Return the first array.
+    """
+    ret = ret.ravel()
+    other = other.ravel()
+    for i in nb.prange(len(ret)):
+        if isnull(ret[i]) and not isnull(other[i]):
+            ret[i] = other[i]
+
+
+@ngjit_parallel
+def nanlast_in_place(ret, other):
+    """Last of 2 arrays but taking nans into account.
+    Return the first array.
+    """
+    ret = ret.ravel()
+    other = other.ravel()
+    for i in nb.prange(len(ret)):
+        if not isnull(other[i]):
+            ret[i] = other[i]
+
+
+@ngjit_parallel
 def nanmax_in_place(ret, other):
     """Max of 2 arrays but taking nans into account.  Could use np.nanmax but
     would need to replace zeros with nans where both arrays are nans.


### PR DESCRIPTION
This implements compound reductions such as `mean` and `summary` for antialiased lines on the CPU only. The only reductions not yet covered are `std` and `var`, but there is a possible solution for these being investigated. There is no support for antialiased lines on the GPU, and this will not occur soon as it requires significant changes.

Demonstration of antialiased lines and various reductions:
```python
import datashader as ds
import datashader.transfer_functions as tf
import numpy as np
import pandas as pd

df = pd.DataFrame(dict(ystart=[0.2, 0, 1, 0.8], yend=[0.2, 1, 0, 0.8], value=[1, 2, 3, 4]))

cvs = ds.Canvas(plot_width=200, plot_height=150, x_range=(-0.1, 1.1), y_range=(-0.1, 1.1))
kwargs = dict(source=df, x=np.asarray([0, 1]), y=["ystart", "yend"], axis=1, line_width=15)

for i, reduction in enumerate([
    ds.any(), ds.count(), ds.sum("value"), ds.min("value"), ds.max("value"),
    ds.first("value"), ds.last("value"), ds.mean("value")
]):
    agg = cvs.line(agg=reduction, **kwargs)
    im = tf.shade(agg, how="linear")
    ds.utils.export_image(im, f"temp{i}")
```

Output images for `any`, `count` and `sum`
![temp0](https://user-images.githubusercontent.com/580326/201693642-361ba756-ea0e-44f2-91fb-6858493a48e2.png) ![temp1](https://user-images.githubusercontent.com/580326/201693656-b37e210f-8999-412c-b293-83b510c555cb.png) ![temp2](https://user-images.githubusercontent.com/580326/201693673-cce776c9-fddd-464c-b437-93d2f26fb068.png)

`min` and `max`
![temp3](https://user-images.githubusercontent.com/580326/201693679-644377ac-ab3f-4cea-bd59-fa9f8f61a1c5.png) ![temp4](https://user-images.githubusercontent.com/580326/201693694-c9d7d6dc-90c8-4dcc-87bc-7a2a425fdf0f.png)

`first`, `last`, `mean`
![temp5](https://user-images.githubusercontent.com/580326/201693714-638afb2c-5b7a-47d2-97dc-4f880cd3b41a.png) ![temp6](https://user-images.githubusercontent.com/580326/201693737-5da95a0e-38d4-4ce2-9fb8-3c70afcdca00.png) ![temp7](https://user-images.githubusercontent.com/580326/201693755-28d5df0c-146d-4da7-8109-f643bca79094.png)

Two observations:

- Note the halos around crossing edges of `min`, `first` and `last`.
- `mean` loses the antialiased edges as it essentially performs a block fill of the pixels that would be rendered partially transparent. This is understandable from the maths of `mean = sum / count`. For a single antialiased line of a constant `value` the pixel values for `sum` equal `count * value`, hence `mean = value`. Note that this is also subject to numerical rounding (not seen here) as typically an antialiased `count` is calculated using `float32` whereas a `sum` uses `float64`.

Closes #1133.