### PR TITLE
Bump holoviz tasks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,12 +30,12 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a9
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a14
         with:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}
           channel-priority: strict
-          channels: pyviz/label/dev,numba,conda-forge,nodefaults
+          channels: pyviz/label/dev,conda-forge,nodefaults
           envs: "-o tests -o examples"
           cache: true
           conda-update: true

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ examples = [
     'geopandas',
     'holoviews',
     'matplotlib',
+    'panel >1.1',
     'scikit-image',
     'spatialpandas',
 ]


### PR DESCRIPTION
- Bump holoviz tasks to `v0.1a14`
- Removed use of `numba` conda channel
- Pinning `panel >1.1`