### PR TITLE
CUDA support for where reduction

### DIFF
--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -85,7 +85,10 @@ def default(glyph, df, schema, canvas, summary, *, antialias=False, cuda=False):
             if partition_info is not None:
                 partition_index = partition_info["number"]
                 row_offset = cumulative_lengths[partition_index-1] if partition_index > 0 else 0
-                partition.attrs["_datashader_row_offset"] = row_offset
+                # Try to add new attribute to attrs if they exist, otherwise
+                # just set the attribute directly.
+                attrs = getattr(partition, "attrs", None)
+                setattr(attrs or partition, "_datashader_row_offset", row_offset)
             return partition
 
         cumulative_lengths = df.map_partitions(len).compute().cumsum().to_numpy()

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -177,7 +177,7 @@ def test_max(ddf):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('f64')), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_max(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -197,7 +197,7 @@ def test_where_max(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.max('f32'))), out)
 
 
-@pytest.mark.parametrize('ddf',[_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_min(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -215,12 +215,6 @@ def test_where_min(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('i64'))), out)
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f64'))), out)
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f32'))), out)
-
-
-@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
-def test_where_cuda():
-    with pytest.raises(NotImplementedError, match="where reduction not supported on CUDA"):
-        c.points(cudf_ddf, 'x', 'y', ds.where(ds.min('i32'), 'reverse'))
 
 
 @pytest.mark.parametrize('ddf', ddfs)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -244,7 +244,7 @@ def test_where_last(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.last('f32'))), out)
 
 
-@pytest.mark.parametrize('df', dfs_pd)
+@pytest.mark.parametrize('df', dfs)
 def test_where_max(df):
     out = xr.DataArray([[16, 6], [11, 1]], coords=coords, dims=dims)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('i32'), 'reverse')), out)
@@ -260,7 +260,7 @@ def test_where_max(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.max('f32'))), out)
 
 
-@pytest.mark.parametrize('df', dfs_pd)
+@pytest.mark.parametrize('df', dfs)
 def test_where_min(df):
     out = xr.DataArray([[20, 10], [15, 5]], coords=coords, dims=dims)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('i32'), 'reverse')), out)
@@ -274,12 +274,6 @@ def test_where_min(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('i64'))), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f64'))), out)
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f32'))), out)
-
-
-@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
-def test_where_cuda():
-    with pytest.raises(NotImplementedError, match="where reduction not supported on CUDA"):
-        c.points(df_cuda, 'x', 'y', ds.where(ds.min('i32'), 'reverse'))
 
 
 @pytest.mark.parametrize('df', dfs)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -584,6 +584,14 @@ def isnull(val):
     return not (val <= 0 or val > 0)
 
 
+@ngjit
+def isminus1(val):
+    """
+    Check for -1 which is equivalent to NaN for some integer aggregations
+    """
+    return val == -1
+
+
 @ngjit_parallel
 def nanfirst_in_place(ret, other):
     """First of 2 arrays but taking nans into account.


### PR DESCRIPTION
This adds CUDA support (`cudf` and `dask-cudf`) for the new `where` reduction, for both possible approaches of referencing a named column of the dataframe and using the virtual row index of the dataframe.

Support only covers `where(min)` and `where(max)`. CPU also supports `where(first)` and `where(last)` but there has never been support for `first` and `last` on the GPU due to the massively-parallel implementation not knowing the order of the dataframe rows. I note in passing that this is now feasible using the virtual row index idea as, for example, `first` is equivalent to `min` using the virtual row index. But that is future work!