### PR TITLE
Add tests for handling of NaNs in where reductions

### DIFF
--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -46,9 +46,10 @@ df_pd = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                       'cat_int': np.array([10]*5 + [11]*5 + [12]*5 + [13]*5)})
 df_pd.cat = df_pd.cat.astype('category')
 df_pd.cat2 = df_pd.cat2.astype('category')
-df_pd.at[2,'f32'] = nan
-df_pd.at[2,'f64'] = nan
-df_pd.at[2,'plusminus'] = nan
+df_pd.at[2, 'f32'] = nan
+df_pd.at[2, 'f64'] = nan
+df_pd.at[6, 'reverse'] = nan
+df_pd.at[2, 'plusminus'] = nan
 
 _ddf = dd.from_pandas(df_pd, npartitions=2)
 
@@ -558,7 +559,7 @@ def test_where_max_n(ddf, npartitions):
                               [14, 12, 10, 11, 13, -1]],
                              [[ 8,  6,  5,  7,  9, -1],
                               [18, 16, 15, 17, 19, -1]]])
-    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = np.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 7):
         # Using row index.
@@ -587,7 +588,7 @@ def test_where_min_n(ddf, npartitions):
                               [13, 11, 10, 12, 14, -1]],
                              [[ 9,  7,  5,  6,  8, -1],
                               [19, 17, 15, 16, 18, -1]]])
-    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = np.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 7):
         # Using row index.
@@ -658,7 +659,7 @@ def test_where_first_n(ddf, npartitions):
                               [10, 11, 12, 13, 14, -1]],
                              [[ 5,  6,  7,  8,  9, -1],
                               [15, 16, 17, 18, 19, -1]]])
-    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = np.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 7):
         # Using row index.
@@ -687,7 +688,7 @@ def test_where_last_n(ddf, npartitions):
                               [14, 13, 12, 11, 10, -1]],
                              [[ 9,  8,  7,  6,  5, -1],
                               [19, 18, 17, 16, 15, -1]]])
-    sol_reverse = np.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = np.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 7):
         # Using row index.
@@ -720,7 +721,8 @@ def test_summary_where_n(ddf, npartitions):
                                     [14, 12, 10, 11, 13]],
                                    [[ 8,  6,  5,  7,  9],
                                     [18, 16, 15, 17, 19]]])
-    sol_max_n_reverse = np.where(sol_max_n_rowindex < 0, np.nan, 20 - sol_max_n_rowindex)
+    sol_max_n_reverse = np.where(np.logical_or(sol_max_n_rowindex < 0, sol_max_n_rowindex == 6),
+                                 np.nan, 20 - sol_max_n_rowindex)
 
     agg = c.points(ddf, 'x', 'y', ds.summary(
         count=ds.count(),
@@ -2234,7 +2236,7 @@ def test_categorical_where_max(ddf, npartitions):
     assert ddf.npartitions == npartitions
     sol_rowindex = xr.DataArray([[[4, 1, -1, 3], [12, 13, 14, 11]], [[8, 5, 6, 7], [16, 17, 18, 15]]],
                                 coords=coords + [['a', 'b', 'c', 'd']], dims=dims + ['cat2'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     # Using row index
     agg = c.points(ddf, 'x', 'y', ds.by('cat2', ds.where(ds.max('plusminus'))))
@@ -2254,7 +2256,7 @@ def test_categorical_where_min(ddf, npartitions):
     assert ddf.npartitions == npartitions
     sol_rowindex = xr.DataArray([[[0, 1, -1, 3], [12, 13, 10, 11]], [[8, 9, 6, 7], [16, 17, 18, 19]]],
                                 coords=coords + [['a', 'b', 'c', 'd']], dims=dims + ['cat2'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     # Using row index
     agg = c.points(ddf, 'x', 'y', ds.by('cat2', ds.where(ds.min('plusminus'))))
@@ -2274,7 +2276,7 @@ def test_categorical_where_first(ddf, npartitions):
     assert ddf.npartitions == npartitions
     sol_rowindex = xr.DataArray([[[0, 1, -1, 3], [12, 13, 10, 11]], [[8, 5, 6, 7], [16, 17, 18, 15]]],
                                 coords=coords + [['a', 'b', 'c', 'd']], dims=dims + ['cat2'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     # Using row index
     agg = c.points(ddf, 'x', 'y', ds.by('cat2', ds.where(ds.first('plusminus'))))
@@ -2294,7 +2296,7 @@ def test_categorical_where_last(ddf, npartitions):
     assert ddf.npartitions == npartitions
     sol_rowindex = xr.DataArray([[[4, 1, -1, 3], [12, 13, 14, 11]], [[8, 9, 6, 7], [16, 17, 18, 19]]],
                                 coords=coords + [['a', 'b', 'c', 'd']], dims=dims + ['cat2'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     # Using row index
     agg = c.points(ddf, 'x', 'y', ds.by('cat2', ds.where(ds.last('plusminus'))))
@@ -2318,7 +2320,7 @@ def test_categorical_where_max_n(ddf, npartitions):
          [[[8, -1, -1], [5, 9, -1], [6, -1, -1], [7, -1, -1]],
           [[16, -1, -1], [17, -1, -1], [18, -1, -1], [15, 19, -1]]]],
         coords=coords + [['a', 'b', 'c', 'd'], [0, 1, 2]], dims=dims + ['cat2', 'n'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 4):
         # Using row index
@@ -2351,7 +2353,7 @@ def test_categorical_where_min_n(ddf, npartitions):
          [[[8, -1, -1], [9, 5, -1], [6, -1, -1], [7, -1, -1]],
           [[16, -1, -1], [17, -1, -1], [18, -1, -1], [19, 15, -1]]]],
         coords=coords + [['a', 'b', 'c', 'd'], [0, 1, 2]], dims=dims + ['cat2', 'n'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 4):
         # Using row index
@@ -2384,7 +2386,7 @@ def test_categorical_where_first_n(ddf, npartitions):
          [[[8, -1, -1], [5, 9, -1], [6, -1, -1], [7, -1, -1]],
           [[16, -1, -1], [17, -1, -1], [18, -1, -1], [15, 19, -1]]]],
         coords=coords + [['a', 'b', 'c', 'd'], [0, 1, 2]], dims=dims + ['cat2', 'n'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 4):
         # Using row index
@@ -2413,7 +2415,7 @@ def test_categorical_where_last_n(ddf, npartitions):
          [[[8, -1, -1], [9, 5, -1], [6, -1, -1], [7, -1, -1]],
           [[16, -1, -1], [17, -1, -1], [18, -1, -1], [19, 15, -1]]]],
         coords=coords + [['a', 'b', 'c', 'd'], [0, 1, 2]], dims=dims + ['cat2', 'n'])
-    sol_reverse = xr.where(sol_rowindex < 0, np.nan, 20 - sol_rowindex)
+    sol_reverse = xr.where(np.logical_or(sol_rowindex < 0, sol_rowindex == 6), np.nan, 20 - sol_rowindex)
 
     for n in range(1, 4):
         # Using row index


### PR DESCRIPTION
Fixes #1215.

There are no code changes here, the correct behaviour has already been implemented in previous PRs. This modifies existing tests by adding extra `NaN`s to explicitly test that the behaviour is correct.