### PR TITLE
Cancel concurrent test workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 16 * * SUN'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_suite:
     name: Tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}


### PR DESCRIPTION
Cancel concurrent jobs to avoid bogging down CI across the holoviz org.