### PR TITLE
Prepare for 0.15.0 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           doit env_capture
       - name: conda build
-        run: doit package_build $PKG_TEST_PYTHON --test-group=all
+        run: doit package_build $PKG_TEST_PYTHON --no-pkg-tests
       - name: dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,49 @@
+Version 0.15.0 (2023-05-26)
+---------------------------
+
+This release provides significant improvements for inspection reductions by adding new ``first_n``, ``last_n``, ``max_n`` and ``min_n`` reductions, and providing Dask and CUDA support for all existing and new inspection reductions including ``where``. It also provides support for Numba 0.57, NumPy 1.24 and Python 3.11, and drops support for Python 3.7.
+
+Thanks to first-time contributors `@danigm <https://github.com/danigm>`_ and `@Jap8nted <https://github.com/Jap8nted>`_, and also regulars `@Hoxbro <https://github.com/Hoxbro>`_, `@philippjfr <https://github.com/philippjfr>`_ and `@ianthomas23 <https://github.com/ianthomas23>`_
+
+Enhancements:
+
+* Inspection reductions:
+
+  - Reduction append functions return index not boolean (#1180)
+  - ``first_n``, ``last_n``, ``max_n`` and ``min_n`` reductions (#1184)
+  - Add ``cuda`` argument to ``_build_combine`` (#1194)
+  - Support ``max_n`` and ``min_n`` reductions on GPU (#1196)
+  - Use fast cuda mutex available in numba 0.57 (#1212)
+  - Dask support for ``first``, ``last``, ``first_n`` and ``last_n`` reductions (#1214)
+  - Wrap use of cuda mutex in ``where`` reductions (#1217)
+  - Cuda and cuda-with-dask support for inspection reductions (#1219)
+
+* x and y range attributes on returned aggregations (#1198)
+
+* Make ``datashader.composite`` imports lazy for faster import time (#1222)
+
+* Improvements to CI:
+
+  - Cancel concurrent test workflows (#1208)
+
+* Improvements to documentation:
+
+  - Inspection reduction documentation (#1186, #1190)
+  - Upgrade to latest nbsite and pydata-sphinx-theme (#1221)
+  - Use geodatasets in example data
+
+Bug fixes:
+
+* Fix conversion from ``cupy`` in categorical ``rescale_discrete_levels`` (#1179)
+* Validate canvas ``width``, ``height`` (#1183)
+* Support antialiasing in pipeline API (#1213)
+
+Compatibility:
+
+* NumPy 1.24 compatibility (#1176, #1185, #1218)
+
+* Numba 0.57 compatibility (#1205)
+
 Version 0.14.4 (2023-02-02)
 ---------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,40 +9,40 @@ Enhancements:
 
 * Inspection reductions:
 
-  - Reduction append functions return index not boolean (#1180)
-  - ``first_n``, ``last_n``, ``max_n`` and ``min_n`` reductions (#1184)
-  - Add ``cuda`` argument to ``_build_combine`` (#1194)
-  - Support ``max_n`` and ``min_n`` reductions on GPU (#1196)
-  - Use fast cuda mutex available in numba 0.57 (#1212)
-  - Dask support for ``first``, ``last``, ``first_n`` and ``last_n`` reductions (#1214)
-  - Wrap use of cuda mutex in ``where`` reductions (#1217)
-  - Cuda and cuda-with-dask support for inspection reductions (#1219)
+  - Reduction append functions return index not boolean (`#1180 <https://github.com/holoviz/datashader/pull/1180>`_)
+  - ``first_n``, ``last_n``, ``max_n`` and ``min_n`` reductions (`#1184 <https://github.com/holoviz/datashader/pull/1184>`_)
+  - Add ``cuda`` argument to ``_build_combine`` (`#1194 <https://github.com/holoviz/datashader/pull/1194>`_)
+  - Support ``max_n`` and ``min_n`` reductions on GPU (`#1196 <https://github.com/holoviz/datashader/pull/1196>`_)
+  - Use fast cuda mutex available in numba 0.57 (`#1212 <https://github.com/holoviz/datashader/pull/1212>`_)
+  - Dask support for ``first``, ``last``, ``first_n`` and ``last_n`` reductions (`#1214 <https://github.com/holoviz/datashader/pull/1214>`_)
+  - Wrap use of cuda mutex in ``where`` reductions (`#1217 <https://github.com/holoviz/datashader/pull/1217>`_)
+  - Cuda and cuda-with-dask support for inspection reductions (`#1219 <https://github.com/holoviz/datashader/pull/1219>`_)
 
-* x and y range attributes on returned aggregations (#1198)
+* x and y range attributes on returned aggregations (`#1198 <https://github.com/holoviz/datashader/pull/1198>`_)
 
-* Make ``datashader.composite`` imports lazy for faster import time (#1222)
+* Make ``datashader.composite`` imports lazy for faster import time (`#1222 <https://github.com/holoviz/datashader/pull/1222>`_)
 
 * Improvements to CI:
 
-  - Cancel concurrent test workflows (#1208)
+  - Cancel concurrent test workflows (`#1208 <https://github.com/holoviz/datashader/pull/1208>`_)
 
 * Improvements to documentation:
 
-  - Inspection reduction documentation (#1186, #1190)
-  - Upgrade to latest nbsite and pydata-sphinx-theme (#1221)
+  - Inspection reduction documentation (`#1186 <https://github.com/holoviz/datashader/pull/1186>`_, `#1190 <https://github.com/holoviz/datashader/pull/1190>`_)
+  - Upgrade to latest nbsite and pydata-sphinx-theme (`#1221 <https://github.com/holoviz/datashader/pull/1221>`_)
   - Use geodatasets in example data
 
 Bug fixes:
 
-* Fix conversion from ``cupy`` in categorical ``rescale_discrete_levels`` (#1179)
-* Validate canvas ``width``, ``height`` (#1183)
-* Support antialiasing in pipeline API (#1213)
+* Fix conversion from ``cupy`` in categorical ``rescale_discrete_levels`` (`#1179 <https://github.com/holoviz/datashader/pull/1179>`_)
+* Validate canvas ``width``, ``height`` (`#1183 <https://github.com/holoviz/datashader/pull/1183>`_)
+* Support antialiasing in pipeline API (`#1213 <https://github.com/holoviz/datashader/pull/1213>`_)
 
 Compatibility:
 
-* NumPy 1.24 compatibility (#1176, #1185, #1218)
+* NumPy 1.24 compatibility (`#1176 <https://github.com/holoviz/datashader/pull/1176>`_, `#1185 <https://github.com/holoviz/datashader/pull/1185>`_, `#1218 <https://github.com/holoviz/datashader/pull/1218>`_)
 
-* Numba 0.57 compatibility (#1205)
+* Numba 0.57 compatibility (`#1205 <https://github.com/holoviz/datashader/pull/1205>`_)
 
 Version 0.14.4 (2023-02-02)
 ---------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-Version 0.15.0 (2023-05-26)
+Version 0.15.0 (2023-05-30)
 ---------------------------
 
 This release provides significant improvements for inspection reductions by adding new ``first_n``, ``last_n``, ``max_n`` and ``min_n`` reductions, and providing Dask and CUDA support for all existing and new inspection reductions including ``where``. It also provides support for Numba 0.57, NumPy 1.24 and Python 3.11, and drops support for Python 3.7.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/holoviz/datashader/raw/main/doc/_static/logo_stacked.png" data-canonical-src="https://github.com/holoviz/datashader/raw/main/doc/_static/logo_stacked.png" width="200"/><br>
+<img src="https://github.com/holoviz/datashader/raw/main/doc/_static/logo_horizontal.svg" data-canonical-src="https://github.com/holoviz/datashader/raw/main/doc/_static/logo_horizontal.svg" width="400"/><br>
 
 -----------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,7 +2,7 @@
 
 .. raw:: html
 
-  <h1><img src="_static/logo_horizontal.png" style="width: 50%;"></h1>
+  <h1><img class="dark-light" src="_static/logo_horizontal.svg" style="width: 50%;"></h1>
 
 **Accurately render even the largest data**
 

--- a/examples/getting_started/3_Interactivity.ipynb
+++ b/examples/getting_started/3_Interactivity.ipynb
@@ -211,7 +211,7 @@
     "from datashader.colors import Sets1to3\n",
     "\n",
     "datashaded  = hd.datashade(points, aggregator=ds.count_cat('cat'), color_key=Sets1to3)\n",
-    "gaussspread = hd.dynspread(datashaded, threshold=0.50, how='over').opts(plot=dict(height=400,width=400))\n",
+    "gaussspread = hd.dynspread(datashaded, threshold=0.50, how='over').opts(height=400,width=400)\n",
     "\n",
     "color_key = [(name,color) for name,color in zip([\"d1\",\"d2\",\"d3\",\"d4\",\"d5\"], Sets1to3)]\n",
     "color_points = hv.NdOverlay({n: hv.Points([0,0], label=str(n)).opts(color=c,size=0) for n,c in color_key})\n",

--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,11 @@ extras_require = {
         'python-graphviz',
         'python-snappy',
         'rasterio',
-        'snappy',
     ]
 }
 
 extras_require['doc'] = extras_require['examples_extra'] + [
-    'nbsite >=0.8.0rc37',
+    'nbsite ==0.8.0',
     'numpydoc',
 ]
 


### PR DESCRIPTION
Prepare for 0.15.0 release:

- Changelog.
- `conda` build fix.
- Documentation fix.
- Use SVG for logo as it works for dark and light mode.