### PR TITLE
Use fast cuda mutex available in numba 0.57

### DIFF
--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -114,7 +114,7 @@ class AreaToZeroAxis0(_PointLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_name)
@@ -198,7 +198,7 @@ class AreaToLineAxis0(_AreaToLineLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_name)
@@ -290,7 +290,7 @@ class AreaToZeroAxis0Multi(_PointLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
@@ -381,7 +381,7 @@ class AreaToLineAxis0Multi(_AreaToLineLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
@@ -489,7 +489,7 @@ class AreaToZeroAxis1(_PointLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
@@ -596,7 +596,7 @@ class AreaToLineAxis1(_AreaToLineLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
@@ -665,7 +665,7 @@ class AreaToZeroAxis1XConstant(AreaToZeroAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 ys = self.to_cupy_array(df,list(y_names))
@@ -745,7 +745,7 @@ class AreaToLineAxis1XConstant(AreaToLineAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 ys = self.to_cupy_array(df,list(y_names))
@@ -813,7 +813,7 @@ class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
@@ -881,7 +881,7 @@ class AreaToLineAxis1YConstant(AreaToLineAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df,list(x_names))
@@ -968,7 +968,7 @@ class AreaToZeroAxis1Ragged(_PointLike):
 
             xs = df[x_name].values
             ys = df[y_name].values
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             perform_extend_cpu(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,
@@ -1051,7 +1051,7 @@ class AreaToLineAxis1Ragged(_AreaToLineLike):
             ys = df[y_name].values
             y_stacks = df[y_stack_name].values
 
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             extend_cpu(
                 sx, tx, sy, ty,
                 xmin, xmax, ymin, ymax,

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -95,7 +95,7 @@ class LineAxis0(_PointLike, _AntiAliasedLine):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_name)
@@ -189,7 +189,7 @@ class LineAxis0Multi(_PointLike, _AntiAliasedLine):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
@@ -304,7 +304,7 @@ class LinesAxis1(_PointLike, _AntiAliasedLine):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
@@ -380,7 +380,7 @@ class LinesAxis1XConstant(LinesAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = cp.asarray(x_values)
@@ -456,7 +456,7 @@ class LinesAxis1YConstant(LinesAxis1):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
 
             if cudf and isinstance(df, cudf.DataFrame):
                 xs = self.to_cupy_array(df, x_names)
@@ -536,7 +536,7 @@ class LinesAxis1Ragged(_PointLike, _AntiAliasedLine):
             xs = df[x_name].array
             ys = df[y_name].array
 
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             # line may be clipped, then mapped to pixels
             extend_cpu(
                 sx, tx, sy, ty, xmin, xmax, ymin, ymax, xs, ys, antialias_stage_2, *aggs_and_cols
@@ -579,7 +579,7 @@ class LineAxis1Geometry(_GeometryLike, _AntiAliasedLine):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             geom_array = df[geometry_name].array
 
             # Use type to decide whether geometry represents a closed .

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -199,7 +199,7 @@ class Point(_PointLike):
 
         def extend(aggs, df, vt, bounds):
             yymax, xxmax = aggs[0].shape[:2]
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
 
@@ -282,7 +282,7 @@ class MultiPointGeometry(_GeometryLike):
         def extend(aggs, df, vt, bounds):
             from spatialpandas.geometry import PointArray
 
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
 

--- a/datashader/glyphs/polygon.py
+++ b/datashader/glyphs/polygon.py
@@ -35,7 +35,7 @@ class PolygonGeom(_GeometryLike):
         def extend(aggs, df, vt, bounds, plot_start=True):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
-            aggs_and_cols = aggs + info(df)
+            aggs_and_cols = aggs + info(df, aggs[0].shape[:2])
             geom_array = df[geom_name].array
 
             perform_extend_cpu(

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -204,7 +204,7 @@ class QuadMeshRectilinear(_QuadMeshLike):
             ys = (yscaled[ym0:ym1 + 1] * plot_height).astype(int).clip(0, plot_height)
 
             # For input "column", down select to valid range
-            cols_full = info(xr_ds.transpose(y_name, x_name))
+            cols_full = info(xr_ds.transpose(y_name, x_name), aggs[0].shape[:2])
             cols = tuple([c[ym0:ym1, xm0:xm1] for c in cols_full])
 
             aggs_and_cols = aggs + cols
@@ -378,7 +378,7 @@ class QuadMeshRaster(QuadMeshRectilinear):
                 offset_x = offset_y = 0
 
             # Build aggs_and_cols tuple
-            cols = info(xr_ds)
+            cols = info(xr_ds, aggs[0].shape[:2])
             aggs_and_cols = tuple(aggs) + tuple(cols)
 
             if src_h == 0 or src_w == 0 or out_h == 0 or out_w == 0:
@@ -660,7 +660,7 @@ class QuadMeshCurvilinear(_QuadMeshLike):
             ys = (yscaled * plot_height).astype(int)
 
             coord_dims = xr_ds.coords[x_name].dims
-            aggs_and_cols = aggs + info(xr_ds.transpose(*coord_dims))
+            aggs_and_cols = aggs + info(xr_ds.transpose(*coord_dims), aggs[0].shape[:2])
             if use_cuda:
                 do_extend = extend_cuda[cuda_args(xr_ds[name].shape)]
             else:

--- a/datashader/glyphs/trimesh.py
+++ b/datashader/glyphs/trimesh.py
@@ -70,7 +70,7 @@ class Triangles(_PolygonLike):
         interpolate = self.interpolate
 
         def extend(aggs, df, vt, bounds, plot_start=True):
-            cols = info(df)
+            cols = info(df, aggs[0].shape[:2])
             assert cols, 'There must be at least one column on which to aggregate'
             # mapped to pixels, then may be clipped
             extend_triangles(vt, bounds, df.values, weight_type, interpolate, aggs, cols)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1359,7 +1359,7 @@ class max_n(FloatingNReduction):
             # Linear walk along stored values.
             # Could do binary search instead but not expecting n to be large.
             n = agg.shape[2]
-            index = (x, y)
+            index = (y, x)
             cuda_mutex_lock(mutex, index)
             for i in range(n):
                 if isnull(agg[y, x, i]) or field > agg[y, x, i]:
@@ -1430,7 +1430,7 @@ class min_n(FloatingNReduction):
             # Linear walk along stored values.
             # Could do binary search instead but not expecting n to be large.
             n = agg.shape[2]
-            index = (x, y)
+            index = (y, x)
             cuda_mutex_lock(mutex, index)
             for i in range(n):
                 if isnull(agg[y, x, i]) or field < agg[y, x, i]:


### PR DESCRIPTION
Fixes #1211.

For `numba >= 0.57` there is a CUDA mutex that is lockable on a per-pixel basis whereas earlier `numba` doesn't have the required functionality so there is a single lock shared between all pixels. Complicated CUDA reductions such as `max_n` need the mutex so that they work atomically; the new mutex allows the CUDA code to work in parallel very efficiently whereas the old solution forces datashader to run mostly serially.

There is very little code changed here. The `numba.__version__` is used to select the appropriate mutex lock and unlock functions, and the size of the `cupy` array used for the mutex. Other than that there is a new argument to the `info` function as the canvas shape is needed. Although this argument is only needed for CUDA code running a complicated reduction such as `max_n`, I have chosen to pass it for every call rather than dynamically determine at the point of calling whether it is needed or not.

As an illustration of performance, demo code:
```python
import cudf, datashader as ds, numba as nb, numpy as np, pandas as pd

n = 1_000_000
rng = np.random.default_rng(95123)
df = pd.DataFrame(dict(
    x = rng.random(size=n, dtype=np.float32),
    y = rng.random(size=n, dtype=np.float32),
    value = rng.random(size=n, dtype=np.float32),
))
df = cudf.DataFrame.from_pandas(df)

canvas = ds.Canvas(plot_height=300, plot_width=600)
agg = canvas.points(source=df, x="x", y="y", agg=ds.max_n("value", 3))
```

and time the `canvas.points` call, discarding the first timing as this includes `numba` compilation. This gives the following timings (using `numba 0.56.3` and `numba 0.57` for the `slow` and `fast` mutex):

<img width="599" alt="Screenshot 2023-05-10 at 13 46 06" src="https://github.com/holoviz/datashader/assets/580326/8101e200-e0f7-44f1-ae95-842ec7735a1d">

GPU on test system is an Nvidia Quadro T1000.