### PR TITLE
Add docs on first_n, last_n, max_n and min_n

### DIFF
--- a/examples/user_guide/12_Inspection_Reductions.ipynb
+++ b/examples/user_guide/12_Inspection_Reductions.ipynb
@@ -98,13 +98,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. `max` and `min` selection reductions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "## 2. `max` and `min` selection reductions\n",
+    "\n",
     "A `max` selection reduction returns, for each pixel in the canvas, the maximum value of the specified column of all rows that map to that pixel. For example:"
    ]
   },
@@ -134,10 +129,36 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. `where` selection reductions\n",
+    "## 3. `first_n`, `last_n`, `max_n` and `min_n` selection reductions\n",
+    "\n",
+    "These provide the same functionality as `first`, `last`, `max` and `min` reductions except that they return multiple values per pixel. For example, the `max_n` reduction with `n=3` returns the 3 largest values, in descending order, for each pixel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvas.points(df, 'x', 'y', ds.max_n('value', n=3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The returned `xarray.DataArray` has shape `(ny, nx, n)` which is `(2, 3, 3)` in this example. The third dimension contains the maximum `n` values in order for each pixel, and where there are fewer than `n` values available `nan` is used instead as usual."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `where` selection reductions\n",
     "\n",
     "A `where` reduction takes two arguments, a `selector` reduction and a `lookup_column` name. The `selector` reduction, such as a `first` or `max`, selects which row of the dataset to return information about for each pixel. But the information returned is that from the `lookup_column` rather than the column used by the `selector`.\n",
     "\n",
@@ -174,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. `where` selection reductions returning a row index\n",
+    "## 5. `where` selection reductions returning a row index\n",
     "\n",
     "The `lookup_column` argument to `where` is optional. If not specified, `where` defaults to returning the index of the row in the dataset corresponding to the `selector` for each pixel."
    ]
@@ -205,11 +226,28 @@
    "source": [
     "canvas.points(df, 'x', 'y', ds.where(ds.first('value')))"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`where` reductions can also use a `selector` that is a `first_n`, `last_n`, `max_n` or `min_n` reduction, for example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "canvas.points(df, 'x', 'y', ds.where(ds.first_n('value', 3)))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -223,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds information on `first_n`, `last_n`, `max_n` and `min_n` reductions to the Inspection Reductions user guide page.