### PR TITLE
Fix python 3.7 CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - os: 'windows-latest'
+            python-version: "3.7"
     timeout-minutes: 180
     defaults:
       run:
@@ -106,3 +109,38 @@ jobs:
       - name: codecov
         run: |
           codecov
+
+  test_pip_manual:
+    name: Pip manual tests on windows using python 3.7
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest']
+        python-version: ["3.7"]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip and setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install datashader
+        run: |
+          python -m pip install -ve .
+      - name: Manually install test dependencies
+        run: |
+          # Exclude rasterio and rioxarray
+          # netcdf4 by default gives 1.6.2 which is an sdist not wheel.
+          python -m pip install netcdf4==1.5.8 pyarrow pytest pytest-benchmark spatialpandas
+          python -m pip list
+      - name: Run tests
+        run: |
+          python -m pytest -v datashader/tests
+        env:
+          NUMBA_DISABLE_JIT: 1


### PR DESCRIPTION
Python 3.7 windows CI is failing as `mamba` cannot resolve the dependencies. A number of dependent packages have stopped support for 3.7. Here I am removing that particular CI run from the `pyctdev`/`holoviz_tasks` `conda`-based run and replaced them with a `pip` equivalent which is much easier to control.