### PR TITLE
Cuda and cuda-with-dask support for inspection reductions

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1185,11 +1185,6 @@ class _first_or_last(Reduction):
     def _antialias_requires_2_stages(self):
         return True
 
-    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
-        if cuda:
-            raise ValueError(f"'{type(self).__name__}' reduction is not supported on the GPU")
-        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
-
     def _build_bases(self, cuda, partitioned):
         if self.uses_row_index(cuda, partitioned):
             row_index_selector = self._create_row_index_selector()
@@ -1334,17 +1329,10 @@ class _first_n_or_last_n(FloatingNReduction):
     """Abstract base class of first_n and last_n reductions.
     """
     def uses_row_index(self, cuda, partitioned):
-        if cuda:
-            raise ValueError(f"'{type(self).__name__}' reduction is not supported on the GPU")
-        return partitioned
+        return cuda or partitioned
 
     def _antialias_requires_2_stages(self):
         return True
-
-    def _build_append(self, dshape, schema, cuda, antialias, self_intersect):
-        if cuda:
-            raise ValueError(f"'{type(self).__name__}' reduction is not supported on the GPU")
-        return super()._build_append(dshape, schema, cuda, antialias, self_intersect)
 
     def _build_bases(self, cuda, partitioned):
         if self.uses_row_index(cuda, partitioned):

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -267,7 +267,7 @@ def test_max_n(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.max('plusminus')).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_min_n_row_index(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -282,7 +282,7 @@ def test_min_n_row_index(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds._min_row_index()).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_max_n_row_index(ddf, npartitions):
     ddf = ddf.repartition(npartitions)

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -167,7 +167,7 @@ def test_sum(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.sum('f64')), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_first(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -179,7 +179,7 @@ def test_first(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.first('f64')), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_last(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -297,7 +297,7 @@ def test_max_n_row_index(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds._max_row_index()).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_first_n(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -312,7 +312,7 @@ def test_first_n(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.first('plusminus')).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_last_n(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -369,7 +369,7 @@ def test_where_min(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.min('f32'))), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_max_n(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -398,7 +398,7 @@ def test_where_max_n(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.where(ds.max('plusminus'), 'reverse')).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_min_n(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -427,7 +427,7 @@ def test_where_min_n(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.where(ds.min('plusminus'), 'reverse')).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_first(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -448,7 +448,7 @@ def test_where_first(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.first('f32'))), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_last(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -469,7 +469,7 @@ def test_where_last(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.where(ds.last('f32'))), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_first_n(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -498,7 +498,7 @@ def test_where_first_n(ddf, npartitions):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(ddf, 'x', 'y', ds.where(ds.first('plusminus'), 'reverse')).data)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_where_last_n(ddf, npartitions):
     # Important to test with npartitions > 2 to have multiple combination stages.
@@ -2002,15 +2002,3 @@ def test_canvas_size():
     for cvs in cvs_list:
         with pytest.raises(ValueError, match=msg):
             cvs.points(ddf, "x", "y", ds.mean("z"))
-
-
-@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
-@pytest.mark.parametrize('reduction', [
-    ds.where(ds.first_n('f64')),
-    ds.where(ds.last_n('f64')),
-    ds.where(ds.max_n('f64', n=3)),
-    ds.where(ds.min_n('f64', n=3)),
-])
-def test_reduction_on_cuda_dask_raises_error(reduction):
-    with pytest.raises((NotImplementedError, ValueError)):
-        c.points(cudf_ddf, 'x', 'y', reduction)

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -219,7 +219,7 @@ def test_max(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('f64')), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_min_row_index(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -228,7 +228,7 @@ def test_min_row_index(ddf, npartitions):
     assert_eq_xr(c.points(ddf, 'x', 'y', ds._min_row_index()), out)
 
 
-@pytest.mark.parametrize('ddf', [_ddf])
+@pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_max_row_index(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
@@ -2006,9 +2006,7 @@ def test_canvas_size():
 
 @pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
 @pytest.mark.parametrize('reduction', [
-    ds.where(ds.first('f64')),
     ds.where(ds.first_n('f64')),
-    ds.where(ds.last('f64')),
     ds.where(ds.last_n('f64')),
     ds.where(ds.max_n('f64', n=3)),
     ds.where(ds.min_n('f64', n=3)),

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -827,6 +827,18 @@ def test_last_n(df):
 
 
 @pytest.mark.parametrize('df', dfs)
+def test_min_row_index(df):
+    out = xr.DataArray([[0, 10], [5, 15]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds._min_row_index()), out)
+
+
+@pytest.mark.parametrize('df', dfs)
+def test_max_row_index(df):
+    out = xr.DataArray([[4, 14], [9, 19]], coords=coords, dims=dims)
+    assert_eq_xr(c.points(df, 'x', 'y', ds._max_row_index()), out)
+
+
+@pytest.mark.parametrize('df', dfs)
 def test_multiple_aggregates(df):
     agg = c.points(df, 'x', 'y',
                    ds.summary(f64_mean=ds.mean('f64'),
@@ -2658,13 +2670,9 @@ def test_canvas_size():
 
 @pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
 @pytest.mark.parametrize('reduction', [
-    ds.first('f64'),
     ds.first_n('f64', n=3),
-    ds.last('f64'),
     ds.last_n('f64', n=3),
-    ds.where(ds.first('f64')),
     ds.where(ds.first_n('f64', n=3)),
-    ds.where(ds.last('f64')),
     ds.where(ds.last_n('f64', n=3)),
 ])
 def test_reduction_on_cuda_raises_error(reduction):

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -281,7 +281,7 @@ def test_where_max_n_row_index(df):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(df, 'x', 'y', ds.where(ds._max_row_index(), 'plusminus')).data)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_where_first(df):
     # Note reductions like ds.where(ds.first('i32'), 'reverse') are supported,
     # but the same results can be achieved using the simpler ds.first('reverse')
@@ -349,7 +349,7 @@ def test_where_min(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.where(ds.min('f32'))), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_where_first_n(df):
     sol_rowindex = np.array([[[ 0,  1,  3,  4, -1, -1],
                               [10, 11, 12, 13, 14, -1]],
@@ -373,7 +373,7 @@ def test_where_first_n(df):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(df, 'x', 'y', ds.where(ds.first('plusminus'), 'reverse')).data)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_where_last_n(df):
     sol_rowindex = np.array([[[ 4,  3,  1,  0, -1, -1],
                               [14, 13, 12, 11, 10, -1]],
@@ -827,7 +827,7 @@ def test_categorical_std(df):
         assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_first(df):
     out = xr.DataArray([[0, 10], [5, 15]], coords=coords, dims=dims)
     assert_eq_xr(c.points(df, 'x', 'y', ds.first('i32')), out)
@@ -836,7 +836,7 @@ def test_first(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.first('f64')), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_last(df):
     out = xr.DataArray([[4, 14], [9, 19]], coords=coords, dims=dims)
     assert_eq_xr(c.points(df, 'x', 'y', ds.last('i32')), out)
@@ -845,7 +845,7 @@ def test_last(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.last('f64')), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_first_n(df):
     solution = np.array([[[0, -1, -3, 4, nan, nan], [10, -11, 12, -13, 14, nan]],
                          [[-5, 6, -7, 8, -9, nan], [-15, 16, -17, 18, -19, nan]]])
@@ -857,7 +857,7 @@ def test_first_n(df):
             assert_eq_ndarray(agg[:, :, 0].data, c.points(df, 'x', 'y', ds.first('plusminus')).data)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_last_n(df):
     solution = np.array([[[4, -3, -1, 0, nan, nan], [14, -13, 12, -11, 10, nan]],
                          [[-9, 8, -7, 6, -5, nan], [-19, 18, -17, 16, -15, nan]]])
@@ -2739,15 +2739,3 @@ def test_canvas_size():
     for cvs in cvs_list:
         with pytest.raises(ValueError, match=msg):
             cvs.points(df, "x", "y", ds.mean("z"))
-
-
-@pytest.mark.skipif(not test_gpu, reason="DATASHADER_TEST_GPU not set")
-@pytest.mark.parametrize('reduction', [
-    ds.first_n('f64', n=3),
-    ds.last_n('f64', n=3),
-    ds.where(ds.first_n('f64', n=3)),
-    ds.where(ds.last_n('f64', n=3)),
-])
-def test_reduction_on_cuda_raises_error(reduction):
-    with pytest.raises(ValueError, match="not supported on the GPU"):
-        c.points(df_cuda, 'x', 'y', reduction)

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -252,3 +252,14 @@ def cuda_nanmin_n_in_place(ret, other):
                     ret_pixel[i] = other_value
                     istart = i+1
                     break
+
+
+@cuda.jit
+def cuda_row_min_in_place(ret, other):
+    """CUDA equivalent of row_min_in_place.
+    """
+    ny, nx = ret.shape
+    x, y = cuda.grid(2)
+    if x < nx and y < ny:
+        if other[y, x] > -1 and (ret[y, x] == -1 or other[y, x] < ret[y, x]):
+            ret[y, x] = other[y, x]

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -263,3 +263,59 @@ def cuda_row_min_in_place(ret, other):
     if x < nx and y < ny:
         if other[y, x] > -1 and (ret[y, x] == -1 or other[y, x] < ret[y, x]):
             ret[y, x] = other[y, x]
+
+
+@cuda.jit
+def cuda_row_max_n_in_place(ret, other):
+    """CUDA equivalent of row_max_n_in_place.
+    """
+    ny, nx, n = ret.shape
+    x, y = cuda.grid(2)
+    if x < nx and y < ny:
+        ret_pixel = ret[y, x]      # 1D array of n values for single pixel
+        other_pixel = other[y, x]  # ditto
+        # Walk along other_pixel array a value at a time, find insertion
+        # index in ret_pixel and bump values along to insert.  Next
+        # other_pixel value is inserted at a higher index, so this walks
+        # the two pixel arrays just once each.
+        istart = 0
+        for other_value in other_pixel:
+            if other_value == -1:
+                break
+
+            for i in range(istart, n):
+                if ret_pixel[i] == -1 or other_value > ret_pixel[i]:
+                    # Bump values along then insert.
+                    for j in range(n-1, i, -1):  # fails
+                        ret_pixel[j] = ret_pixel[j-1]
+                    ret_pixel[i] = other_value
+                    istart = i+1
+                    break
+
+
+@cuda.jit
+def cuda_row_min_n_in_place(ret, other):
+    """CUDA equivalent of row_min_n_in_place.
+    """
+    ny, nx, n = ret.shape
+    x, y = cuda.grid(2)
+    if x < nx and y < ny:
+        ret_pixel = ret[y, x]      # 1D array of n values for single pixel
+        other_pixel = other[y, x]  # ditto
+        # Walk along other_pixel array a value at a time, find insertion
+        # index in ret_pixel and bump values along to insert.  Next
+        # other_pixel value is inserted at a higher index, so this walks
+        # the two pixel arrays just once each.
+        istart = 0
+        for other_value in other_pixel:
+            if other_value == -1:
+                break
+
+            for i in range(istart, n):
+                if ret_pixel[i] == -1 or other_value < ret_pixel[i]:
+                    # Bump values along then insert.
+                    for j in range(n-1, i, -1):
+                        ret_pixel[j] = ret_pixel[j-1]
+                    ret_pixel[i] = other_value
+                    istart = i+1
+                    break

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -735,20 +735,6 @@ def parallel_fill(array, value):
 
 
 @ngjit
-def row_max_in_place(ret, other):
-    """Maximum of 2 arrays of row indexes.
-    Row indexes are integers from 0 upwards, missing data is -1,
-    so simple max suffices.
-    Return the first array.
-    """
-    ret = ret.ravel()
-    other = other.ravel()
-    for i in range(len(ret)):
-        if other[i] > ret[i]:
-            ret[i] = other[i]
-
-
-@ngjit
 def row_min_in_place(ret, other):
     """Minimum of 2 arrays of row indexes.
     Row indexes are integers from 0 upwards, missing data is -1.

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -2,10 +2,10 @@
 :class:`~datashader.reductions.any`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.by`,      yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.count`,   yes, yes,        yes, yes,        yes,
-:class:`~datashader.reductions.first`,   yes, yes,        ,    ,           yes,          yes
-:class:`~datashader.reductions.first_n`, yes, yes,        ,    ,           ,             yes
-:class:`~datashader.reductions.last`,    yes, yes,        ,    ,           yes,          yes
-:class:`~datashader.reductions.last_n`,  yes, yes,        ,    ,           ,             yes
+:class:`~datashader.reductions.first`,   yes, yes,        yes, ,           yes,          yes
+:class:`~datashader.reductions.first_n`, yes, yes,        yes, ,           ,             yes
+:class:`~datashader.reductions.last`,    yes, yes,        yes, ,           yes,          yes
+:class:`~datashader.reductions.last_n`,  yes, yes,        yes, ,           ,             yes
 :class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.max_n`,   yes, yes,        yes, yes,        ,             yes
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -2,10 +2,10 @@
 :class:`~datashader.reductions.any`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.by`,      yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.count`,   yes, yes,        yes, yes,        yes,
-:class:`~datashader.reductions.first`,   yes, yes,        yes, ,           yes,          yes
-:class:`~datashader.reductions.first_n`, yes, yes,        yes, ,           ,             yes
-:class:`~datashader.reductions.last`,    yes, yes,        yes, ,           yes,          yes
-:class:`~datashader.reductions.last_n`,  yes, yes,        yes, ,           ,             yes
+:class:`~datashader.reductions.first`,   yes, yes,        yes, yes,        yes,          yes
+:class:`~datashader.reductions.first_n`, yes, yes,        yes, yes,        ,             yes
+:class:`~datashader.reductions.last`,    yes, yes,        yes, yes,        yes,          yes
+:class:`~datashader.reductions.last_n`,  yes, yes,        yes, yes,        ,             yes
 :class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.max_n`,   yes, yes,        yes, yes,        ,             yes
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,


### PR DESCRIPTION
This implements CUDA and CUDA-with-Dask support for the inspection reductions `first`, `first_n`, `last` and `last_n`, as well as the same reductions wrapped in a `where` reduction e.g. `where(first_n("value", n=3), "other")`.

Closes #1182 and #1207.

This is implemented on top of #1217; ideally that would be merged before this to keep the commits separate.