### PR TITLE
Ensure categorical column order is the same across dask partitions

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1289,7 +1289,7 @@ def _bypixel_sanitise(source, glyph, agg):
                 source[glyph.geometry].array._sindex = sindex
         dshape = dshape_from_pandas(source)
     elif isinstance(source, dd.DataFrame):
-        dshape = dshape_from_dask(source)
+        dshape, source = dshape_from_dask(source)
     elif isinstance(source, Dataset):
         # Multi-dimensional Dataset
         dshape = dshape_from_xarray_dataset(source)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -456,7 +456,7 @@ def dshape_from_dask(df):
     # for dask-cudf DataFrames with multiple partitions
     return datashape.var * datashape.Record([
         (k, dshape_from_pandas_helper(df[k].get_partition(0))) for k in df.columns
-    ])
+    ]), df
 
 
 def dshape_from_xarray_dataset(xr_ds):


### PR DESCRIPTION
Fixes #1202.

This fixes datashader's handling of categorical columns in dask partitions. It was broken by a change in dask's reading of categorical columns between releases `2022.7.0` and `2022.7.1` (dask/dask#9264) but really is due to our slightly inconsistent handling of categorical columns which we got away with historically but not after that change.

Relevant section of dask docs is https://docs.dask.org/en/stable/dataframe-categoricals.html. When categorical columns are read from parquet files there is no enforcement of the columns being the same across dask partitions for performance reasons, and we need to do this ourselves. They provide a couple of solutions, both of which incur a performance loss as they involve traversing the whole dataframe.

Cutting a long story short, the fix is actually a two-liner in datashader. We already correct the categorical columns in `dshape_from_dask()` by calling `categorize` passing a list of the categorical columns to correct. The corrected `dask.DataFrame` is used in datashader to work out the full list of categories for the categorical dimension of the returned `xarray.DataArray`. But the originally supplied (and therefore uncorrected) `dask.DataFrame` was still used in each individual partition's mapping of category to integer index. So the fix is to use the categorically-corrected `DataFrame` for the remainder of the datashader calculations. As we were already performinng the `categorize` call, we incur no performance loss by doing this.

I have added a new explicit test.

Using the USA 2010 Census data and the following test code:
```python
import dask.dataframe as dd
import datashader as ds

cvs = ds.Canvas(plot_width=450, plot_height=265, x_range=[-14E6, -7.4E6], y_range=[2.7E6, 6.4E6])

for engine in ('fastparquet', 'pyarrow'):
    df  = dd.read_parquet('~/data/census2010.parq', engine=engine)
    agg = cvs.points(df, 'easting', 'northing', ds.count_cat('race'))
    color_key = {'w':'aqua', 'b':'lime', 'a':'red', 'h':'fuchsia', 'o':'yellow' }
    img = ds.tf.shade(agg, how='eq_hist', color_key=color_key)
    ds.utils.export_image(img, f'issue1202_{engine}')
```
before the fix we see for `fastparquet` and `pyarrow` readers respectively
![before_fastparquet](https://github.com/holoviz/datashader/assets/580326/b6eb4a30-e260-4b4a-87d5-6603c484a620)
![before_pyarrow](https://github.com/holoviz/datashader/assets/580326/b4d05eb4-f7e4-42d2-aa62-6dfc42841dea)

and after the fix
![after_fastparquet](https://github.com/holoviz/datashader/assets/580326/09c5c54f-33aa-47ac-b36e-87c690b387b1)
![after_pyarrow](https://github.com/holoviz/datashader/assets/580326/fae98329-4a93-48c5-8007-99bf504782d5)
