### PR TITLE
Temporarily pin ipykernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ examples = [
     'bokeh <3.0',
     'geopandas',
     'holoviews',
+    # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
+    'ipykernel <6.18.0'
     'matplotlib',
     'scikit-image',
     'spatialpandas',
@@ -57,8 +59,6 @@ extras_require = {
         ### conda only below here
         'fastparquet',
         'graphviz',
-        # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
-        'ipykernel <6.18.0'
         'python-graphviz',
         'python-snappy',
         'rasterio',

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ extras_require = {
         ### conda only below here
         'fastparquet',
         'graphviz',
+        # Issues with comm (see https://github.com/ipython/ipykernel/issues/1026)
+        'ipykernel <6.18.0'
         'python-graphviz',
         'python-snappy',
         'rasterio',


### PR DESCRIPTION
There are problems building the examples leading to problems in the docs. Trying pin of `ipykernel` as that has worked on `panel`.