### PR TITLE
Better validate canvas.line() coordinate lengths

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-    timeout-minutes: 90
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash -l {0}

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -125,6 +125,10 @@ class LineAxis0Multi(_PointLike, _AntiAliasedLine):
         elif not all([isreal(in_dshape.measure[str(ycol)]) for ycol in self.y]):
             raise ValueError('y columns must be real')
 
+        if len(self.x) != len(self.y):
+            raise ValueError(
+                f'x and y coordinate lengths do not match: {len(self.x)} != {len(self.y)}')
+
     @property
     def x_label(self):
         return 'x'
@@ -233,6 +237,10 @@ class LinesAxis1(_PointLike, _AntiAliasedLine):
         if len(unique_y_measures) > 1:
             raise ValueError('y columns must have the same data type')
 
+        if len(self.x) != len(self.y):
+            raise ValueError(
+                f'x and y coordinate lengths do not match: {len(self.x)} != {len(self.y)}')
+
     def required_columns(self):
         return self.x + self.y
 
@@ -326,6 +334,10 @@ class LinesAxis1XConstant(LinesAxis1):
         if len(unique_y_measures) > 1:
             raise ValueError('y columns must have the same data type')
 
+        if len(self.x) != len(self.y):
+            raise ValueError(
+                f'x and y coordinate lengths do not match: {len(self.x)} != {len(self.y)}')
+
     def required_columns(self):
         return self.y
 
@@ -397,6 +409,10 @@ class LinesAxis1YConstant(LinesAxis1):
                                 for xcol in self.x)
         if len(unique_x_measures) > 1:
             raise ValueError('x columns must have the same data type')
+
+        if len(self.x) != len(self.y):
+            raise ValueError(
+                f'x and y coordinate lengths do not match: {len(self.x)} != {len(self.y)}')
 
     def required_columns(self):
         return self.x

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2230,3 +2230,30 @@ def test_reduction_dtype(reduction, dtype, aa_dtype):
 def test_log_axis_not_positive(df, canvas):
     with pytest.raises(ValueError, match='Range values must be >0 for logarithmic axes'):
         canvas.line(df, 'x', 'y')
+
+
+def test_line_coordinate_lengths():
+    # Issue #1159.
+    cvs = ds.Canvas(plot_width=10, plot_height=6)
+    msg = r'^x and y coordinate lengths do not match'
+
+    # LineAxis0Multi (axis=0) and LinesAxis1 (axis=1)
+    df = pd.DataFrame(
+        dict(x0=[0, 0.2, 1], y0=[0, 0.4, 1], x1=[0, 0.6, 1], y1=[1, 0.8, 1]))
+    for axis in (0, 1):
+        with pytest.raises(ValueError, match=msg):
+            cvs.line(source=df, x=["x0"], y=["y0", "y1"], axis=axis)
+        with pytest.raises(ValueError, match=msg):
+            cvs.line(source=df, x=["x0", "x1"], y=["y0"], axis=axis)
+
+    # LinesAxis1XConstant
+    df = pd.DataFrame(dict(y0=[0, 1, 0, 1], y1=[0, 1, 1, 0]))
+    for nx in (1, 3):
+        with pytest.raises(ValueError, match=msg):
+            cvs.line(source=df, x=np.arange(nx), y=["y0", "y1"], axis=1)
+
+    # LinesAxis1YConstant
+    df = pd.DataFrame(dict(x0=[0, 1, 0, 1], x1=[0, 1, 1, 0]))
+    for ny in (1, 3):
+        with pytest.raises(ValueError, match=msg):
+            cvs.line(source=df, x=["x0", "x1"], y=np.arange(ny), axis=1)


### PR DESCRIPTION
Fixes #1159.

This adds extra checks in the `validate()` functions of the various line classes such as `LinesAxis1XConstant` to check that the supplied `x` and `y` coordinates have the same lengths.