### PR TITLE
Remove fsspec version pin for python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ extras_require = {
 
 if sys.version_info < (3, 8):
     extras_require['tests'] += [
-        "fsspec ==2023.1",  # Bad conda-forge fsspec 2023.3.0 release
         "hdf5 ==1.12.1",  # To be able to solve on mamba
     ]
 


### PR DESCRIPTION
This reverts #1191 as `fsspec` on `conda-forge` now contains the correct version information.