### PR TITLE
Add governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+For the code of conduct, see [HoloViz/HoloViz - CODE_OF_CONDUCT.md](<https://github.com/holoviz/holoviz/blob/datashader-gov/CODE_OF_CONDUCT.md>).
+
+The Datashader Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-doc/CONTRIBUTING.md
+++ b/doc/governance/project-doc/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+For the contributing policy, see [HoloViz/HoloViz - CONTRIBUTING.md](<https://github.com/holoviz/holoviz/blob/datashader-gov/doc/governance/project-docs/CONTRIBUTING.md>).
+
+The Datashader Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-doc/GOVERNANCE.md
+++ b/doc/governance/project-doc/GOVERNANCE.md
@@ -1,0 +1,7 @@
+# Governance Policy
+
+The "Project" is herein defined as the activities related to this specific GitHub repository [Datashader](<https://github.com/holoviz/datashader>), within the `HoloViz` GitHub Organization.
+
+This Project adopts the governance specified by all of the numbered sections of [HoloViz/HoloViz - GOVERNANCE.md](<https://github.com/holoviz/holoviz/blob/datashader-gov/doc/governance/project-docs/GOVERNANCE.md>).
+
+The Datashader Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-doc/LICENSE.md
+++ b/doc/governance/project-doc/LICENSE.md
@@ -1,0 +1,3 @@
+# License
+
+For the license, see [HoloViz/Datashader - LICENSE.txt](<https://github.com/holoviz/datashader/blob/main/LICENSE.txt>).

--- a/doc/governance/project-doc/MEMBERS.md
+++ b/doc/governance/project-doc/MEMBERS.md
@@ -4,8 +4,8 @@ For member policy, see the description at the top of [HoloViz/HoloViz - MEMBERS.
 
 The Datashader Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.
 
-| **NAME** | **Role** | **GitHub Handle** | **Affiliated Organization** |
-| --- | --- | --- | --- |
-| James Bednar | Project Director | [jbednar](https://github.com/jbednar) | Anaconda, Inc |
-| Ian Thomas | Lead Maintainer | [ianthomas23](https://github.com/ianthomas23) | Anaconda, Inc |
-| Philipp Rudiger | Maintainer | [philippjfr](https://github.com/philippjfr) | Anaconda, Inc |
+| **NAME** | **Role** | **GitHub Handle** |
+| --- | --- | --- |
+| James Bednar | Project Director | [jbednar](https://github.com/jbednar) |
+| Ian Thomas | Lead Maintainer | [ianthomas23](https://github.com/ianthomas23) |
+| Philipp Rudiger | Maintainer | [philippjfr](https://github.com/philippjfr) |

--- a/doc/governance/project-doc/MEMBERS.md
+++ b/doc/governance/project-doc/MEMBERS.md
@@ -1,0 +1,11 @@
+# Maintainers
+
+For member policy, see the description at the top of [HoloViz/HoloViz - MEMBERS.md](<https://github.com/holoviz/holoviz/blob/datashader-gov/doc/governance/project-docs/MEMBERS.md>).
+
+The Datashader Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.
+
+| **NAME** | **Role** | **GitHub Handle** | **Affiliated Organization** |
+| --- | --- | --- | --- |
+| James Bednar | Project Director | [jbednar](https://github.com/jbednar) | Anaconda, Inc |
+| Ian Thomas | Lead Maintainer | [ianthomas23](https://github.com/ianthomas23) | Anaconda, Inc |
+| Philipp Rudiger | Maintainer | [philippjfr](https://github.com/philippjfr) | Anaconda, Inc |


### PR DESCRIPTION
This PR adds the initial governance docs to the datashader repo. It adopts the default HoloViz docs following the process detailed at https://github.com/holoviz/holoviz/wiki/Create-or-Update-a-HoloViz-Project-Governance.

To merge this requires the approval of the three named project members @jbednar , @philippjfr  and @ianthomas23.