### PR TITLE
Support antialiasing in pipeline API

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -431,7 +431,6 @@ The axis argument to Canvas.line must be 0 or 1
             line_width = 0
 
         glyph.set_line_width(line_width)
-        glyph.antialiased = (line_width > 0)
 
         if glyph.antialiased:
             # This is required to identify and report use of reductions that do

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -61,6 +61,8 @@ class _AntiAliasedLine(object):
 
     def set_line_width(self, line_width):
         self._line_width = line_width
+        if hasattr(self, "antialiased"):
+            self.antialiased = (line_width > 0)
 
     def _build_extend(self, x_mapper, y_mapper, info, append, antialias_stage_2):
         return self._internal_build_extend(

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -66,6 +66,7 @@ class Pipeline(object):
         canvas = core.Canvas(plot_width=int(width*self.width_scale),
                              plot_height=int(height*self.height_scale),
                              x_range=x_range, y_range=y_range)
-        bins = core.bypixel(self.df, canvas, self.glyph, self.agg)
+        bins = core.bypixel(self.df, canvas, self.glyph, self.agg,
+                            antialias=self.glyph.antialiased)
         img = self.color_fn(self.transform_fn(bins))
         return self.spread_fn(img)

--- a/datashader/tests/test_pipeline.py
+++ b/datashader/tests/test_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import numpy as np
 import pandas as pd
+import pytest
 import datashader as ds
 import datashader.transfer_functions as tf
 
@@ -11,6 +12,7 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
 df.f64.iloc[2] = np.nan
 
 cvs = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
+cvs10 = ds.Canvas(plot_width=10, plot_height=10, x_range=(0, 1), y_range=(0, 1))
 
 
 def test_pipeline():
@@ -33,3 +35,18 @@ def test_pipeline():
     img = pipeline((0, 1), (0, 1), 2, 2)
     agg = cvs.points(df, 'x', 'y', ds.sum('f64'))
     assert img.equals(tf.shade(agg))
+
+
+@pytest.mark.parametrize("line_width", [0.0, 0.5, 1.0, 2.0])
+def test_pipeline_antialias(line_width):
+    glyph = ds.glyphs.LineAxis0('x', 'y')
+
+    glyph.set_line_width(line_width=line_width)
+    assert glyph._line_width == line_width
+    assert glyph.antialiased == (line_width > 0)
+
+    pipeline = ds.Pipeline(df, glyph)
+    img = pipeline(width=cvs10.plot_width, height=cvs10.plot_height,
+                   x_range=cvs10.x_range, y_range=cvs10.y_range)
+    agg = cvs10.line(df, 'x', 'y', agg=ds.reductions.count(), line_width=line_width)
+    assert img.equals(tf.dynspread(tf.shade(agg)))


### PR DESCRIPTION
Fixes #1204.

In the `pipeline` API we weren't passing through the `antialias` flag. With this fix, the OP's example works fine for all values of `line_width`:
```python
import datashader as ds
import pandas as pd

df = pd.DataFrame(dict(x=[0,1],y=[0,1]))

glyph = ds.glyphs.LineAxis0('x','y')
glyph.set_line_width(1)
pipeline = ds.Pipeline(df, glyph)

image = pipeline(x_range=(0,1), y_range=(0,1), width=400, height=400)
```