### PR TITLE
Only check dask.DataFrame dtypes of columns actually used

### DIFF
--- a/datashader/data_libraries/dask_xarray.py
+++ b/datashader/data_libraries/dask_xarray.py
@@ -59,7 +59,7 @@ def dask_rectilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize, antialias_stage_2 = compile_components(
+    create, info, append, combine, finalize, antialias_stage_2, _ = compile_components(
         summary, schema, glyph, antialias=antialias, cuda=cuda, partitioned=True)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
@@ -141,7 +141,7 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize, antialias_stage_2 = compile_components(
+    create, info, append, combine, finalize, antialias_stage_2, _ = compile_components(
         summary, schema, glyph, antialias=antialias, cuda=cuda, partitioned=True)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
@@ -235,7 +235,7 @@ def dask_curvilinear(glyph, xr_ds, schema, canvas, summary, *, antialias=False, 
     shape, bounds, st, axis = shape_bounds_st_and_axis(xr_ds, canvas, glyph)
 
     # Compile functions
-    create, info, append, combine, finalize, antialias_stage_2 = compile_components(
+    create, info, append, combine, finalize, antialias_stage_2, _ = compile_components(
         summary, schema, glyph, antialias=antialias, cuda=cuda, partitioned=True)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -24,7 +24,7 @@ glyph_dispatch = Dispatcher()
 @glyph_dispatch.register(_GeometryLike)
 @glyph_dispatch.register(_AreaToLineLike)
 def default(glyph, source, schema, canvas, summary, *, antialias=False, cuda=False):
-    create, info, append, _, finalize, antialias_stage_2 = compile_components(
+    create, info, append, _, finalize, antialias_stage_2, _ = compile_components(
         summary, schema, glyph, antialias=antialias, cuda=cuda, partitioned=False)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -2118,3 +2118,13 @@ def test_canvas_size():
     for cvs in cvs_list:
         with pytest.raises(ValueError, match=msg):
             cvs.points(ddf, "x", "y", ds.mean("z"))
+
+
+@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('npartitions', [1, 2, 3])
+def test_dataframe_dtypes(ddf, npartitions):
+    # Issue #1235.
+    ddf['dates'] = pd.Series(['2007-07-13']*20, dtype='datetime64[ns]')
+    ddf = ddf.repartition(npartitions)
+    assert ddf.npartitions == npartitions
+    ds.Canvas(2, 2).points(ddf, 'x', 'y', ds.count())


### PR DESCRIPTION
Fixes #1235.

In our dask DataFrame workflows we use a prediction of a `dtype` to return, and previously we tried to calculate one that suited all columns of the DataFrame. This fix restricts the calculation to only look at the columns that we actually use.

In terms of implementation, the columns used have already been identified in the `compile_components` function so we just need to return them to all callers, and the dask workflow now uses just those columns.

I have been really conservative here. Using up-to-date dependent packages the predicted `dtype` doesn't matter at all, I can put in anything here and datashader works as expected. But given that this code does some potentially risky things with dask internals I do not want to change it any more than necessary.