### PR TITLE
Use enum for row index column rather than None

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1300,6 +1300,10 @@ def _bypixel_sanitise(source, glyph, agg):
 
 
 def _cols_to_keep(columns, glyph, agg):
+    """
+    Return which columns from the supplied data source are kept as they are
+    needed by the specified agg. Excludes any SpecialColumn.
+    """
     cols_to_keep = OrderedDict({col: False for col in columns})
     for col in glyph.required_columns():
         cols_to_keep[col] = True
@@ -1310,9 +1314,9 @@ def _cols_to_keep(columns, glyph, agg):
                 recurse(cols_to_keep, subagg)
         elif hasattr(agg, 'columns'):
             for column in agg.columns:
-                if column is not None:
+                if column not in (None, rd.SpecialColumn.RowIndex):
                     cols_to_keep[column] = True
-        elif agg.column is not None:
+        elif agg.column not in (None, rd.SpecialColumn.RowIndex):
             cols_to_keep[agg.column] = True
 
     recurse(cols_to_keep, agg)


### PR DESCRIPTION
Internally within Datashader we pass around column string names to identify which columns of the source (e.g. DataFrame) need to be passed to the low-level numba functions. Up until now we have used `None` to represent either no column, which would apply to an `any()` reduction, or a virtual row index column for reductions like `where`. The multiple use of `None` for both is confusing, so this PR introduces a new `Enum` for `RowIndex` so that it is easy to identify this being different from `None` representing no column required.

External API is not changed.