### PR TITLE
Add CUDA support for std and var reductions

### DIFF
--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -812,9 +812,6 @@ def test_mean(ddf, npartitions):
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_var(ddf, npartitions):
-    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
-        pytest.skip("var not supported with cudf")
-
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions
     out = xr.DataArray(
@@ -832,9 +829,6 @@ def test_var(ddf, npartitions):
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_std(ddf, npartitions):
-    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
-        pytest.skip("std not supported with cudf")
-
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions
     out = xr.DataArray(
@@ -1030,10 +1024,6 @@ def test_categorical_mean_binning(ddf, npartitions):
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_categorical_var(ddf, npartitions):
-    if cudf and isinstance(ddf._meta, cudf.DataFrame):
-        pytest.skip(
-            "The 'var' reduction is yet supported on the GPU"
-        )
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions
     sol = np.array([[[ 2.5,  nan,  nan,  nan],
@@ -1074,10 +1064,6 @@ def test_categorical_var(ddf, npartitions):
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_categorical_std(ddf, npartitions):
-    if cudf and isinstance(ddf._meta, cudf.DataFrame):
-        pytest.skip(
-            "The 'std' reduction is yet supported on the GPU"
-        )
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions
     sol = np.sqrt(np.array([
@@ -1120,8 +1106,6 @@ def test_categorical_std(ddf, npartitions):
 @pytest.mark.parametrize('ddf', ddfs)
 @pytest.mark.parametrize('npartitions', [1, 2, 3, 4])
 def test_multiple_aggregates(ddf, npartitions):
-    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
-        pytest.skip("std not supported with cudf")
     ddf = ddf.repartition(npartitions)
     assert ddf.npartitions == npartitions
     agg = c.points(ddf, 'x', 'y',

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -696,7 +696,7 @@ def test_mean(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.mean('f64')), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_var(df):
     out = xr.DataArray(values(df.i32).reshape((2, 2, 5)).var(axis=2, dtype='f8').T,
                        coords=coords, dims=dims)
@@ -708,7 +708,7 @@ def test_var(df):
     assert_eq_xr(c.points(df, 'x', 'y', ds.var('f64')), out)
 
 
-@pytest.mark.parametrize('df', [df_pd])
+@pytest.mark.parametrize('df', dfs)
 def test_std(df):
     out = xr.DataArray(values(df.i32).reshape((2, 2, 5)).std(axis=2, dtype='f8').T,
                        coords=coords, dims=dims)
@@ -917,11 +917,6 @@ def test_categorical_mean_binning(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_var(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The 'var' reduction is yet supported on the GPU"
-        )
-
     sol = np.array([[[ 2.5,  nan,  nan,  nan],
                      [ nan,  nan,   2.,  nan]],
                     [[ nan,   2.,  nan,  nan],
@@ -953,11 +948,6 @@ def test_categorical_var(df):
 
 @pytest.mark.parametrize('df', dfs)
 def test_categorical_std(df):
-    if cudf and isinstance(df, cudf.DataFrame):
-        pytest.skip(
-            "The 'std' reduction is yet supported on the GPU"
-        )
-
     sol = np.sqrt(np.array([
         [[ 2.5,  nan,  nan,  nan],
          [ nan,  nan,   2.,  nan]],

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -11,6 +11,6 @@
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.min`,     yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.min_n`,   yes, yes,        yes, yes,        ,             yes
-:class:`~datashader.reductions.std`,     yes, yes,        ,    ,           ,
+:class:`~datashader.reductions.std`,     yes, yes,        yes, yes,        ,
 :class:`~datashader.reductions.sum`,     yes, yes,        yes, yes,        yes,
-:class:`~datashader.reductions.var`,     yes, yes,        ,    ,           ,
+:class:`~datashader.reductions.var`,     yes, yes,        yes, yes,        ,


### PR DESCRIPTION
This PR adds support for CUDA `std` and `var` reductions, both with and without `dask`. This means that all reductions now work on CPU and GPU, with and without dask, with the exception that some reductions do not yet support antialiasing but this is work in progress which will be completed soon.

The changes here rely on the use of a CUDA mutex that was recently added (#1196, #1212, #1217) which allows us to use more complicated multi-stage per-pixel operations and keep them atomic. This particular PR adds an extra layer of CUDA mutex usage via an enumerated type so that the CUDA mutex use is not just local to a single reduction (`UsesCudaMutex.Local`) but can also be global to the whole `reduction.append` pipeline (`UsesCudaMutex.Global`). It is necessary for `std` and `var` as their constituent sub-reductions which calculate the count, sum and variance need to be atomic so that they are not interrupted by another CUDA thread working on the same pixel. 