### PR TITLE
1141 | Validate canvas width, height

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1227,14 +1227,14 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         self.x_axis.validate(x_range)
         self.y_axis.validate(y_range)
 
-    def validate_extend(self, width, height):
-        if width == 0 or height == 0:
-            raise ValueError("Invalid extend plot_width and plot_height must be bigger than 0")
+    def validate_size(self, width, height):
+        if width <= 0 or height <= 0:
+            raise ValueError("Invalid size: plot_width and plot_height must be bigger than 0")
        
     def validate(self):
         """Check that parameter settings are valid for this object"""
         self.validate_ranges(self.x_range, self.y_range)
-        self.validate_extend(self.plot_width, self.plot_height)
+        self.validate_size(self.plot_width, self.plot_height)
 
 
 def bypixel(source, canvas, glyph, agg, *, antialias=False):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1229,7 +1229,7 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
 
     def validate_extend(self, width, height):
         if width == 0 or height == 0:
-            raise ValueError(f"Invalid extend plot_width and plot_height must be bigger than 0")
+            raise ValueError("Invalid extend plot_width and plot_height must be bigger than 0")
        
     def validate(self):
         """Check that parameter settings are valid for this object"""

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1227,9 +1227,14 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
         self.x_axis.validate(x_range)
         self.y_axis.validate(y_range)
 
+    def validate_extend(self, width, height):
+        if width == 0 or height == 0:
+            raise ValueError(f"Invalid extend plot_width and plot_height must be bigger than 0")
+       
     def validate(self):
         """Check that parameter settings are valid for this object"""
         self.validate_ranges(self.x_range, self.y_range)
+        self.validate_extend(self.plot_width, self.plot_height)
 
 
 def bypixel(source, canvas, glyph, agg, *, antialias=False):

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1564,3 +1564,18 @@ def test_line_antialias_where(npartitions):
             sol_where_min[j, i] = agg_where_min[j, i] = nan
 
     assert_eq_ndarray(agg_where_min.data, sol_where_min)
+
+def test_canvas_extend():
+
+    cvs_list = [
+        ds.Canvas(plot_width=0, plot_height=6),
+        ds.Canvas(plot_width=5, plot_height=0),
+        ds.Canvas(plot_width=0, plot_height=0)
+    ]
+    msg = r'Invalid extend plot_width and plot_height must be bigger than 0'
+    df = pd.DataFrame(dict(x=[0, 0.2, 1], y=[0, 0.4, 1], z=[10, 20, 30]))
+    ddf = dd.from_pandas(df, 1)
+    for cvs in cvs_list:
+        with pytest.raises(ValueError, match=msg): 
+            cvs.points(ddf, "x", "y", ds.mean("z"))
+ 

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1567,7 +1567,6 @@ def test_line_antialias_where(npartitions):
 
 
 def test_canvas_size():
-
     cvs_list = [
         ds.Canvas(plot_width=0, plot_height=6),
         ds.Canvas(plot_width=5, plot_height=0),

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1565,16 +1565,20 @@ def test_line_antialias_where(npartitions):
 
     assert_eq_ndarray(agg_where_min.data, sol_where_min)
 
-def test_canvas_extend():
+
+def test_canvas_size():
 
     cvs_list = [
         ds.Canvas(plot_width=0, plot_height=6),
         ds.Canvas(plot_width=5, plot_height=0),
-        ds.Canvas(plot_width=0, plot_height=0)
+        ds.Canvas(plot_width=0, plot_height=0),
+        ds.Canvas(plot_width=-1, plot_height=1),
+        ds.Canvas(plot_width=10, plot_height=-1)
     ]
-    msg = r'Invalid extend plot_width and plot_height must be bigger than 0'
+    msg = r'Invalid size: plot_width and plot_height must be bigger than 0'
     df = pd.DataFrame(dict(x=[0, 0.2, 1], y=[0, 0.4, 1], z=[10, 20, 30]))
     ddf = dd.from_pandas(df, 1)
+
     for cvs in cvs_list:
         with pytest.raises(ValueError, match=msg): 
             cvs.points(ddf, "x", "y", ds.mean("z"))

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2396,7 +2396,6 @@ def test_line_coordinate_lengths():
 
 
 def test_canvas_size():
-
     cvs_list = [
         ds.Canvas(plot_width=0, plot_height=6),
         ds.Canvas(plot_width=5, plot_height=0),

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2395,15 +2395,16 @@ def test_line_coordinate_lengths():
             cvs.line(source=df, x=["x0", "x1"], y=np.arange(ny), axis=1)
 
 
-
-def test_canvas_extend():
+def test_canvas_size():
 
     cvs_list = [
         ds.Canvas(plot_width=0, plot_height=6),
         ds.Canvas(plot_width=5, plot_height=0),
-        ds.Canvas(plot_width=0, plot_height=0)
+        ds.Canvas(plot_width=0, plot_height=0),
+        ds.Canvas(plot_width=-1, plot_height=1),
+        ds.Canvas(plot_width=10, plot_height=-1)
     ]
-    msg = r'Invalid extend plot_width and plot_height must be bigger than 0'
+    msg = r'Invalid size: plot_width and plot_height must be bigger than 0'
     df = pd.DataFrame(dict(x=[0, 0.2, 1], y=[0, 0.4, 1], z=[10, 20, 30]))
     
     for cvs in cvs_list:

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2393,3 +2393,20 @@ def test_line_coordinate_lengths():
     for ny in (1, 3):
         with pytest.raises(ValueError, match=msg):
             cvs.line(source=df, x=["x0", "x1"], y=np.arange(ny), axis=1)
+
+
+
+def test_canvas_extend():
+
+    cvs_list = [
+        ds.Canvas(plot_width=0, plot_height=6),
+        ds.Canvas(plot_width=5, plot_height=0),
+        ds.Canvas(plot_width=0, plot_height=0)
+    ]
+    msg = r'Invalid extend plot_width and plot_height must be bigger than 0'
+    df = pd.DataFrame(dict(x=[0, 0.2, 1], y=[0, 0.4, 1], z=[10, 20, 30]))
+    
+    for cvs in cvs_list:
+        with pytest.raises(ValueError, match=msg): 
+            cvs.points(df, "x", "y", ds.mean("z"))
+     


### PR DESCRIPTION
See issue https://github.com/holoviz/datashader/issues/1141.

When a canvas is created with plot_width=0 or plot_height=0 and the data is coming from dask, there is a core dump error, up to now, the error could just be reproduced on a machines running amd and intel. On Arm the problem does not appear. 

```
from datashader import Canvas
from datashader.reductions import mean, sum, max, min
from dask import dataframe as ddf
def main():
    df = pd.DataFrame({"LON": [0, 1, 2, 3, 4], "LAT": [0, 1, 2, 3, 4], "VALUE": [0, 1, 2, 3, 4]})
    data = ddf.from_pandas(df, npartitions=1)
    cvs = Canvas(
        plot_width=0,
        plot_height=0
    )
    cvs.points(data, "LON", "LAT", agg=max("VALUE"))
if __name__ == "__main__":
    main()
```