### PR TITLE
x and y range attributes on returned aggregations

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -265,7 +265,13 @@ def make_finalize(bases, agg, schema, cuda):
         def finalize(bases, cuda=False, **kwargs):
             data = {key: finalizer(get(inds, bases), cuda, **kwargs)
                     for (key, finalizer, inds) in calls}
-            return xr.Dataset(data)
+
+            # Copy x and y range attrs from any DataArray (their ranges are all the same)
+            # to set on parent Dataset
+            name = agg.keys[0]  # Name of first DataArray.
+            attrs = {attr: data[name].attrs[attr] for attr in ('x_range', 'y_range')}
+
+            return xr.Dataset(data, attrs=attrs)
         return finalize
     else:
         return agg._build_finalize(schema)

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1200,7 +1200,7 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
 
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]
-        attrs = dict(res=res[0])
+        attrs = dict(res=res[0], x_range=self.x_range, y_range=self.y_range)
 
         # Find nodata value if available in any of the common conventional locations
         # See https://corteva.github.io/rioxarray/stable/getting_started/nodata_management.html

--- a/datashader/data_libraries/dask_xarray.py
+++ b/datashader/data_libraries/dask_xarray.py
@@ -64,6 +64,8 @@ def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
+    x_range = bounds[:2]
+    y_range = bounds[2:]
 
     # Build chunk indices for coordinates
     chunk_inds = {}
@@ -130,7 +132,8 @@ def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     keys2 = [(name, i) for i in range(len(keys))]
     dsk = dict((k2, (chunk, k, k[1], k[2])) for (k2, k) in zip(keys2, keys))
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label]))
+                 dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label],
+                      attrs=dict(x_range=x_range, y_range=y_range)))
     return dsk, name
 
 
@@ -143,6 +146,8 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
+    x_range = bounds[:2]
+    y_range = bounds[2:]
 
     # Build chunk indices for coordinates
     chunk_inds = {}
@@ -221,7 +226,8 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=
     keys2 = [(name, i) for i in range(len(keys))]
     dsk = dict((k2, (chunk, k, k[1], k[2])) for (k2, k) in zip(keys2, keys))
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label]))
+                 dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label],
+                      attrs=dict(x_range=x_range, y_range=y_range)))
     return dsk, name
 
 
@@ -234,6 +240,8 @@ def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append, antialias_stage_2)
+    x_range = bounds[:2]
+    y_range = bounds[2:]
 
     x_coord_name = glyph.x
     y_coord_name = glyph.y
@@ -328,7 +336,8 @@ def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
 
     dsk[result_name] = (
         apply, finalize, [(combine, result_keys)],
-        dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label])
+        dict(cuda=cuda, coords=axis, dims=[glyph.y_label, glyph.x_label],
+             attrs=dict(x_range=x_range, y_range=y_range))
     )
 
     # Add x/y coord tasks to task graph

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -51,4 +51,5 @@ def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=Fal
                     cuda=cuda,
                     coords=OrderedDict([(glyph.x_label, x_axis),
                                         (glyph.y_label, y_axis)]),
-                    dims=[glyph.y_label, glyph.x_label])
+                    dims=[glyph.y_label, glyph.x_label],
+                    attrs=dict(x_range=x_range, y_range=y_range))

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -390,6 +390,8 @@ def test_count_cat(ddf):
     )
     agg = c.points(ddf, 'x', 'y', ds.count_cat('cat'))
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
     # categorizing by (cat_int-10)%4 ought to give the same result
     out = xr.DataArray(
@@ -397,6 +399,8 @@ def test_count_cat(ddf):
     )
     agg = c.points(ddf, 'x', 'y', ds.by(ds.category_modulo('cat_int', modulo=4, offset=10), ds.count()))
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
     # easier to write these tests in here, since we expect the same result with only slight tweaks
 
@@ -410,6 +414,8 @@ def test_count_cat(ddf):
         )
         agg = c.points(ddf, 'x', 'y', ds.by(ds.category_binning(col, 0, 20, 4), ds.count()))
         assert_eq_xr(agg, out)
+        assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+        assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
     # as above, but for the float arange columns. Element 2 has a nan, so the first bin is one short, and the nan bin is +1
     sol[0, 0, 0] = 4
@@ -421,6 +427,8 @@ def test_count_cat(ddf):
         )
         agg = c.points(ddf, 'x', 'y', ds.by(ds.category_binning(col, 0, 20, 4), ds.count()))
         assert_eq_xr(agg, out)
+        assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+        assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 @pytest.mark.parametrize('ddf', ddfs)
@@ -481,6 +489,8 @@ def test_categorical_sum_binning(ddf):
         )
         agg = c.points(ddf, 'x', 'y', ds.by(ds.category_binning(col, 0, 20, 4), ds.sum(col)))
         assert_eq_xr(agg, out)
+        assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+        assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 @pytest.mark.parametrize('ddf', ddfs)
@@ -636,6 +646,9 @@ def test_multiple_aggregates(ddf):
     assert_eq_xr(agg.i32_sum, f(values(df_pd.i32).reshape((2, 2, 5)).sum(axis=2, dtype='f8').T))
     assert_eq_xr(agg.i32_count, f(np.array([[5, 5], [5, 5]], dtype='i4')))
 
+    assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
+
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
 def test_auto_range_points(DataFrame):
@@ -651,6 +664,8 @@ def test_auto_range_points(DataFrame):
     sol = np.zeros((n, n), int)
     np.fill_diagonal(sol, 1)
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 9), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 9), close=True)
 
     cvs = ds.Canvas(plot_width=n+1, plot_height=n+1)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
@@ -658,6 +673,8 @@ def test_auto_range_points(DataFrame):
     np.fill_diagonal(sol, 1)
     sol[5, 5] = 0
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 9), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 9), close=True)
 
     n = 4
     data = np.arange(n, dtype='i4')
@@ -672,6 +689,8 @@ def test_auto_range_points(DataFrame):
     sol[np.array([tuple(range(1, 4, 2))])] = 0
     sol[np.array([tuple(range(4, 8, 2))])] = 0
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 3), close=True)
 
     cvs = ds.Canvas(plot_width=2*n+1, plot_height=2*n+1)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
@@ -681,6 +700,8 @@ def test_auto_range_points(DataFrame):
     sol[6, 6] = 1
     sol[8, 8] = 1
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 3), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -695,6 +716,8 @@ def test_uniform_points(DataFrame):
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
     sol = np.array([[10] * 9 + [11], [10] * 9 + [11]], dtype='i4')
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 100), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -717,6 +740,9 @@ def test_uniform_diagonal_points(DataFrame, low, high):
     diagonal = agg.data.diagonal(0)
     assert sum(diagonal) == n
     assert abs(bounds[1] - bounds[0]) % 2 == abs(diagonal[1] / high - diagonal[0] / high)
+
+    assert_eq_ndarray(agg.x_range, (low, high), close=True)
+    assert_eq_ndarray(agg.y_range, (low, high), close=True)
 
 
 @pytest.mark.parametrize('ddf', ddfs)
@@ -780,6 +806,8 @@ def test_line(DataFrame):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (-3, 3), close=True)
 
 
 # # Line tests
@@ -890,6 +918,8 @@ def test_line_manual_range(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (-3, 3), close=True)
 
 
 line_autorange_params = [
@@ -1006,6 +1036,8 @@ def test_line_autorange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 4), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1083,6 +1115,8 @@ def test_auto_range_line(DataFrame):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-10, 10), close=True)
+    assert_eq_ndarray(agg.y_range, (-10, 10), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1158,6 +1192,8 @@ def test_area_to_zero_fixedrange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3.75, 3.75), close=True)
+    assert_eq_ndarray(agg.y_range, (-2.25, 2.25), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1250,6 +1286,8 @@ def test_area_to_zero_autorange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 0), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1430,6 +1468,8 @@ def test_area_to_line_autorange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 0), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1542,6 +1582,8 @@ def test_trimesh_no_double_edge():
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     ], dtype='i4')
     np.testing.assert_array_equal(np.flipud(agg.fillna(0).astype('i4').values)[:5], sol)
+    assert_eq_ndarray(agg.x_range, (0, 5), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 5), close=True)
 
 
 @pytest.mark.parametrize('npartitions', list(range(1, 6)))
@@ -1592,6 +1634,8 @@ def test_trimesh_dask_partitions(npartitions):
     ], dtype='i4')
     np.testing.assert_array_equal(
         np.flipud(agg.fillna(0).astype('i4').values)[:5], sol)
+    assert_eq_ndarray(agg.x_range, (0, 5), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 5), close=True)
 
 
 @pytest.mark.parametrize('ddf', ddfs)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -476,6 +476,9 @@ def test_count_cat(df):
         dims=(dims + ['cat']))
     agg = c.points(df, 'x', 'y', ds.count_cat('cat'))
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
+
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_count(df):
@@ -585,6 +588,8 @@ def test_categorical_sum_binning(df):
         )
         agg = c.points(df, 'x', 'y', ds.by(ds.category_binning(col, 0, 20, 4), ds.sum(col)))
         assert_eq_xr(agg, out)
+        assert_eq_ndarray(agg.x_range, (0, 1), close=True)
+        assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 @pytest.mark.parametrize('df', dfs)
@@ -777,6 +782,8 @@ def test_first():
         [100., 101., 101., np.nan, np.nan]], dtype='float64')
 
     assert_eq_ndarray(agg, sol)
+    assert_eq_ndarray(agg.x_range, (0, 5), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 5), close=True)
 
 
 def test_last():
@@ -845,6 +852,8 @@ def test_auto_range_points(DataFrame):
     sol = np.zeros((n, n), int)
     np.fill_diagonal(sol, 1)
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 9), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 9), close=True)
 
     cvs = ds.Canvas(plot_width=n+1, plot_height=n+1)
     agg = cvs.points(df, 'x', 'y', ds.count('time'))
@@ -852,6 +861,8 @@ def test_auto_range_points(DataFrame):
     np.fill_diagonal(sol, 1)
     sol[5, 5] = 0
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 9), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 9), close=True)
 
     n = 4
     data = np.arange(n, dtype='i4')
@@ -866,6 +877,8 @@ def test_auto_range_points(DataFrame):
     sol[np.array([tuple(range(1, 4, 2))])] = 0
     sol[np.array([tuple(range(4, 8, 2))])] = 0
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 3), close=True)
 
     cvs = ds.Canvas(plot_width=2*n+1, plot_height=2*n+1)
     agg = cvs.points(df, 'x', 'y', ds.count('time'))
@@ -875,6 +888,8 @@ def test_auto_range_points(DataFrame):
     sol[6, 6] = 1
     sol[8, 8] = 1
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 3), close=True)
 
 
 def test_uniform_points():
@@ -888,6 +903,8 @@ def test_uniform_points():
     agg = cvs.points(df, 'x', 'y', ds.count('time'))
     sol = np.array([[10] * 9 + [11], [10] * 9 + [11]], dtype='i4')
     assert_eq_ndarray(agg.data, sol)
+    assert_eq_ndarray(agg.x_range, (0, 100), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 @pytest.mark.parametrize('high', [9, 10, 99, 100])
@@ -909,6 +926,9 @@ def test_uniform_diagonal_points(low, high):
     diagonal = agg.data.diagonal(0)
     assert sum(diagonal) == n
     assert abs(bounds[1] - bounds[0]) % 2 == abs(diagonal[1] / high - diagonal[0] / high)
+
+    assert_eq_ndarray(agg.x_range, (low, high), close=True)
+    assert_eq_ndarray(agg.y_range, (low, high), close=True)
 
 
 @pytest.mark.parametrize('df', dfs)
@@ -950,6 +970,8 @@ def test_points_geometry_point():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 2), close=True)
 
     # Aggregation should not have triggered calculation of spatial index
     assert df.geom.array._sindex is None
@@ -958,6 +980,8 @@ def test_points_geometry_point():
     df.geom.array.sindex
     agg = cvs.points(df, geometry='geom', agg=ds.sum('v'))
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 2), close=True)
 
 
 @pytest.mark.skipif(not sp, reason="spatialpandas not installed")
@@ -979,6 +1003,8 @@ def test_points_geometry_multipoint():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 2), close=True)
 
     # Aggregation should not have triggered calculation of spatial index
     assert df.geom.array._sindex is None
@@ -987,6 +1013,8 @@ def test_points_geometry_multipoint():
     df.geom.array.sindex
     agg = cvs.points(df, geometry='geom', agg=ds.sum('v'))
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 2), close=True)
 
 
 def test_line():
@@ -1008,6 +1036,8 @@ def test_line():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (-3, 3), close=True)
 
 
 def test_points_on_edge():
@@ -1106,6 +1136,8 @@ def test_auto_range_line():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-10, 10), close=True)
+    assert_eq_ndarray(agg.y_range, (-10, 10), close=True)
 
 
 @pytest.mark.skipif(not sp, reason="spatialpandas not installed")
@@ -1139,6 +1171,8 @@ def test_closed_ring_line(geom_data, geom_type):
         out[0, 0] = 2
 
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 1), close=True)
 
 
 def test_trimesh_no_double_edge():
@@ -1358,6 +1392,9 @@ def test_trimesh_agg_api():
     agg = cvs.trimesh(pts, tris, agg=ds.mean('weight'))
     assert agg.shape == (600, 600)
 
+    assert_eq_ndarray(agg.x_range, (0, 10), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 10), close=True)
+
 
 def test_bug_570():
     # See https://github.com/holoviz/datashader/issues/570
@@ -1475,6 +1512,8 @@ def test_line_manual_range(DataFrame, df_args, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3, 3), close=True)
+    assert_eq_ndarray(agg.y_range, (-3, 3), close=True)
 
 
 line_autorange_params = [
@@ -1583,6 +1622,8 @@ def test_line_autorange(DataFrame, df_args, cvs_kwargs, line_width):
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out, close=(line_width > 0))
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 4), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1690,6 +1731,8 @@ def test_line_autorange_axis1_ragged():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 4), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1753,6 +1796,8 @@ def test_area_to_zero_fixedrange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-3.75, 3.75), close=True)
+    assert_eq_ndarray(agg.y_range, (-2.25, 2.25), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1831,6 +1876,8 @@ def test_area_to_zero_autorange(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 0), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -1896,6 +1943,8 @@ def test_area_to_zero_autorange_gap(DataFrame, df_kwargs, cvs_kwargs):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
     assert_eq_xr(agg, out)
+    assert_eq_ndarray(agg.x_range, (-4, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (-4, 4), close=True)
 
 
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -2201,6 +2250,9 @@ def test_line_antialias():
     sol_mean = np.where(sol_count>0, 3.0, np.nan)
     assert_eq_ndarray(agg.data, sol_mean, close=True)
 
+    assert_eq_ndarray(agg.x_range, x_range, close=True)
+    assert_eq_ndarray(agg.y_range, y_range, close=True)
+
 
 def test_line_antialias_summary():
     kwargs = dict(source=line_antialias_df, x=["x0", "x1"], y=["y0", "y1"], line_width=1)
@@ -2266,6 +2318,9 @@ def test_line_antialias_summary():
         ), **kwargs)
     assert_eq_ndarray(agg["count"].data, sol_count, close=True)
     assert_eq_ndarray(agg["last"].data, sol_last, close=True)
+
+    assert_eq_ndarray(agg.x_range, x_range, close=True)
+    assert_eq_ndarray(agg.y_range, y_range, close=True)
 
 
 line_antialias_nan_sol_intersect = np.array([
@@ -2388,6 +2443,8 @@ def test_line_antialias_nan(df_kwargs, cvs_kwargs, sol_False, sol_True, self_int
     agg = cvs.line(df, line_width=2, agg=ds.count(self_intersect=self_intersect), **cvs_kwargs)
     sol = sol_True if self_intersect else sol_False
     assert_eq_ndarray(agg.data, sol, close=True)
+    assert_eq_ndarray(agg.x_range, x_range, close=True)
+    assert_eq_ndarray(agg.y_range, y_range, close=True)
 
 
 def test_line_antialias_categorical():

--- a/datashader/tests/test_polygons.py
+++ b/datashader/tests/test_polygons.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import xarray as xr
 import datashader as ds
-from datashader.tests.test_pandas import assert_eq_xr
+from datashader.tests.test_pandas import assert_eq_ndarray, assert_eq_xr
 import dask.dataframe as dd
 
 try:
@@ -71,6 +71,9 @@ def test_multipolygon_manual_range(DataFrame):
 
     assert_eq_xr(agg, out)
 
+    assert_eq_ndarray(agg.x_range, (0, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 3), close=True)
+
 
 @pytest.mark.skipif(not spatialpandas, reason="spatialpandas not installed")
 @pytest.mark.parametrize('DataFrame', DataFrames)
@@ -119,6 +122,9 @@ def test_multiple_polygons_auto_range(DataFrame):
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x], dims=['y', 'x'])
 
     assert_eq_xr(agg, out)
+    
+    assert_eq_ndarray(agg.x_range, (-1, 3.5), close=True)
+    assert_eq_ndarray(agg.y_range, (0.1, 2), close=True)
 
 
 @pytest.mark.skipif(not spatialpandas, reason="spatialpandas not installed")
@@ -305,10 +311,10 @@ def test_spatial_index_not_dropped():
     assert df.some_geom.array._sindex is None
     sindex = df.some_geom.array.sindex
     assert sindex is not None
-   
+
     glyph = ds.glyphs.polygon.PolygonGeom('some_geom')
     agg = ds.count()
-    
+
     df2, _ = ds.core._bypixel_sanitise(df, glyph, agg)
 
     assert df2.columns == ['some_geom']

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -7,7 +7,7 @@ import pytest
 from collections import OrderedDict
 
 import dask.array
-from datashader.tests.test_pandas import assert_eq_xr
+from datashader.tests.test_pandas import assert_eq_ndarray, assert_eq_xr
 
 array_modules = [np, dask.array]
 try:
@@ -81,10 +81,14 @@ def test_raster_quadmesh_autorange(array_module):
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 4.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 2.5), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 4.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 2.5), close=True)
 
 
 def test_raster_quadmesh_autorange_chunked():
@@ -246,10 +250,14 @@ def test_raster_quadmesh_manual_range(array_module):
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (1, 3), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 3), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (1, 3), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 3), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)
@@ -314,10 +322,14 @@ def test_rectilinear_quadmesh_autorange(array_module):
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (0.5, 10.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 2.5), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (0.5, 10.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 2.5), close=True)
 
 
 def test_rectilinear_quadmesh_autorange_chunked():
@@ -348,10 +360,14 @@ def test_rectilinear_quadmesh_autorange_chunked():
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (0.5, 10.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 3.5), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (0.5, 10.5), close=True)
+    assert_eq_ndarray(res.y_range, (0.5, 3.5), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)
@@ -380,10 +396,14 @@ def test_rect_quadmesh_autorange_reversed(array_module):
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (-10.5, -0.5), close=True)
+    assert_eq_ndarray(res.y_range, (-2.5, -0.5), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (-10.5, -0.5), close=True)
+    assert_eq_ndarray(res.y_range, (-2.5, -0.5), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)
@@ -415,10 +435,14 @@ def test_rect_quadmesh_manual_range(array_module):
 
     res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (1, 3), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 3), close=True)
 
     # Check transpose gives same answer
     res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
     assert_eq_xr(res, out, close=True)
+    assert_eq_ndarray(res.x_range, (1, 3), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 3), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)
@@ -541,9 +565,13 @@ def test_curve_quadmesh_autorange(array_module):
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 2.5), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 7), close=True)
 
     res = c.quadmesh(da.transpose('X', 'Y', transpose_coords=True), x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 2.5), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 7), close=True)
 
 
 def test_curve_quadmesh_autorange_chunked():
@@ -586,9 +614,13 @@ def test_curve_quadmesh_autorange_chunked():
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 2.5), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 7), close=True)
 
     res = c.quadmesh(da.transpose('X', 'Y', transpose_coords=True), x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (0.5, 2.5), close=True)
+    assert_eq_ndarray(res.y_range, (-1, 7), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)
@@ -633,9 +665,13 @@ def test_curve_quadmesh_manual_range(array_module):
 
     res = c.quadmesh(da, x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (1, 2), close=True)
+    assert_eq_ndarray(res.y_range, (1, 3), close=True)
 
     res = c.quadmesh(da.transpose('X', 'Y', transpose_coords=True), x='Qx', y='Qy', agg=ds.sum('Z'))
     assert_eq_xr(res, out)
+    assert_eq_ndarray(res.x_range, (1, 2), close=True)
+    assert_eq_ndarray(res.y_range, (1, 3), close=True)
 
 
 @pytest.mark.parametrize('array_module', array_modules)

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -143,6 +143,9 @@ def test_full_extent_returns_correct_coords():
         for dim in src.dims:
             assert np.all(agg[dim].data == src[dim].data)
 
+        assert np.allclose(agg.x_range, (-180, 180))
+        assert np.allclose(agg.y_range, (-90, 90))
+
 
 @open_rasterio_available
 def test_calc_res():
@@ -187,6 +190,8 @@ def test_raster_both_ascending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+    assert np.allclose(agg.x_range, (-0.5, 9.5))
+    assert np.allclose(agg.y_range, (-0.5, 4.5))
 
 
 def test_raster_both_ascending_partial_range():
@@ -204,6 +209,8 @@ def test_raster_both_ascending_partial_range():
     assert np.allclose(agg.data, xarr.sel(X=slice(1, 7), Y=slice(1, 3)))
     assert np.allclose(agg.X.values, xs[1:8])
     assert np.allclose(agg.Y.values, ys[1:4])
+    assert np.allclose(agg.x_range, (0.5, 7.5))
+    assert np.allclose(agg.y_range, (0.5, 3.5))
 
 
 def test_raster_both_descending():
@@ -220,6 +227,8 @@ def test_raster_both_descending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+    assert np.allclose(agg.x_range, (-0.5, 9.5))
+    assert np.allclose(agg.y_range, (-0.5, 4.5))
 
 
 def test_raster_both_descending_partial_range():
@@ -237,6 +246,8 @@ def test_raster_both_descending_partial_range():
     assert np.allclose(agg.data, xarr.sel(Y=slice(3,1), X=slice(7, 1)).data)
     assert np.allclose(agg.X.values, xs[2:9])
     assert np.allclose(agg.Y.values, ys[1:4])
+    assert np.allclose(agg.x_range, (0.5, 7.5))
+    assert np.allclose(agg.y_range, (0.5, 3.5))
 
 
 def test_raster_x_ascending_y_descending():
@@ -253,6 +264,8 @@ def test_raster_x_ascending_y_descending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+    assert np.allclose(agg.x_range, (-0.5, 9.5))
+    assert np.allclose(agg.y_range, (-0.5, 4.5))
 
 
 def test_raster_x_ascending_y_descending_partial_range():
@@ -269,6 +282,8 @@ def test_raster_x_ascending_y_descending_partial_range():
     assert np.allclose(agg.data, xarr.sel(X=slice(1, 7), Y=slice(3, 2)).data)
     assert np.allclose(agg.X.values, xs[1:8])
     assert np.allclose(agg.Y.values, ys[1:3])
+    assert np.allclose(agg.x_range, (0.5, 7.5))
+    assert np.allclose(agg.y_range, (1.5, 3.5))
 
 
 def test_raster_x_descending_y_ascending():
@@ -285,6 +300,8 @@ def test_raster_x_descending_y_ascending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+    assert np.allclose(agg.x_range, (-0.5, 9.5))
+    assert np.allclose(agg.y_range, (-0.5, 4.5))
 
 
 def test_raster_x_descending_y_ascending_partial_range():

--- a/datashader/tests/test_xarray.py
+++ b/datashader/tests/test_xarray.py
@@ -48,4 +48,9 @@ def test_count(source):
     out = xr.DataArray(np.array([[4, 5], [5, 5]], dtype='i4'),
                        coords=coords, dims=dims)
     assert_eq(c.points(source, 'x', 'y', ds.count('f32')), out)
-    assert_eq(c.points(source, 'x', 'y', ds.count('f64')), out)
+
+    agg = c.points(source, 'x', 'y', ds.count('f64'))
+    assert_eq(agg, out)
+    np.testing.assert_array_almost_equal(agg.x_range, (0, 1))
+    np.testing.assert_array_almost_equal(agg.y_range, (0, 1))
+

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'datashape',
     'numba >=0.51',
     'numpy',
-    'pandas',
+    'pandas <2',
     'param',
     'pillow',
     'pyct',


### PR DESCRIPTION
Closes #1157.

This PR adds new attributes `x_range` and `y_range` to aggregations returned from datashader. Simple example:

```python
import datashader as ds
import pandas as pd

df = pd.DataFrame(dict(x=[1.1, 2.2, 3.3], y=[4.4, 5.5, 6.6]))
canvas = ds.Canvas(plot_height=5, plot_width=5)
agg = canvas.points(source=df, x="x", y="y")
print(agg)
```

Output produced:
```
<xarray.DataArray (y: 5, x: 5)>
array([[1, 0, 0, 0, 0],
       [0, 0, 0, 0, 0],
       [0, 0, 1, 0, 0],
       [0, 0, 0, 0, 0],
       [0, 0, 0, 0, 1]], dtype=uint32)
Coordinates:
  * x        (x) float64 1.32 1.76 2.2 2.64 3.08
  * y        (y) float64 4.62 5.06 5.5 5.94 6.38
Attributes:
    x_range:  (1.1, 3.3)
    y_range:  (4.4, 6.6)
```

so the attributes can be accessed using `agg.x_range` and similar.

The ranges are set regardless of whether they are specified by the user in the `Canvas` constructor, or determined from the data limits.

For situations that return an `xarray.Dataset` rather than an `xarray.DataArray`, e.g. if a `ds.summary()` is used, the attributes are copied to the `Dataset`. Hence they are always available as attributes of the top-level object returned from `Canvas` aggregation functions.