### PR TITLE
Validate calculated log canvas range

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -131,8 +131,7 @@ class LogAxis(Axis):
         if range is None:
             # Nothing to check if no range
             return
-        low, high = map(self.mapper, range)
-        if not (np.isfinite(low) and np.isfinite(high)):
+        if range[0] <= 0 or range[1] <= 0:
             raise ValueError('Range values must be >0 for logarithmic axes')
 
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -128,9 +128,12 @@ class LogAxis(Axis):
         return y**val
 
     def validate(self, range):
+        if range is None:
+            # Nothing to check if no range
+            return
         low, high = map(self.mapper, range)
         if not (np.isfinite(low) and np.isfinite(high)):
-            raise ValueError('Range values must be >0 for a LogAxis')
+            raise ValueError('Range values must be >0 for logarithmic axes')
 
 
 _axis_lookup = {'linear': LinearAxis(), 'log': LogAxis()}
@@ -1219,10 +1222,13 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
             dims = [layer_dim]+dims
         return DataArray(data, coords=coords, dims=dims, attrs=attrs)
 
+    def validate_ranges(self, x_range, y_range):
+        self.x_axis.validate(x_range)
+        self.y_axis.validate(y_range)
+
     def validate(self):
         """Check that parameter settings are valid for this object"""
-        self.x_axis.validate(self.x_range)
-        self.y_axis.validate(self.y_range)
+        self.validate_ranges(self.x_range, self.y_range)
 
 
 def bypixel(source, canvas, glyph, agg, *, antialias=False):

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -46,6 +46,7 @@ def shape_bounds_st_and_axis(df, canvas, glyph):
     y_range = canvas.y_range or y_extents
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
+    canvas.validate_ranges(x_range, y_range)
 
     width = canvas.plot_width
     height = canvas.plot_height

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -32,6 +32,7 @@ def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=Fal
 
     x_range = canvas.x_range or glyph.compute_x_bounds(source)
     y_range = canvas.y_range or glyph.compute_y_bounds(source)
+    canvas.validate_ranges(x_range, y_range)
 
     width = canvas.plot_width
     height = canvas.plot_height

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1458,3 +1458,15 @@ def test_combine_dtype(ddf, reduction, dtype, aa_dtype):
     # Antialiased lines
     agg = cvs.line(ddf, 'x', 'y', line_width=1, agg=reduction)
     assert agg.dtype == aa_dtype
+
+
+@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('canvas', [
+    ds.Canvas(x_axis_type='log'),
+    ds.Canvas(x_axis_type='log', x_range=(0, 1)),
+    ds.Canvas(y_axis_type='log'),
+    ds.Canvas(y_axis_type='log', y_range=(0, 1)),
+])
+def test_log_axis_not_positive(ddf, canvas):
+    with pytest.raises(ValueError, match='Range values must be >0 for logarithmic axes'):
+        canvas.line(ddf, 'x', 'y')

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2218,3 +2218,15 @@ def test_reduction_dtype(reduction, dtype, aa_dtype):
     # Antialiased lines
     agg = cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
     assert agg.dtype == aa_dtype
+
+
+@pytest.mark.parametrize('df', dfs)
+@pytest.mark.parametrize('canvas', [
+    ds.Canvas(x_axis_type='log'),
+    ds.Canvas(x_axis_type='log', x_range=(0, 1)),
+    ds.Canvas(y_axis_type='log'),
+    ds.Canvas(y_axis_type='log', y_range=(0, 1)),
+])
+def test_log_axis_not_positive(df, canvas):
+    with pytest.raises(ValueError, match='Range values must be >0 for logarithmic axes'):
+        canvas.line(df, 'x', 'y')

--- a/datashader/tests/test_xarray.py
+++ b/datashader/tests/test_xarray.py
@@ -49,6 +49,3 @@ def test_count(source):
                        coords=coords, dims=dims)
     assert_eq(c.points(source, 'x', 'y', ds.count('f32')), out)
     assert_eq(c.points(source, 'x', 'y', ds.count('f64')), out)
-
-
-


### PR DESCRIPTION
Fixes #340, producing a sensible error message rather than an empty plot.

Previously a `Canvas` validated its `x_range` and `y_range` if they were explicitly specified by the user. But if they were calculated from the data limits, no validation occurred.