### PR TITLE
Try with hdf5 pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require = {
     ]
 }
 
-if sys.platform in ("win32", "cygwin") and sys.version_info < (3, 8):
+if sys.version_info < (3, 8):
     extras_require['tests'] += ["hdf5 ==1.12.1"]  # To be able to solve on mamba
 
 extras_require['doc'] = extras_require['examples_extra'] + [

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ extras_require = {
 }
 
 if sys.platform in ("win32", "cygwin") and sys.version_info < (3, 8):
-    extras_require['tests'] = "hdf5 ==1.12.1"  # To be able to solve on mamba
+    extras_require['tests'] += ["hdf5 ==1.12.1"]  # To be able to solve on mamba
 
 extras_require['doc'] = extras_require['examples_extra'] + [
     'nbsite >=0.7.1',

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ extras_require = {
     ]
 }
 
+if sys.platform in ("win32", "cygwin") and sys.version_info < (3, 8):
+    extras_require['tests'] = "hdf5 ==1.12.1"  # To be able to solve on mamba
+
 extras_require['doc'] = extras_require['examples_extra'] + [
     'nbsite >=0.7.1',
     'numpydoc',


### PR DESCRIPTION
This seems to have been the culprit for the no-solve. 

The steps I took to find out this package created the problem.

1) create an environment:
``` bash
mamba create -n tmp35 python=3.7 pyctdev -c pyviz/label/dev  -c conda-forge -c nodefaults
mamba activate tmp35
mamba install -y  "param" "pyct" "setuptools" -c pyviz/label/dev  -c conda-forge -c nodefaults
```
2)  Trying to run the same code as the CI, wich gave the no solve.
``` bash
mamba install   "colorcet" "dask-core" "datashape" "numba >=0.51" "numpy" "pandas" "param" "pillow" "pyct" "requests" "scipy" "toolz" "xarray" "codecov" "fastparquet" "flake8" "nbconvert" "nbformat" "nbsmoke >0.5" "netcdf4" "pyarrow <11" "pytest" "pytest-benchmark" "pytest-cov" "rasterio" "rioxarray" "spatialpandas" "bokeh <3.0" "geopandas" "holoviews" "matplotlib" "scikit-image" "spatialpandas"  -c pyviz/label/dev  -c conda-forge -c nodefaults --dry-run --offline
```

3) I removed all the geo-related packages, which could solve.
``` bash
mamba install   "colorcet" "dask-core" "datashape" "numba >=0.51" "numpy" "pandas" "param" "pillow" "pyct" "requests" "scipy" "toolz" "xarray" "codecov" "fastparquet" "flake8" "nbconvert" "nbformat" "nbsmoke >0.5" "netcdf4" "pyarrow <11" "pytest" "pytest-benchmark" "pytest-cov" "bokeh <3.0" "holoviews" "matplotlib" "scikit-image"   -c pyviz/label/dev  -c conda-forge -c nodefaults
```
4) Installed the geo-packages, which could solve, but gave these downgrades:
![ Screenshot 2023-02-27 10 11 43](https://user-images.githubusercontent.com/19758978/221556481-ee1bbfca-f7bc-44d5-b749-79d3373501c5.png)

5) I Tried to pin the downgrades one at a time and saw that `hdf5` was a problem.
