### PR TITLE
Show reduction class support in docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -92,6 +92,20 @@ Reductions
    var
    where
 
+The table below indicates which ``Reduction`` classes are supported on the CPU (e.g. using
+``pandas``), on CPU with Dask (e.g. using ``dask.dataframe``), on the GPU (e.g. using ``cudf``),
+and on the GPU with Dask (e.g. using ``dask-cudf``). The final two columns indicate which reductions
+support antialiased lines and which can be used as the ``selector`` in a
+:class:`~datashader.reductions.where` reduction.
+
+.. csv-table::
+   :file: reduction.csv
+   :header-rows: 1
+
+The :class:`~datashader.reductions.mode` reduction is not listed in the table and can only be used
+with ``Canvas.raster``. A :class:`~datashader.reductions.by` reduction supports anything that its
+contained reduction (that is applied separately to each category) supports.
+
 **Categorizers**
 
 .. autosummary::

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -1,0 +1,16 @@
+,                                        CPU, CPU + Dask, GPU, GPU + Dask, Antialiasing, Within :class:`~datashader.reductions.where`
+:class:`~datashader.reductions.any`,     yes, yes,        yes, yes,        yes,          
+:class:`~datashader.reductions.by`,      yes, yes,        yes, yes,        yes,
+:class:`~datashader.reductions.count`,   yes, yes,        yes, yes,        yes,
+:class:`~datashader.reductions.first`,   yes, ,           ,    ,           yes,          yes
+:class:`~datashader.reductions.first_n`, yes, ,           ,    ,           ,             yes
+:class:`~datashader.reductions.last`,    yes, ,           ,    ,           yes,          yes
+:class:`~datashader.reductions.last_n`,  yes, ,           ,    ,           ,             yes
+:class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
+:class:`~datashader.reductions.max_n`,   yes, yes,        ,    ,           ,             yes
+:class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,
+:class:`~datashader.reductions.min`,     yes, yes,        yes, yes,        yes,          yes
+:class:`~datashader.reductions.min_n`,   yes, yes,        ,    ,           ,             yes
+:class:`~datashader.reductions.std`,     yes, yes,        ,    ,           ,
+:class:`~datashader.reductions.sum`,     yes, yes,        yes, yes,        yes,
+:class:`~datashader.reductions.var`,     yes, yes,        ,    ,           ,


### PR DESCRIPTION
This PR adds a table to the API page in the docs that indicates which `Reduction` classes are supported using Dask and/or GPU and which support antialiasing and so on. The appearance is quite simple, my aim is to get this documentation available for users and contributors as soon as possible, and later on when we refactor the docs we can improve its appearance and think more about where it should be located.

This is what the rendered output looks like:

<img width="869" alt="Screenshot 2023-02-23 at 12 28 24" src="https://user-images.githubusercontent.com/580326/220907240-1c46fdae-9948-4f1c-ac35-2e6af4c3eee1.png">