### PR TITLE
Remove twitter from index page [skip ci]

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,12 +6,6 @@
 
 **Accurately render even the largest data**
 
-.. raw:: html
-
-  <div style="display: flex">
-    <div style="width: 70%">
-
-
 New to Datashader? Check out this
 `quick video introduction to what it does and how it works <https://youtu.be/U6dyIRolIhI>`_!
 
@@ -31,14 +25,6 @@ hardware, while exploiting distributed and GPU systems when available.
 
 .. raw:: html
 
-  </div>
-
-.. raw:: html
-    :file: latest_news.html
-
-.. raw:: html
-
-  </div>
   <hr width='100%'></hr>
 
 .. notebook:: datashader ../examples/index.ipynb

--- a/doc/latest_news.html
+++ b/doc/latest_news.html
@@ -1,3 +1,0 @@
-<div style='width: 30%; float: right; margin-right: -15%; margin-top: -12%; padding-left: 20px;'>
-  <a class="twitter-timeline" data-width="400" data-height="560" data-link-color="#902040" href="https://twitter.com/datashader">Tweets Datashader</a>
-</div><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
Remove twitter from doc index page.

Following holoviz/holoviews#5815.

Top of index page now looks like this:
<img width="1095" alt="Screenshot 2023-07-21 at 17 28 11" src="https://github.com/holoviz/datashader/assets/580326/89dbdaf8-e261-426e-b009-128fb37dbdeb">
