### PR TITLE
Support by reduction within summary reduction

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -116,8 +116,9 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False, parti
     temps = list(pluck(4, calls))
     combine_temps = list(pluck(5, calls))
 
+    categorical = agg.is_categorical()
     create = make_create(bases, dshapes, cuda)
-    append, uses_cuda_mutex = make_append(bases, cols, calls, glyph, isinstance(agg, by), antialias)
+    append, uses_cuda_mutex = make_append(bases, cols, calls, glyph, categorical, antialias)
     info = make_info(cols, uses_cuda_mutex)
     combine = make_combine(bases, dshapes, temps, combine_temps, antialias, cuda, partitioned)
     finalize = make_finalize(bases, agg, schema, cuda, partitioned)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -324,6 +324,10 @@ class Reduction(Expr):
     def inputs(self):
         return (extract(self.column),)
 
+    def is_categorical(self):
+        """Return ``True`` if this is or contains a categorical reduction."""
+        return False
+
     def is_where(self):
         """Return ``True`` if this is a ``where`` reduction or directly wraps
         a where reduction."""
@@ -685,6 +689,9 @@ class by(Reduction):
     @property
     def inputs(self):
         return (self.preprocess,)
+
+    def is_categorical(self):
+        return True
 
     def is_where(self):
         return self.reduction.is_where()
@@ -1995,6 +2002,9 @@ class summary(Expr):
 
     def __hash__(self):
         return hash((type(self), tuple(self.keys), tuple(self.values)))
+
+    def is_categorical(self):
+        return any(v.is_categorical() for v in self.values)
 
     def uses_row_index(self, cuda, partitioned):
         return any(v.uses_row_index(cuda, partitioned) for v in self.values)

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -2004,10 +2004,16 @@ class summary(Expr):
         return hash((type(self), tuple(self.keys), tuple(self.values)))
 
     def is_categorical(self):
-        return any(v.is_categorical() for v in self.values)
+        for v in self.values:
+            if v.is_categorical():
+                return True
+        return False
 
     def uses_row_index(self, cuda, partitioned):
-        return any(v.uses_row_index(cuda, partitioned) for v in self.values)
+        for v in self.values:
+            if v.uses_row_index(cuda, partitioned):
+                return True
+        return False
 
     def validate(self, input_dshape):
         for v in self.values:

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -332,6 +332,19 @@ def test_last_n(ddf, npartitions):
 
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
+def test_categorical_count(ddf, npartitions):
+    ddf = ddf.repartition(npartitions)
+    assert ddf.npartitions == npartitions
+    sol = np.array([[[2, 1, 1, 1], [1, 1, 2, 1]], [[1, 2, 1, 1], [1, 1, 1, 2]]], dtype=np.uint32)
+    assert_eq_ndarray(c.points(ddf, 'x', 'y', ds.by('cat2')).data, sol)
+
+    # ds.summary(name=ds.by("cat2")) should give same result as ds.by("cat2"). Issue 1252
+    dataset = c.points(ddf, 'x', 'y', ds.summary(name=ds.by('cat2')))
+    assert_eq_ndarray(dataset["name"].data, sol)
+
+
+@pytest.mark.parametrize('ddf', ddfs)
+@pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_categorical_min(ddf, npartitions):
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -712,6 +712,10 @@ def test_categorical_count(df):
     agg = c.points(df, 'x', 'y', ds.by('cat', ds.count('i32')))
     assert_eq_xr(agg, out)
 
+    # ds.summary(name=ds.by("cat")) should give same result as ds.by("cat"). Issue 1252
+    dataset = c.points(df, 'x', 'y', ds.summary(name=ds.by('cat', ds.count('i32'))))
+    assert_eq_xr(dataset["name"], out)
+
     # categorizing by (cat_int-10)%4 ought to give the same result
     out = xr.DataArray(sol, coords=coords + [range(4)], dims=(dims + ['cat_int']))
     agg = c.points(df, 'x', 'y', ds.by(ds.category_modulo('cat_int', modulo=4, offset=10), ds.count()))


### PR DESCRIPTION
Fixes #1252, allowing use of `by` reduction within a `summary` reduction such as
```python
ds.summary(other=ds.by("cat"))`
```