### PR TITLE
Fix conversion from cupy in categorical rescale_discrete_levels

### DIFF
--- a/datashader/transfer_functions/__init__.py
+++ b/datashader/transfer_functions/__init__.py
@@ -489,7 +489,7 @@ def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha, rescale_d
             norm_span = norm_span[0]  # Ignore discrete_levels
 
     # Issue 1178. Convert norm_span from 2-tuple to numpy/cupy array.
-    # array_module.stack() tolerates tuple of one float and one cupy array,
+    # array_module.hstack() tolerates tuple of one float and one cupy array,
     # whereas array_module.array() does not.
     norm_span = array_module.hstack(norm_span)
 


### PR DESCRIPTION
See issue #1178.

When using `cudf`, a categorical aggregate, `how='eq_hist'` and `rescale_discrete_levels=True` then categorical shading raises an error when trying to convert a tuple that contains a `cupy` array and scalar to a `cupy` array.

The simplest possible fix would have been in `_rescale_discrete_levels()` here:
https://github.com/holoviz/datashader/blob/d8167b41577058abe01ae1b847a5178ae6ccf172/datashader/transfer_functions/__init__.py#L230-L232
by casting `lower_span` to a `float`. This is fine if `lower_span` ia a scalar or `numpy` array, but if it is a `cupy` array then this would transfer it from GPU to CPU memory, only to be pushed back to the GPU subsequently. The solution here is to convert the span from tuple to `numpy`/`cupy` array using `hstack` in `_interpolate_alpha`.

This fixes the error produced by the OP's example code, but there is still a problem in `holoviews` not displaying the categorical legend if using the GPU. I will create a separate `holoviews` issue for this.