### PR TITLE
Support summary containing by reduction with other reductions

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -736,6 +736,9 @@ class by(Reduction):
         cats = list(self.categorizer.categories(dshape))
 
         def finalize(bases, cuda=False, **kwargs):
+            # Return a modified copy of kwargs. Cannot modify supplied kwargs as it
+            # may be used by multiple reductions, e.g. if a summary reduction.
+            kwargs = copy.deepcopy(kwargs)
             kwargs['dims'] += [self.cat_column]
             kwargs['coords'][self.cat_column] = cats
             return self.reduction._build_finalize(dshape)(bases, cuda=cuda, **kwargs)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -611,6 +611,37 @@ def test_where_min_n(df):
 
 
 @pytest.mark.parametrize('df', dfs)
+def test_summary_by(df):
+    # summary(by)
+    agg_summary = c.points(df, 'x', 'y', ds.summary(by=ds.by("cat")))
+    agg_by = c.points(df, 'x', 'y', ds.by("cat"))
+    assert_eq_xr(agg_summary["by"], agg_by)
+
+    # summary(by, other_reduction)
+    agg_summary = c.points(df, 'x', 'y', ds.summary(by=ds.by("cat"), max=ds.max("plusminus")))
+    agg_max = c.points(df, 'x', 'y', ds.max("plusminus"))
+    assert_eq_xr(agg_summary["by"], agg_by)
+    assert_eq_xr(agg_summary["max"], agg_max)
+
+    # summary(other_reduction, by)
+    agg_summary = c.points(df, 'x', 'y', ds.summary(max=ds.max("plusminus"), by=ds.by("cat")))
+    assert_eq_xr(agg_summary["by"], agg_by)
+    assert_eq_xr(agg_summary["max"], agg_max)
+
+    # summary(by, by)
+    agg_summary = c.points(df, 'x', 'y', ds.summary(by=ds.by("cat"), by_any=ds.by("cat", ds.any())))
+    agg_by_any = c.points(df, 'x', 'y', ds.by("cat", ds.any()))
+    assert_eq_xr(agg_summary["by"], agg_by)
+    assert_eq_xr(agg_summary["by_any"], agg_by_any)
+
+    # summary(by("cat1"), by("cat2"))
+    agg_summary = c.points(df, 'x', 'y', ds.summary(by=ds.by("cat"), by2=ds.by("cat2")))
+    agg_by2 = c.points(df, 'x', 'y', ds.by("cat2"))
+    assert_eq_xr(agg_summary["by"], agg_by)
+    assert_eq_xr(agg_summary["by2"], agg_by2)
+
+
+@pytest.mark.parametrize('df', dfs)
 def test_summary_where_n(df):
     sol_min_n_rowindex = np.array([[[ 3,  1,  0,  4, -1],
                                     [13, 11, 10, 12, 14]],


### PR DESCRIPTION
Fixes #1256.

Adds support for the following combinations of `summary` and `by` reductions:

1. `summary(by("cat1"), other_reduction)` and with the order swapped.
2. `summary(by("cat1"), by("cat1"))`
3. `summary(by("cat1"), by("cat2"))`

The biggest change here is in the handling of categorical columns in `compiler.py` `make_append()`. Previously the `categorical` flag was constant for all reductions within a `summary`, now it is checked for each constituent reduction. Where categorical columns are reused, they are only extracted once.

Also, the addition of `kwargs` to `xr.DataArray` in `by.finalize` has been modified to follow the same approach as in `where` reductions, which is to add the new categorical coords/dims to a copy of the `kwargs`, not modify them in-place. Hence each constituent reduction of a `summary` can have different categorical coordinates from others.

Tested on CPU and GPU, with and without Dask.