### PR TITLE
Support antialiased lines in *_n reductions

### DIFF
--- a/datashader/antialias.py
+++ b/datashader/antialias.py
@@ -32,11 +32,13 @@ def two_stage_agg(antialias_stage_2: UnzippedAntialiasStage2 | None):
         # Not using antialiased lines, doesn't matter what is returned.
         return False, False
 
+    aa_combinations = antialias_stage_2[0]
+
     # A single combination in (SUM_2AGG, FIRST, LAST, MIN) means that a 2-stage
     # aggregation will be used, otherwise use a 1-stage aggregation that is
     # faster.
     use_2_stage_agg = False
-    for comb in antialias_stage_2[0]:
+    for comb in aa_combinations:
         if comb in (AntialiasCombination.SUM_2AGG, AntialiasCombination.MIN,
                     AntialiasCombination.FIRST, AntialiasCombination.LAST):
             use_2_stage_agg = True
@@ -47,7 +49,7 @@ def two_stage_agg(antialias_stage_2: UnzippedAntialiasStage2 | None):
     # complicated correction algorithm. Prefer overwrite=True for speed, but
     # any SUM_1AGG implies overwrite=False.
     overwrite = True
-    for comb in antialias_stage_2[0]:
+    for comb in aa_combinations:
         if comb == AntialiasCombination.SUM_1AGG:
             overwrite = False
             break

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -440,7 +440,8 @@ The axis argument to Canvas.line must be 0 or 1
 
             if not isinstance(non_cat_agg, (
                 rd.any, rd.count, rd.max, rd.min, rd.sum, rd.summary, rd._sum_zero,
-                rd.mean, rd._first_or_last, rd._max_or_min_row_index,
+                rd._first_or_last, rd.mean, rd.max_n, rd.min_n, rd._first_n_or_last_n,
+                rd._max_or_min_row_index, rd._max_n_or_min_n_row_index
             )):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -2494,6 +2494,45 @@ def test_line_antialias():
     agg = cvs.line(agg=ds._max_row_index(), **kwargs)
     assert_eq_ndarray(agg.data, line_antialias_sol_max_index_0)
 
+    agg = cvs.line(agg=ds._min_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, line_antialias_sol_min_index_0)
+    sol = np.full((11, 11), -1)
+    sol[(4, 5, 5, 5, 6, 1, 2), (5, 4, 5, 6, 5, 9, 9)] = 2
+    sol[8:10, 9] = 1
+    assert_eq_ndarray(agg[:, :, 1].data, sol)
+
+    agg = cvs.line(agg=ds._max_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, line_antialias_sol_max_index_0)
+    sol = np.full((11, 11), -1)
+    sol[(4, 5, 5, 5, 6, 8, 9), (5, 4, 5, 6, 5, 9, 9)] = 0
+    sol[1:3, 9] = 1
+    assert_eq_ndarray(agg[:, :, 1].data, sol)
+
+    agg = cvs.line(agg=ds.max_n("value", n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, 3*line_antialias_sol_0, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[(1, 5, 9), (9, 5, 9)] = 3.0
+    sol[(2, 4, 5, 5, 6, 8), (9, 5, 4, 6, 5, 9)] = 0.878680
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
+    agg = cvs.line(agg=ds.min_n("value", n=2), **kwargs)
+    sol = 3*line_antialias_sol_0
+    sol[(2, 8), (9, 9)] = 0.878680
+    assert_eq_ndarray(agg[:, :, 0].data, sol, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[(1, 2, 5, 8, 9), (9, 9, 5, 9, 9)] = 3.0
+    sol[(4, 5, 5, 6), (5, 4, 6, 5)] = 0.878680
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
+    agg = cvs.line(agg=ds.first_n("value", n=2), **kwargs)
+    sol = 3*line_antialias_sol_0
+    sol[8, 9] = 0.878680
+    assert_eq_ndarray(agg[:, :, 0].data, sol, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[(1, 5, 8, 9), (9, 5, 9, 9)] = 3.0
+    sol[(2, 4, 5, 5, 6), (9, 5, 4, 6, 5)] = 0.878680
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
     # Second line only, doesn't self-intersect
     kwargs = dict(source=line_antialias_df, x="x1", y="y1", line_width=1)
     agg = cvs.line(agg=ds.any(), **kwargs)
@@ -2532,6 +2571,51 @@ def test_line_antialias():
 
     agg = cvs.line(agg=ds._max_row_index(), **kwargs)
     assert_eq_ndarray(agg.data, line_antialias_sol_max_index_1)
+
+    agg = cvs.line(agg=ds._min_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, line_antialias_sol_min_index_1)
+    sol = np.full((11, 11), -1)
+    sol[(2, 2, 3), (3, 4, 4)] = 1
+    sol[2:4, 6:8] = 2
+    assert_eq_ndarray(agg[:, :, 1].data, sol)
+
+    agg = cvs.line(agg=ds._max_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, line_antialias_sol_max_index_1)
+    sol = np.full((11, 11), -1)
+    sol[(2, 2, 3), (3, 4, 4)] = 0
+    sol[2:4, 6:8] = 1
+    assert_eq_ndarray(agg[:, :, 1].data, sol)
+
+    agg = cvs.line(agg=ds.max_n("value", n=2), **kwargs)
+    assert_eq_ndarray(agg[:, :, 0].data, 3*line_antialias_sol_1, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[2, 3:8] = (0.911939, 1.833810, nan, 1.437950, 0.667619)
+    sol[(3, 3, 3), (4, 6, 7)] = (0.4, 0.940874, 0.309275)
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
+    agg = cvs.line(agg=ds.min_n("value", n=2), **kwargs)
+    sol = np.full((11, 11), np.nan)
+    sol[2, 1:-1] = [3.0, 2.775630, 0.911939, 1.833810, 2.1025216, 1.437950, 0.667619, 1.429411, 1.205041]
+    sol[3, 1:-1] = [0.008402, 0.232772, 0.457142, 0.4, 0.905881, 0.940874, 0.309275, 1.578991, 1.8]
+    assert_eq_ndarray(agg[:, :, 0].data, sol, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[2, 3:8] = (2.551260, 2.326890, nan, 1.878151, 1.653781)
+    sol[(3, 3, 3), (4, 6, 7)] = (0.681512, 1.130251, 1.354621)
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
+    agg = cvs.line(agg=ds.first_n("value", n=2), **kwargs)
+    sol = 3*line_antialias_sol_1
+    sol[(2, 2, 3, 3), (4, 7, 4, 7)] = (1.833810, 0.667619, 0.4, 0.309275)
+    assert_eq_ndarray(agg[:, :, 0].data, sol, close=True)
+    sol = np.full((11, 11), np.nan)
+    sol[2, 3:8] = (0.911939, 2.326890, nan, 1.437950, 1.653781)
+    sol[(3, 3, 3), (4, 6, 7)] = (0.681512, 0.940874, 1.354621)
+    assert_eq_ndarray(agg[:, :, 1].data, sol, close=True)
+
+    agg = cvs.line(agg=ds.last_n("value", n=2), **kwargs)
+    sol = 3*line_antialias_sol_1
+    sol[(2, 2, 3), (3, 6, 6)] = (0.911939, 1.437950, 0.940874)
+    assert_eq_ndarray(agg[:, :, 0].data, sol, close=True)
 
     # Both lines.
     kwargs = dict(source=line_antialias_df, x=["x0", "x1"], y=["y0", "y1"], line_width=1)
@@ -2579,6 +2663,12 @@ def test_line_antialias():
     agg = cvs.line(agg=ds._max_row_index(), **kwargs)
     sol_max_row = rowmax(line_antialias_sol_max_index_0, line_antialias_sol_max_index_1)
     assert_eq_ndarray(agg.data, sol_max_row)
+
+    agg = cvs.line(agg=ds._min_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg.data[:, :, 0], sol_min_row)
+
+    agg = cvs.line(agg=ds._max_n_row_index(n=2), **kwargs)
+    assert_eq_ndarray(agg.data[:, :, 0], sol_max_row)
 
     assert_eq_ndarray(agg.x_range, x_range, close=True)
     assert_eq_ndarray(agg.y_range, y_range, close=True)


### PR DESCRIPTION
This adds support for antialiased lines in `*_n` reductions such as `max_n` and `first_n`. They return reasonable results, but these are not necessarily consistent with the non-`*_n` reductions yet. Support for antialiased `where` reductions will follow this, and then a full review of whether the results are consistent for all of the different line types supported (axis 0, axis 1, etc).

Example of output using this script
```python
import datashader as ds
import numpy as np
import pandas as pd

df = pd.DataFrame(dict(
    ystart=[0.2, 0, 1, 0.8],
    yend=[0.2, 1, 0, 0.8],
    value=[2, 4, 1, 3],
))
kwargs = dict(source=df, x=np.asarray([0, 1]), y=["ystart", "yend"], axis=1, line_width=15)

reductions = dict(
    first_n=ds.first_n("value", n=2),
    last_n=ds.last_n("value", n=2),
    min_n=ds.min_n("value", n=2),
    max_n=ds.max_n("value", n=2),
    min_n_row_index=ds._min_n_row_index(n=2),
    max_n_row_index=ds._max_n_row_index(n=2),
)

cvs = ds.Canvas(plot_width=200, plot_height=150, x_range=(-0.1, 1.1), y_range=(-0.1, 1.1))
for name, reduction in reductions.items():
    agg = cvs.line(agg=reduction, **kwargs)
    span = (np.nanmin(agg), np.nanmax(agg))
    for k in range(agg.shape[2]):
        im = ds.transfer_functions.shade(agg[:, :, k], how="linear", span=span)
        ds.utils.export_image(im, f"temp_{name}_{k}", background="white")
```
`first_n` showing `[:, :, 0]` then `[:, :, 1]`:
![temp_first_n_0](https://github.com/holoviz/datashader/assets/580326/7ba2b1fc-51f7-4928-8b85-294e4eca2329) ![temp_first_n_1](https://github.com/holoviz/datashader/assets/580326/7b792bef-f0cc-420f-9677-09cd54f32b84)

`last_n`:
![temp_last_n_0](https://github.com/holoviz/datashader/assets/580326/e01a24ea-ffa3-4c49-a626-aca27baa2028) ![temp_last_n_1](https://github.com/holoviz/datashader/assets/580326/72f45af4-4589-487a-b716-b92f3d87c3bc)

`min_n`:
![temp_min_n_0](https://github.com/holoviz/datashader/assets/580326/6b651ab7-708f-4df0-8566-697ae5ffc83b) ![temp_min_n_1](https://github.com/holoviz/datashader/assets/580326/e9bb4044-ec9f-4473-9b4b-7ec03b21dacd)

`max_n`:
![temp_max_n_0](https://github.com/holoviz/datashader/assets/580326/f649dd16-4a8e-44c2-9301-b32fef8638b3) ![temp_max_n_1](https://github.com/holoviz/datashader/assets/580326/3b20154b-b6fe-48c8-9532-89df12b1002d)

`_min_n_row_index`:
![temp_min_n_row_n_0](https://github.com/holoviz/datashader/assets/580326/f5b89e15-3588-41ba-ac0b-4c09298c5a9a) ![temp_min_n_row_n_1](https://github.com/holoviz/datashader/assets/580326/043c39ba-8309-4ed3-851a-7667979f2cdb)

`_max_n_row_index`:
![temp_max_n_row_n_0](https://github.com/holoviz/datashader/assets/580326/4e4d0c57-153d-4f02-9578-7923fd5acb1e) ![temp_max_n_row_n_1](https://github.com/holoviz/datashader/assets/580326/45800b42-96fa-4272-8c52-a7b9f6757cc9)
