### PR TITLE
Pin Bokeh to <3 in CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 ]
 
 examples = [
-    'bokeh',
+    'bokeh <3.0',
     'geopandas',
     'holoviews',
     'matplotlib',


### PR DESCRIPTION
CI runs are picking up Bokeh 3.0 to create examples, this pins Bokeh to < 3.