### PR TITLE
Correct links to pandas docs

### DIFF
--- a/datashader/tests/test_datatypes.py
+++ b/datashader/tests/test_datatypes.py
@@ -519,7 +519,7 @@ def test_equality_validation(other):
 
 # Pandas-provided extension array tests
 # -------------------------------------
-# See http://pandas-docs.github.io/pandas-docs-travis/extending.html
+# See https://pandas.pydata.org/docs/development/extending.html
 @pytest.fixture
 def dtype():
     """A fixture providing the ExtensionDtype to validate."""

--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -248,7 +248,7 @@
     "The above examples are 2D reductions that generate a single _x_ × _y_ aggregate array when given a particular reduction operator. You can instead supply a `by` reduction operator to do 3D reductions, resulting in a stack of aggregate arrays, _x_ × _y_ × _c_, where _c_ is some other column:\n",
     "\n",
     "**`by(column, reduction)`**: \n",
-    "  create a 3D stack of aggregates, with each datapoint contributing to _one_ of the aggregate arrays according to the value of the indicated [categorical column](https://pandas-docs.github.io/pandas-docs-travis/user_guide/categorical.html) or `categorizer` object and using the indicated 2D `reduction` operator to create each 2D array in the 3D stack.\n",
+    "  create a 3D stack of aggregates, with each datapoint contributing to _one_ of the aggregate arrays according to the value of the indicated [categorical column](https://pandas.pydata.org/docs/user_guide/categorical.html) or `categorizer` object and using the indicated 2D `reduction` operator to create each 2D array in the 3D stack.\n",
     "  \n",
     "The resulting 3D stack can later be selected or collapsed into a 2D array for visualization, or the third dimension can be used for colormappping to generate an _x_ × _y_ × _color_ image.\n",
     "\n",


### PR DESCRIPTION
This corrects a couple of links to pandas docs, originally identified by @jlstevens.