### PR TITLE
Pip pyarrow in tests dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-    timeout-minutes: 120
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash -l {0}

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require = {
         'nbformat',
         'nbsmoke[verify] >0.5',
         'netcdf4',
-        'pyarrow',
+        'pyarrow <11',
         'pytest',
         'pytest-benchmark',
         'pytest-cov',


### PR DESCRIPTION
Recent release of `pyarrow 11.0.0` is causing an error when running the examples after `pip install`. The problem is actually in `spatialpandas` so will be fixed there. In the meantime, pinning `pyarrow` version here so that `examples` pass in CI.