### PR TITLE
Update readme to include python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to work with much larger datasets than it would otherwise.
 
 ## Installation
 
-Datashader supports Python 3.8, 3.9 and 3.10 on Linux, Windows, or
+Datashader supports Python 3.8, 3.9, 3.10, and 3.11 on Linux, Windows, or
 Mac and can be installed with conda:
 
     conda install datashader


### PR DESCRIPTION
Added Python 3.11 in `Installation` section as datashader has officially supported it since version 0.15.0