### PR TITLE
first_n, last_n, max_n and min_n reductions

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -164,14 +164,21 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
         if antialias:
             args.append("aa_factor")
 
-        body.append('{0}(x, y, {1})'.format(func_name, ', '.join(args)))
-
         where_reduction = len(bases) == 1 and isinstance(bases[0], where)
+        if where_reduction:
+            arg_name = 'xxx'
+            args.append(arg_name)
+
+        call  = '{0}(x, y, {1})'.format(func_name, ', '.join(args))
+
         if where_reduction:
             # where reduction needs access to the return of the contained
             # reduction, which is the preceding one here.
-            body[-2] = 'if ' + body[-2] + ' >= 0:'
-            body[-1] = '    ' + body[-1]
+            body[-1] = f'{arg_name} = {body[-1]}'
+            body.append(f'if {arg_name} >= 0:')
+            call = f'    {call}'
+
+        body.append(call)
 
     body = ['{0} = {1}[y, x]'.format(name, arg_lk[agg])
             for agg, name in local_lk.items()] + body

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -166,17 +166,16 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
 
         where_reduction = len(bases) == 1 and isinstance(bases[0], where)
         if where_reduction:
-            arg_name = 'xxx'
-            args.append(arg_name)
+            update_index_arg_name = next(names)
+            args.append(update_index_arg_name)
 
-        call  = '{0}(x, y, {1})'.format(func_name, ', '.join(args))
-
-        if where_reduction:
             # where reduction needs access to the return of the contained
             # reduction, which is the preceding one here.
-            body[-1] = f'{arg_name} = {body[-1]}'
-            body.append(f'if {arg_name} >= 0:')
-            call = f'    {call}'
+            body[-1] = f'{update_index_arg_name} = {body[-1]}'
+            body.append(f'if {update_index_arg_name} >= 0:')
+            call  = '    {0}(x, y, {1})'.format(func_name, ', '.join(args))
+        else:
+            call  = '{0}(x, y, {1})'.format(func_name, ', '.join(args))
 
         body.append(call)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -442,7 +442,7 @@ The axis argument to Canvas.line must be 0 or 1
 
             if not isinstance(non_cat_agg, (
                 rd.any, rd.count, rd.max, rd.min, rd.sum, rd.summary, rd._sum_zero,
-                rd.first, rd.last, rd.mean, rd.where
+                rd.first, rd.last, rd.mean
             )):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1312,16 +1312,19 @@ def _cols_to_keep(columns, glyph, agg):
     for col in glyph.required_columns():
         cols_to_keep[col] = True
 
-    if hasattr(agg, 'values'):
-        for subagg in agg.values:
-            if subagg.column is not None:
-                cols_to_keep[subagg.column] = True
-    elif hasattr(agg, 'columns'):
-        for column in agg.columns:
-            if column is not None:
-                cols_to_keep[column] = True
-    elif agg.column is not None:
-        cols_to_keep[agg.column] = True
+    def recurse(cols_to_keep, agg):
+        if hasattr(agg, 'values'):
+            for subagg in agg.values:
+                recurse(cols_to_keep, subagg)
+        elif hasattr(agg, 'columns'):
+            for column in agg.columns:
+                if column is not None:
+                    cols_to_keep[column] = True
+        elif agg.column is not None:
+            cols_to_keep[agg.column] = True
+
+    recurse(cols_to_keep, agg)
+
     return [col for col, keepit in cols_to_keep.items() if keepit]
 
 

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1096,11 +1096,9 @@ def _aa_stage_2_clear(aggs_and_copies, antialias_zeroes):
 
 @ngjit
 def _aa_stage_2_copy_back(aggs_and_copies):
-    k = 0
     # Numba access to heterogeneous tuples is only permitted using literal_unroll.
     for agg_and_copy in literal_unroll(aggs_and_copies):
         agg_and_copy[0][:] = agg_and_copy[1][:]
-        k += 1
 
 
 def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, use_2_stage_agg):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1672,6 +1672,17 @@ class summary(Expr):
         for v in self.values:
             v.validate(input_dshape)
 
+        # Check that any included FloatingNReductions have the same n values.
+        n_values = []
+        for v in self.values:
+            if isinstance(v, where):
+                v = v.selector
+            if isinstance(v, FloatingNReduction):
+                n_values.append(v.n)
+        if len(np.unique(n_values)) > 1:
+            raise ValueError(
+                "Using multiple FloatingNReductions with different n values is not supported")
+
     @property
     def inputs(self):
         return tuple(unique(concat(v.inputs for v in self.values)))

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1155,6 +1155,11 @@ class first(Reduction):
             return 0
         return -1
 
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'first' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
+
     @staticmethod
     def _combine(aggs):
         raise NotImplementedError("first is not implemented for dask DataFrames")
@@ -1204,6 +1209,11 @@ class last(Reduction):
             agg[y, x] = value
             return 0
         return -1
+
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'last' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
 
     @staticmethod
     def _combine(aggs):
@@ -1260,6 +1270,11 @@ class first_n(FloatingNReduction):
                     return True
         return False
 
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'first_n' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
+
     @staticmethod
     def _combine(aggs):
         raise NotImplementedError("first_n is not implemented for dask DataFrames")
@@ -1278,6 +1293,11 @@ class last_n(FloatingNReduction):
             agg[y, x, 0] = field
             return True
         return False
+
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'last_n' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
 
     @staticmethod
     def _combine(aggs):
@@ -1301,6 +1321,11 @@ class max_n(FloatingNReduction):
                     agg[y, x, i] = field
                     return True
         return False
+
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'max_n' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
 
     @staticmethod
     def _combine(aggs):
@@ -1327,6 +1352,11 @@ class min_n(FloatingNReduction):
                     agg[y, x, i] = field
                     return True
         return False
+
+    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
+        if cuda:
+            raise ValueError("'min_n' reduction is not supported on the GPU")
+        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
 
     @staticmethod
     def _combine(aggs):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -22,7 +22,10 @@ try:
 except Exception:
     cudf = cp = None
 
-from .utils import Expr, ngjit, nansum_missing, nanmax_in_place, nansum_in_place
+from .utils import (
+    Expr, ngjit, nansum_missing, nanmax_in_place, nansum_in_place,
+    nanmax_n_in_place, nanmin_n_in_place
+)
 
 
 class Preprocess(Expr):
@@ -1234,6 +1237,9 @@ class FloatingNReduction(FloatingReduction):
 
         return finalize
 
+    def _hashable_inputs(self):
+        return super()._hashable_inputs() + (self.n,)
+
 
 class first_n(FloatingNReduction):
     # CPU append functions
@@ -1298,8 +1304,10 @@ class max_n(FloatingNReduction):
 
     @staticmethod
     def _combine(aggs):
-        print("XXX _combine")
-        raise NotImplementedError
+        ret = aggs[0]
+        for i in range(1, len(aggs)):
+            nanmax_n_in_place(ret, aggs[i])
+        return ret
 
 
 class min_n(FloatingNReduction):
@@ -1322,8 +1330,10 @@ class min_n(FloatingNReduction):
 
     @staticmethod
     def _combine(aggs):
-        print("XXX _combine")
-        raise NotImplementedError
+        ret = aggs[0]
+        for i in range(1, len(aggs)):
+            nanmax_n_in_place(ret, aggs[i])
+        return ret
 
 
 class mode(Reduction):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1457,7 +1457,7 @@ class where(FloatingReduction):
         if not isinstance(selector, (first, first_n, last, last_n, max, max_n, min, min_n)):
             raise TypeError(
                 "selector can only be a first, first_n, last, last_n, "
-                "max, max_n, min or min_ reduction")
+                "max, max_n, min or min_n reduction")
         super().__init__(lookup_column)
         self.selector = selector
         # List of all column names that this reduction uses.

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -180,7 +180,7 @@ def test_max(ddf):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('f64')), out)
 
 
-@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('ddf', [_ddf])
 def test_min_n(ddf):
     solution = np.array([[[-3, -1, 0, 4, nan, nan], [-13, -11, 10, 12, 14, nan]],
                          [[-9, -7, -5, 6, 8, nan], [-19, -17, -15, 16, 18, nan]]])
@@ -192,7 +192,7 @@ def test_min_n(ddf):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.min('plusminus')).data)
 
 
-@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('ddf', [_ddf])
 def test_max_n(ddf):
     solution = np.array([[[4, 0, -1, -3, nan, nan], [14, 12, 10, -11, -13, nan]],
                          [[8, 6, -5, -7, -9, nan], [18, 16, -15, -17, -19, nan]]])

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1629,6 +1629,7 @@ def test_log_axis_not_positive(ddf, canvas):
         canvas.line(ddf, 'x', 'y')
 
 
+@pytest.mark.skip(reason='Antialised where reduction not yet supported')
 @pytest.mark.parametrize('npartitions', [1, 2, 3])
 def test_line_antialias_where(npartitions):
     x = np.arange(3)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -414,6 +414,16 @@ def test_summary_where_n(df):
     assert_eq_ndarray(agg['max_n'].data, sol_max_n_reverse)
 
 
+@pytest.mark.parametrize('df', dfs_pd)
+def test_summary_different_n(df):
+    msg = 'Using multiple FloatingNReductions with different n values is not supported'
+    with pytest.raises(ValueError, match=msg):
+        c.points(df, 'x', 'y', ds.summary(
+            min_n=ds.where(ds.min_n('plusminus', 2)),
+            max_n=ds.where(ds.max_n('plusminus', 3)),
+        ))
+
+
 @pytest.mark.parametrize('df', dfs)
 def test_mean(df):
     out = xr.DataArray(values(df.i32).reshape((2, 2, 5)).mean(axis=2, dtype='f8').T,

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2418,6 +2418,14 @@ def test_line_antialias_duplicate_points(self_intersect):
 @pytest.mark.parametrize('reduction', [
     ds.std('value'),
     ds.var('value'),
+    ds.where(ds.first('value')),
+    ds.where(ds.first_n('value')),
+    ds.where(ds.last('value')),
+    ds.where(ds.last_n('value')),
+    ds.where(ds.max('value')),
+    ds.where(ds.max_n('value')),
+    ds.where(ds.min('value')),
+    ds.where(ds.min_n('value')),
 ])
 def test_line_antialias_reduction_not_implemented(reduction):
     # Issue #1133, detect and report reductions that are not implemented.
@@ -2428,6 +2436,7 @@ def test_line_antialias_reduction_not_implemented(reduction):
         cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
 
 
+@pytest.mark.skip(reason='Antialised where reduction not yet supported')
 def test_line_antialias_where():
     x = np.arange(3)
     df = pd.DataFrame(dict(
@@ -2487,8 +2496,9 @@ def test_reduction_dtype(reduction, dtype, aa_dtype):
     assert agg.dtype == dtype
 
     # Antialiased lines
-    agg = cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
-    assert agg.dtype == aa_dtype
+    if not isinstance(reduction, ds.where):  # Antialiased ds.where not implemented")
+        agg = cvs.line(df, 'x', 'y', line_width=1, agg=reduction)
+        assert agg.dtype == aa_dtype
 
 
 @pytest.mark.parametrize('df', dfs)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2527,7 +2527,8 @@ def test_where_unsupported_selector(selector):
     cvs = ds.Canvas(plot_width=10, plot_height=10)
     df = pd.DataFrame(dict(x=[0, 1], y=[1, 2], value=[1, 2], ))
 
-    with pytest.raises(TypeError, match='selector can only be a first, last, max or min reduction'):
+    with pytest.raises(TypeError, match='selector can only be a first, first_n, last, last_n, '
+                                        'max, max_n, min or min_n reduction'):
         cvs.line(df, 'x', 'y', agg=ds.where(selector, 'value'))
 
 

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -303,6 +303,86 @@ def test_where_min(df):
 
 
 @pytest.mark.parametrize('df', dfs)
+def test_where_first_n(df):
+    sol_rowindex = np.array([[[ 0,  1,  3,  4, -1, -1],
+                              [10, 11, 12, 13, 14, -1]],
+                             [[ 5,  6,  7,  8,  9, -1],
+                              [15, 16, 17, 18, 19, -1]]])
+    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+
+    for n in range(1, 7):
+        # Using row index.
+        agg = c.points(df, 'x', 'y', ds.where(ds.first_n('plusminus', n=n)))
+        out = sol_rowindex[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+        # Using another column
+        agg = c.points(df, 'x', 'y', ds.where(ds.first_n('plusminus', n=n), 'reverse'))
+        out = sol_reverse[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+
+@pytest.mark.parametrize('df', dfs)
+def test_where_last_n(df):
+    sol_rowindex = np.array([[[ 4,  3,  1,  0, -1, -1],
+                              [14, 13, 12, 11, 10, -1]],
+                             [[ 9,  8,  7,  6,  5, -1],
+                              [19, 18, 17, 16, 15, -1]]])
+    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+
+    for n in range(1, 7):
+        # Using row index.
+        agg = c.points(df, 'x', 'y', ds.where(ds.last_n('plusminus', n=n)))
+        out = sol_rowindex[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+        # Using another column
+        agg = c.points(df, 'x', 'y', ds.where(ds.last_n('plusminus', n=n), 'reverse'))
+        out = sol_reverse[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+
+@pytest.mark.parametrize('df', dfs)
+def test_where_max_n(df):
+    sol_rowindex = np.array([[[ 4,  0,  1,  3, -1, -1],
+                              [14, 12, 10, 11, 13, -1]],
+                             [[ 8,  6,  5,  7,  9, -1],
+                              [18, 16, 15, 17, 19, -1]]])
+    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+
+    for n in range(1, 7):
+        # Using row index.
+        agg = c.points(df, 'x', 'y', ds.where(ds.max_n('plusminus', n=n)))
+        out = sol_rowindex[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+        # Using another column
+        agg = c.points(df, 'x', 'y', ds.where(ds.max_n('plusminus', n=n), 'reverse'))
+        out = sol_reverse[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+
+@pytest.mark.parametrize('df', dfs)
+def test_where_min_n(df):
+    sol_rowindex = np.array([[[3,  1,  0,  4, -1, -1],
+                              [13, 11, 10, 12, 14, -1]],
+                             [[ 9,  7,  5,  6,  8, -1],
+                              [19, 17, 15, 16, 18, -1]]])
+    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+
+    for n in range(1, 7):
+        # Using row index.
+        agg = c.points(df, 'x', 'y', ds.where(ds.min_n('plusminus', n=n)))
+        out = sol_rowindex[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+        # Using another column
+        agg = c.points(df, 'x', 'y', ds.where(ds.min_n('plusminus', n=n), 'reverse'))
+        out = sol_reverse[:, :, :n]
+        assert_eq_ndarray(agg.data, out)
+
+
+@pytest.mark.parametrize('df', dfs)
 def test_mean(df):
     out = xr.DataArray(values(df.i32).reshape((2, 2, 5)).mean(axis=2, dtype='f8').T,
                        coords=coords, dims=dims)


### PR DESCRIPTION
This is further work on improved inspection reductions (issue #1126) to add `first_n`, `last_n`, `max_n` and `min_n` reductions. Each accepts a column name and value for `n`, the number of results to return for each pixel. For example, `max("value", n=3)` will return a DataArray of shape `(ny, nx, n)` containing the 3 highest values of column `"value"` for each pixel.

Demo code using these within a `where` reduction to return corresponding row indexes or values from a different column:
```python
import datashader as ds
import pandas as pd

df = pd.DataFrame(dict(
    x     = [ 0,  0,  1,  1,  0,  0,  2,  2],
    y     = [ 0,  0,  0,  0,  1,  1,  1,  1],
    value = [ 9,  8,  7,  6,  2,  3,  4,  5],
    other = [11, 12, 13, 14, 15, 16, 17, 18],
    #index    0   1   2   3   4   5   6   7
))

canvas = ds.Canvas(plot_height=2, plot_width=3)

reductions = [
    ("where first_n index", ds.where(ds.first_n("value", 3))),
    ("where first_n other", ds.where(ds.first_n("value", 3), "other")),
    ("where max_n index", ds.where(ds.max_n("value", 3))),
    ("where max_n other", ds.where(ds.max_n("value", 3), "other")),
]

for name, reduction in reductions:
    agg = canvas.points(df, 'x', 'y', agg=reduction)
    print(name, agg.data.dtype)
    print(agg.data)
```
which outputs
```
where first_n index int64
[[[ 0  1 -1]
  [ 2  3 -1]
  [-1 -1 -1]]

 [[ 4  5 -1]
  [-1 -1 -1]
  [ 6  7 -1]]]
where first_n other float64
[[[11. 12. nan]
  [13. 14. nan]
  [nan nan nan]]

 [[15. 16. nan]
  [nan nan nan]
  [17. 18. nan]]]
where max_n index int64
[[[ 0  1 -1]
  [ 2  3 -1]
  [-1 -1 -1]]

 [[ 5  4 -1]
  [-1 -1 -1]
  [ 7  6 -1]]]
where max_n other float64
[[[11. 12. nan]
  [13. 14. nan]
  [nan nan nan]]

 [[16. 15. nan]
  [nan nan nan]
  [18. 17. nan]]]
```
where, as usual, `-1` means no row index and `nan` means no data to return.

This allows us to do some complicated combinations such as
```python
ds.summary(
    count=ds.count(),
    min_n=ds.where(ds.min_n("value", n=3)),
    max_n=ds.where(ds.max_n("value", n=3)),
)
```
to return `count` plus `min_n` and `max_n` (or `first_n` and `last_n`) in a single datashader pass.

`max_n` and `min_n` work with dask but not CUDA (issue #1177 needs to be solved for that). `first_n` and `last_n` only work on the CPU and without dask, the same as `first` and `last` (#1177 and #1182 are needed to fix that).

Using antialiased lines the results looked OK in some situation and not others, so I am raising a `NotImplemented` error for all of these when using with antialiasing and I will separately consider what is reasonable behaviour here. This includes `where(first_n)` and so on as well.

There is one issue here that needs deciding. I've called the third dimension of the DataArray returned by such a reduction `"n"` to fit in with the names `first_n`, etc. You can put multiple `whatever_n` reductions in a single `summary` reduction as shown above. If they have the same `n` then it all works out as expected. But we need a policy on labelling the third dimension if the `whatever_n` have different `n` values. We could keep the first `n` as `n`, and if subsequent `n` values are different call them `n1`, `n2`, etc?