### PR TITLE
Reduction append functions return index not boolean

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -170,7 +170,7 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
         if where_reduction:
             # where reduction needs access to the return of the contained
             # reduction, which is the preceding one here.
-            body[-2] = 'if ' + body[-2] + ':'
+            body[-2] = 'if ' + body[-2] + ' >= 0:'
             body[-1] = '    ' + body[-1]
 
     body = ['{0} = {1}[y, x]'.format(name, arg_lk[agg])


### PR DESCRIPTION
Recently the various `Reduction._append` functions were changed to return a boolean to indicate if they have performed any modification to their `agg`. This was to support the new `where` reductions that need to know if their `selector` reduction has modified anything so that they can propagate this to their own `agg` containing e.g. row index. Boolean was fine for that, but with the plan to introduce new 3D aggs such as `max_n` then a boolean is not sufficient as it needs to be the index of change in the final dimension.

This PR just changes the return from a boolean to an integer index, to confirm that it does not break anything in CI. `True` is changed to `0`, meaning index of `0` in the 3rd agg dimension, and `False` to `-1` meaning no change has occurred.