### PR TITLE
Replace accumulate with copy on first call to antialiased stage 2 combine

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -201,9 +201,16 @@ def make_antialias_stage_2_functions(antialias_stage_2):
     for func in set(funcs):
         namespace[func.__name__] = func
 
-    lines = ["def aa_stage_2_accumulate(aggs_and_copies):"]
+    lines = [
+        "def aa_stage_2_accumulate(aggs_and_copies, first_pass):",
+        #    Don't need to accumulate if first_pass, just copy (opposite of aa_stage_2_copy_back)
+        "    if first_pass:",
+        "        for a in literal_unroll(aggs_and_copies):",
+        "            a[1][:] = a[0][:]",
+        "    else:",
+    ]
     for i, func in enumerate(funcs):
-        lines.append(f"    {func.__name__}(aggs_and_copies[{i}][1], aggs_and_copies[{i}][0])")
+        lines.append(f"        {func.__name__}(aggs_and_copies[{i}][1], aggs_and_copies[{i}][0])")
 
     code = "\n".join(lines)
     exec(code, namespace)

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -1115,7 +1115,7 @@ def _build_extend_line_axis0_multi(draw_segment, expand_aggs_and_cols, antialias
             if ncols == 1:
                 return
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, j==0)
 
             if j < ncols - 1:
                 aa_stage_2_clear(aggs_and_accums)
@@ -1208,7 +1208,7 @@ def _build_extend_line_axis1_none_constant(draw_segment, expand_aggs_and_cols, a
             if xs.shape[0] == 1:
                 return
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, i==0)
 
             if i < xs.shape[0] - 1:
                 aa_stage_2_clear(aggs_and_accums)
@@ -1302,7 +1302,7 @@ def _build_extend_line_axis1_x_constant(draw_segment, expand_aggs_and_cols, anti
             if ys.shape[0] == 1:
                 return
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, i==0)
 
             if i < ys.shape[0] - 1:
                 aa_stage_2_clear(aggs_and_accums)
@@ -1398,7 +1398,7 @@ def _build_extend_line_axis1_y_constant(draw_segment, expand_aggs_and_cols, anti
             if xs.shape[0] == 1:
                 return
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, i==0)
 
             if i < xs.shape[0] - 1:
                 aa_stage_2_clear(aggs_and_accums)
@@ -1574,7 +1574,7 @@ def _build_extend_line_axis1_ragged(draw_segment, expand_aggs_and_cols, antialia
             if nrows == 1:
                 return
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, i==0)
 
             if i < nrows - 1:
                 aa_stage_2_clear(aggs_and_accums)
@@ -1728,6 +1728,7 @@ def _build_extend_line_axis1_geometry(draw_segment, expand_aggs_and_cols, antial
         antialias = antialias_stage_2 is not None
         buffer = np.empty(8) if antialias else None
 
+        first_pass = True
         for i in eligible_inds:
             if missing[i]:
                 continue
@@ -1772,7 +1773,8 @@ def _build_extend_line_axis1_geometry(draw_segment, expand_aggs_and_cols, antial
                                  segment_start, segment_end, x0, x1, y0, y1,
                                  0.0, 0.0, buffer, *aggs_and_cols)
 
-            aa_stage_2_accumulate(aggs_and_accums)
+            aa_stage_2_accumulate(aggs_and_accums, first_pass)
+            first_pass = False
             aa_stage_2_clear(aggs_and_accums)
 
         aa_stage_2_copy_back(aggs_and_accums)


### PR DESCRIPTION
When performing antialiased stage 2 combining of aggs, on the first pass do not need to do the full accumulate as a simple copy will suffice, given that the target aggs are all empty. This gives a slight performance improvement, there is no functional change.