### PR TITLE
Support max_n and min_n reductions on GPU

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -146,7 +146,7 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
     if any_uses_cuda_mutex:
         # This adds an argument to the append() function that is the cuda mutex
         # generated in make_info.
-        inputs += [True]  # Doesn't matter what is in the list.
+        inputs += ["_cuda_mutex"]
     signature = [next(names) for i in inputs]
     arg_lk = dict(zip(inputs, signature))
     local_lk = {}
@@ -179,7 +179,7 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
             args.append("aa_factor")
 
         if uses_cuda_mutex:
-            args.append(signature[-1])
+            args.append(arg_lk["_cuda_mutex"])
 
         where_reduction = len(bases) == 1 and isinstance(bases[0], where)
         if where_reduction:

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -76,7 +76,7 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
         self_intersect = False
         antialias_stage_2 = False
 
-    # List of tuples of (append, base, input columns, temps, combine temps)
+    # List of tuples of (append, base, input columns, temps, combine temps, uses cuda mutex)
     calls = [_get_call_tuples(b, d, schema, cuda, antialias, self_intersect)
              for (b, d) in zip(bases, dshapes)]
 
@@ -87,8 +87,8 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False):
     combine_temps = list(pluck(4, calls))
 
     create = make_create(bases, dshapes, cuda)
-    info = make_info(cols)
-    append = make_append(bases, cols, calls, glyph, isinstance(agg, by), antialias)
+    append, uses_cuda_mutex = make_append(bases, cols, calls, glyph, isinstance(agg, by), antialias)
+    info = make_info(cols, uses_cuda_mutex)
     combine = make_combine(bases, dshapes, temps, combine_temps, antialias, cuda)
     finalize = make_finalize(bases, agg, schema, cuda)
 
@@ -113,6 +113,7 @@ def _get_call_tuples(base, dshape, schema, cuda, antialias, self_intersect):
         base.inputs,  # cols
         base._build_temps(cuda),  # temps
         base._build_combine_temps(cuda),  # combine temps
+        cuda and base.uses_cuda_mutex(),  # uses cuda mutex
     )
 
 
@@ -126,13 +127,26 @@ def make_create(bases, dshapes, cuda):
     return lambda shape: tuple(c(shape, array_module) for c in creators)
 
 
-def make_info(cols):
-    return lambda df: tuple(c.apply(df) for c in cols)
+def make_info(cols, uses_cuda_mutex):
+    def info(df):
+        ret = tuple(c.apply(df) for c in cols)
+        if uses_cuda_mutex:
+            import cupy  # Guaranteed to be available if uses_cuda_mutex is True
+            mutex_array = cupy.zeros((1,), dtype=np.uint32)
+            ret += (mutex_array,)
+        return ret
+
+    return info
 
 
 def make_append(bases, cols, calls, glyph, categorical, antialias):
     names = ('_{0}'.format(i) for i in count())
     inputs = list(bases) + list(cols)
+    any_uses_cuda_mutex = any(call[5] for call in calls)
+    if any_uses_cuda_mutex:
+        # This adds an argument to the append() function that is the cuda mutex
+        # generated in make_info.
+        inputs += [True]  # Doesn't matter what is in the list.
     signature = [next(names) for i in inputs]
     arg_lk = dict(zip(inputs, signature))
     local_lk = {}
@@ -144,7 +158,7 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
     else:
         subscript = None
 
-    for func, bases, cols, temps, _ in calls:
+    for func, bases, cols, temps, _, uses_cuda_mutex in calls:
         local_lk.update(zip(temps, (next(names) for i in temps)))
         func_name = next(names)
         namespace[func_name] = func
@@ -163,6 +177,9 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
         args.extend([local_lk[i] for i in temps])
         if antialias:
             args.append("aa_factor")
+
+        if uses_cuda_mutex:
+            args.append(signature[-1])
 
         where_reduction = len(bases) == 1 and isinstance(bases[0], where)
         if where_reduction:
@@ -200,7 +217,7 @@ def make_append(bases, cols, calls, glyph, categorical, antialias):
                 '    {2}'
                 ).format(subscript, ', '.join(signature), '\n    '.join(body))
     exec(code, namespace)
-    return ngjit(namespace['append'])
+    return ngjit(namespace['append']), any_uses_cuda_mutex
 
 
 def make_combine(bases, dshapes, temps, combine_temps, antialias, cuda):

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -106,8 +106,12 @@ def assert_eq_xr(agg, b, close=False):
 def assert_eq_ndarray(data, b, close=False):
     """Assert that two ndarrays are equal, handling the possibility that the
     ndarrays are of different types"""
-    if cupy and isinstance(data, cupy.ndarray):
-        data = cupy.asnumpy(data)
+    if cupy:
+        if isinstance(data, cupy.ndarray):
+            data = cupy.asnumpy(data)
+        if isinstance(b, cupy.ndarray):
+            b = cupy.asnumpy(b)
+
     if close:
         np.testing.assert_array_almost_equal(data, b, decimal=5)
     else:

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -210,7 +210,7 @@ def test_max(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.max('f64')), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs_pd)
 def test_min_n(df):
     solution = np.array([[[-3, -1, 0, 4, nan, nan], [-13, -11, 10, 12, 14, nan]],
                          [[-9, -7, -5, 6, 8, nan], [-19, -17, -15, 16, 18, nan]]])
@@ -222,7 +222,7 @@ def test_min_n(df):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(df, 'x', 'y', ds.min('plusminus')).data)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs_pd)
 def test_max_n(df):
     solution = np.array([[[4, 0, -1, -3, nan, nan], [14, 12, 10, -11, -13, nan]],
                          [[8, 6, -5, -7, -9, nan], [18, 16, -15, -17, -19, nan]]])
@@ -2601,14 +2601,10 @@ def test_canvas_size():
     ds.first_n('f64', n=3),
     ds.last('f64'),
     ds.last_n('f64', n=3),
-    ds.max_n('f64', n=3),
-    ds.min_n('f64', n=3),
     ds.where(ds.first('f64')),
     ds.where(ds.first_n('f64', n=3)),
     ds.where(ds.last('f64')),
     ds.where(ds.last_n('f64', n=3)),
-    ds.where(ds.max_n('f64', n=3)),
-    ds.where(ds.min_n('f64', n=3)),
 ])
 def test_reduction_on_cuda_raises_error(reduction):
     with pytest.raises(ValueError, match="not supported on the GPU"):

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -171,3 +171,16 @@ def interp2d_kernel(x, xp, fp, left, right, output_y):
 
             # Update output
             output_y[i, j] = y_interp
+
+
+@cuda.jit(device=True)
+def cuda_mutex_lock(mutex, index):
+    while cuda.atomic.compare_and_swap(mutex, 0, 1) != 0:
+          pass
+    cuda.threadfence()
+
+
+@cuda.jit(device=True)
+def cuda_mutex_unlock(mutex, index):
+    cuda.threadfence()
+    cuda.atomic.exch(mutex, 0, 0)

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -184,3 +184,59 @@ def cuda_mutex_lock(mutex, index):
 def cuda_mutex_unlock(mutex, index):
     cuda.threadfence()
     cuda.atomic.exch(mutex, 0, 0)
+
+
+@cuda.jit
+def cuda_nanmax_n_in_place(ret, other):
+    """CUDA equivalent of nanmax_n_in_place.
+    """
+    ny, nx, n = ret.shape
+    x, y = cuda.grid(2)
+    if x < nx and y < ny:
+        ret_pixel = ret[y, x]      # 1D array of n values for single pixel
+        other_pixel = other[y, x]  # ditto
+        # Walk along other_pixel array a value at a time, find insertion
+        # index in ret_pixel and bump values along to insert.  Next
+        # other_pixel value is inserted at a higher index, so this walks
+        # the two pixel arrays just once each.
+        istart = 0
+        for other_value in other_pixel:
+            if isnan(other_value):
+                break
+
+            for i in range(istart, n):
+                if isnan(ret_pixel[i]) or other_value > ret_pixel[i]:
+                    # Bump values along then insert.
+                    for j in range(n-1, i, -1):
+                        ret_pixel[j] = ret_pixel[j-1]
+                    ret_pixel[i] = other_value
+                    istart = i+1
+                    break
+
+
+@cuda.jit
+def cuda_nanmin_n_in_place(ret, other):
+    """CUDA equivalent of nanmin_n_in_place.
+    """
+    ny, nx, n = ret.shape
+    x, y = cuda.grid(2)
+    if x < nx and y < ny:
+        ret_pixel = ret[y, x]      # 1D array of n values for single pixel
+        other_pixel = other[y, x]  # ditto
+        # Walk along other_pixel array a value at a time, find insertion
+        # index in ret_pixel and bump values along to insert.  Next
+        # other_pixel value is inserted at a higher index, so this walks
+        # the two pixel arrays just once each.
+        istart = 0
+        for other_value in other_pixel:
+            if isnan(other_value):
+                break
+
+            for i in range(istart, n):
+                if isnan(ret_pixel[i]) or other_value < ret_pixel[i]:
+                    # Bump values along then insert.
+                    for j in range(n-1, i, -1):
+                        ret_pixel[j] = ret_pixel[j-1]
+                    ret_pixel[i] = other_value
+                    istart = i+1
+                    break

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -7,10 +7,10 @@
 :class:`~datashader.reductions.last`,    yes, ,           ,    ,           yes,          yes
 :class:`~datashader.reductions.last_n`,  yes, ,           ,    ,           ,             yes
 :class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.max_n`,   yes, yes,        yes, ,           ,             yes
+:class:`~datashader.reductions.max_n`,   yes, yes,        yes, yes,        ,             yes
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.min`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.min_n`,   yes, yes,        yes, ,           ,             yes
+:class:`~datashader.reductions.min_n`,   yes, yes,        yes, yes,        ,             yes
 :class:`~datashader.reductions.std`,     yes, yes,        ,    ,           ,
 :class:`~datashader.reductions.sum`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.var`,     yes, yes,        ,    ,           ,

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -1,5 +1,5 @@
 ,                                        CPU, CPU + Dask, GPU, GPU + Dask, Antialiasing, Within :class:`~datashader.reductions.where`
-:class:`~datashader.reductions.any`,     yes, yes,        yes, yes,        yes,          
+:class:`~datashader.reductions.any`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.by`,      yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.count`,   yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.first`,   yes, ,           ,    ,           yes,          yes
@@ -7,10 +7,10 @@
 :class:`~datashader.reductions.last`,    yes, ,           ,    ,           yes,          yes
 :class:`~datashader.reductions.last_n`,  yes, ,           ,    ,           ,             yes
 :class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.max_n`,   yes, yes,        ,    ,           ,             yes
+:class:`~datashader.reductions.max_n`,   yes, yes,        yes, ,           ,             yes
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.min`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.min_n`,   yes, yes,        ,    ,           ,             yes
+:class:`~datashader.reductions.min_n`,   yes, yes,        yes, ,           ,             yes
 :class:`~datashader.reductions.std`,     yes, yes,        ,    ,           ,
 :class:`~datashader.reductions.sum`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.var`,     yes, yes,        ,    ,           ,


### PR DESCRIPTION
Closes #1177.

This adds support for `max_n` and `min_n` reductions on a GPU, both with and without `dask`. The key change is to add new CUDA mutex functionality to support CUDA `append` functions (i.e. individual pixel callbacks) that do more than a simple get/set operation. Because of the massively parallel nature of CUDA hardware multiple threads can access the same `canvas` pixel at the same time, and up until now we have been restricted to CUDA atomic operations (https://numba.readthedocs.io/en/stable/cuda/intrinsics.html#supported-atomic-operations) in `append` functions. With the new mutex we can lock access to a particular pixel to a single thread at a time and thus perform more complicated operations such as for `max_n` without any race conditions.

In implementation we need to get the mutex (a `cupy` array) to the CUDA `append` functions and this is achieved within the `expand_aggs_and_cols` framework by appending the mutex array in the `make_info` function which is where other arrays and/or dataframe columns are extracted and passed to `append` functions. This ensures that there is only ever a single shared mutex even if multiple reductions need it.

This implementation is limited by what is currently available in `numba` 0.56 which means we can only lock/unlock the mutex as a whole rather than individual elements/pixels of it so the performance will not be great. Numba PR https://github.com/numba/numba/pull/8790 will allow us to lock individual pixels, so when `numba` 0.57 is released I will write another PR to check use the fast route if that is available otherwise drop back to this slower one.

There is no support yet for `where(max_n)` on CUDA, but this will follow in another PR soon.