### PR TITLE
Where reduction using dataframe row index

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1315,6 +1315,12 @@ def _cols_to_keep(columns, glyph, agg):
                 cols_to_keep[column] = True
     elif agg.column is not None:
         cols_to_keep[agg.column] = True
+
+    #################
+    if agg.column == "rowindex":
+        cols_to_keep[agg.column] = False
+    #################
+
     return [col for col, keepit in cols_to_keep.items() if keepit]
 
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1315,12 +1315,6 @@ def _cols_to_keep(columns, glyph, agg):
                 cols_to_keep[column] = True
     elif agg.column is not None:
         cols_to_keep[agg.column] = True
-
-    #################
-    if agg.column == "rowindex":
-        cols_to_keep[agg.column] = False
-    #################
-
     return [col for col, keepit in cols_to_keep.items() if keepit]
 
 

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -78,8 +78,6 @@ def default(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
     if summary.uses_row_index() and isinstance(df, dd.DataFrame) and df.npartitions > 1:
-        print("want_row_offset")
-
         def func(partition: pd.DataFrame, cumulative_lens, partition_info=None):
             # This function is called once for each dask dataframe partition.
             # It sets the _datashader_row_offset attribute so that row indexes

--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -77,8 +77,7 @@ def default(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
 
-    want_row_offset = True   # Only if dask too, and npartitions > 1
-    if want_row_offset:
+    if summary.uses_row_index() and isinstance(df, dd.DataFrame) and df.npartitions > 1:
         print("want_row_offset")
 
         def func(partition: pd.DataFrame, cumulative_lens, partition_info=None):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1266,7 +1266,7 @@ class where(FloatingReduction):
         reduction, or ``None`` to return row indexes instead.
     """
     def __init__(self, selector: Reduction, lookup_column: str | None=None):
-        if not isinstance(selector, (max, min)):
+        if not isinstance(selector, (first, last, max, min)):
             raise TypeError("selector can only be a max or min reduction")
         super().__init__(lookup_column)
         self.selector = selector

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -236,6 +236,9 @@ class Reduction(Expr):
     def __init__(self, column=None):
         self.column = column
 
+    def uses_row_index(self):
+        return False
+
     def validate(self, in_dshape):
 
 
@@ -1274,6 +1277,9 @@ class where(FloatingReduction):
     def out_dshape(self, input_dshape, antialias):
         return self.selector.out_dshape(input_dshape, antialias)
 
+    def uses_row_index(self):
+        return self.column == "rowindex"
+
     def validate(self, in_dshape):
         super().validate(in_dshape)
         self.selector.validate(in_dshape)
@@ -1359,6 +1365,9 @@ class summary(Expr):
 
     def __hash__(self):
         return hash((type(self), tuple(self.keys), tuple(self.values)))
+
+    def uses_row_index(self):
+        return any(v.uses_row_index() for v in self.values)
 
     def validate(self, input_dshape):
         for v in self.values:

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -49,8 +49,14 @@ class extract(Preprocess):
         elif isinstance(df, xr.Dataset):
             # DataArray could be backed by numpy or cupy array
             return df[self.column].data
+        elif self.column == "rowindex":
+            row_index = df.attrs.get("_datashader_row_offset", 0)
+            ret = np.arange(row_index, row_index+len(df), dtype=np.int64)
+            print("XXX create row_index array", type(df), ret)
+            return ret
         else:
             return df[self.column].values
+
 
 class CategoryPreprocess(Preprocess):
     """Base class for categorizing preprocessors."""
@@ -231,6 +237,14 @@ class Reduction(Expr):
         self.column = column
 
     def validate(self, in_dshape):
+
+
+        ################
+        if self.column == "rowindex":
+            return
+        ################
+
+
         if not self.column in in_dshape.dict:
             raise ValueError("specified column not found")
         if not isnumeric(in_dshape.measure[self.column]):

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -189,6 +189,13 @@ def test_where_max(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('f32'), 'reverse')), out)
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('f64'), 'reverse')), out)
 
+    # Using row index.
+    out = xr.DataArray([[4, 14], [9, 19]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('i32'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('i64'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('f64'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('f32'))), out)
+
 
 @pytest.mark.parametrize('ddf',[_ddf])
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
@@ -201,6 +208,13 @@ def test_where_min(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('i64'), 'reverse')), out)
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f32'), 'reverse')), out)
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f64'), 'reverse')), out)
+
+    # Using row index.
+    out = xr.DataArray([[0, 10], [5, 15]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('i32'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('i64'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f64'))), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f32'))), out)
 
 
 @pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -209,12 +209,55 @@ def test_max(df):
 
 
 @pytest.mark.parametrize('df', dfs_pd)
+def test_where_first(df):
+    # Note reductions like ds.where(ds.first('i32'), 'reverse') are supported,
+    # but the same results can be achieved using the simpler ds.first('reverse')
+    out = xr.DataArray([[20, 10], [15, 5]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('i32'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('i64'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('f32'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('f64'), 'reverse')), out)
+
+    # Using row index.
+    out = xr.DataArray([[0, 10], [5, 15]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('i32'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('i64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('f64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.first('f32'))), out)
+
+
+@pytest.mark.parametrize('df', dfs_pd)
+def test_where_last(df):
+    # Note reductions like ds.where(ds.last('i32'), 'reverse') are supported,
+    # but the same results can be achieved using the simpler ds.last('reverse')
+    out = xr.DataArray([[16, 6], [11, 1]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('i32'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('i64'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('f32'), 'reverse')), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('f64'), 'reverse')), out)
+
+    # Using row index.
+    out = xr.DataArray([[4, 14], [9, 19]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('i32'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('i64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('f64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('f32'))), out)
+
+
+@pytest.mark.parametrize('df', dfs_pd)
 def test_where_max(df):
     out = xr.DataArray([[16, 6], [11, 1]], coords=coords, dims=dims)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('i32'), 'reverse')), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('i64'), 'reverse')), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('f32'), 'reverse')), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('f64'), 'reverse')), out)
+
+    # Using row index.
+    out = xr.DataArray([[4, 14], [9, 19]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('i32'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('i64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('f64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('f32'))), out)
 
 
 @pytest.mark.parametrize('df', dfs_pd)
@@ -224,6 +267,13 @@ def test_where_min(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('i64'), 'reverse')), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f32'), 'reverse')), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f64'), 'reverse')), out)
+
+    # Using row index.
+    out = xr.DataArray([[0, 10], [5, 15]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('i32'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('i64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f64'))), out)
+    assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f32'))), out)
 
 
 @pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
@@ -2268,10 +2318,12 @@ def test_line_antialias_where():
     (ds.max("value"), np.float64, np.float64),
     (ds.min("value"), np.float64, np.float64),
     (ds.sum("value"), np.float64, np.float64),
+    (ds.where(ds.max("value")), np.int64, np.int64),
+    (ds.where(ds.max("value"), "other"), np.float64, np.float64),
 ])
 def test_reduction_dtype(reduction, dtype, aa_dtype):
     cvs = ds.Canvas(plot_width=10, plot_height=10)
-    df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2]))
+    df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2], other=[1.2, 3.4]))
 
     # Non-antialiased lines
     agg = cvs.line(df, 'x', 'y', line_width=0, agg=reduction)
@@ -2297,8 +2349,6 @@ def test_log_axis_not_positive(df, canvas):
 @pytest.mark.parametrize('selector', [
     ds.any(),
     ds.count(),
-    ds.first('value'),
-    ds.last('value'),
     ds.mean('value'),
     ds.std('value'),
     ds.sum('value'),
@@ -2310,7 +2360,7 @@ def test_where_unsupported_selector(selector):
     cvs = ds.Canvas(plot_width=10, plot_height=10)
     df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2], ))
 
-    with pytest.raises(TypeError, match='selector can only be a max or min reduction'):
+    with pytest.raises(TypeError, match='selector can only be a first, last, max or min reduction'):
         cvs.line(df, 'x', 'y', agg=ds.where(selector, 'value'))
 
 


### PR DESCRIPTION
This is built on top of PR #1155 and ideally that should be merged first, then this rebased on top of it. I am submitting it early to run it through CI.

It supports the use of the `where` reduction without specifying the `lookup_column` argument to return an agg containing the corresponding row indexes from the pandas/dask DataFrame. The agg returned is `int64` with `-1` to represent missing values. Implementing the row index for pandas DataFrames is quite simple, for dask DataFrames the implementation is more complicated as this information is not normally available and the `index` of the DataFrame cannot be relied upon in all scenarios.

Demo code:
```python
import datashader as ds
import numpy as np
import pandas as pd

df = pd.DataFrame(dict(
    x     = [ 0,  0,  1,  1,  0,  0,  2,  2],
    y     = [ 0,  0,  0,  0,  1,  1,  1,  1],
    value = [ 9,  8,  7,  6,  2,  3,  4,  5],
    other = [11, 12, 13, 14, 15, 16, 17, 18],
    #index    0   1   2   3   4   5   6   7
))

canvas = ds.Canvas(plot_height=2, plot_width=3)

reductions = [
    ("where first index", ds.where(ds.first("value"))),
    ("where last index", ds.where(ds.last("value"))),
    ("where max index", ds.where(ds.max("value"))),
    ("where max other", ds.where(ds.max("value"), "other")),
    ("where min index", ds.where(ds.min("value"))),
    ("where min other", ds.where(ds.min("value"), "other")),
]

for name, reduction in reductions:
    agg = canvas.points(df, 'x', 'y', agg=reduction)
    print(name, agg.data.dtype)
    print(agg.data)

```
which outputs
```
where first index int64
[[ 0  2 -1]
 [ 4 -1  6]]
where last index int64
[[ 1  3 -1]
 [ 5 -1  7]]
where max index int64
[[ 0  2 -1]
 [ 5 -1  7]]
where max other float64
[[11. 13. nan]
 [16. nan 18.]]
where min index int64
[[ 1  3 -1]
 [ 4 -1  6]]
where min other float64
[[12. 14. nan]
 [15. nan 17.]]
```

`selector` reductions that `where` supports in this way are `first`, `last`, `max` and `min`. For dask DataFrames this is just `max` and `min` so far as `first` and `last` do not have any dask implementation.