### PR TITLE
Antialiased line support for where reductions

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 
 from .antialias import AntialiasCombination
-from .reductions import SpecialColumn, by, category_codes, summary
+from .reductions import SpecialColumn, UsesCudaMutex, by, category_codes, summary
 from .utils import (isnull, ngjit,
     nanmax_in_place, nanmin_in_place, nansum_in_place, nanfirst_in_place, nanlast_in_place,
     nanmax_n_in_place_3d, nanmax_n_in_place_4d, nanmin_n_in_place_3d, nanmin_n_in_place_4d,
@@ -113,7 +113,7 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False, parti
         else:
             array_module = np
         antialias_stage_2 = antialias_stage_2(array_module)
-        antialias_stage_2_funcs = make_antialias_stage_2_functions(antialias_stage_2)
+        antialias_stage_2_funcs = make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned)
     else:
         self_intersect = False
         antialias_stage_2 = False
@@ -146,11 +146,12 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False, parti
 
 def _get_antialias_stage_2_combine_func(combination: AntialiasCombination, zero: float,
                                         n_reduction: bool, categorical: bool):
+    print("==> CHECK", combination, zero, n_reduction, categorical)
     if n_reduction:
         if zero == -1:
-            if combination == AntialiasCombination.MAX:
+            if combination in (AntialiasCombination.MAX, AntialiasCombination.LAST):
                 return row_max_n_in_place_4d if categorical else row_max_n_in_place_3d
-            elif combination == AntialiasCombination.MIN:
+            elif combination in (AntialiasCombination.MIN, AntialiasCombination.FIRST):
                 return row_min_n_in_place_4d if categorical else row_min_n_in_place_3d
             else:
                 raise NotImplementedError
@@ -170,9 +171,9 @@ def _get_antialias_stage_2_combine_func(combination: AntialiasCombination, zero:
         # 2D (ny, nx) if categorical is False. The same combination functions can be for both
         # as all elements are independent.
         if zero == -1:
-            if combination == AntialiasCombination.MAX:
+            if combination in (AntialiasCombination.MAX, AntialiasCombination.LAST):
                 return row_max_in_place
-            elif combination == AntialiasCombination.MIN:
+            elif combination in (AntialiasCombination.MIN, AntialiasCombination.FIRST):
                 return row_min_in_place
             else:
                 raise NotImplementedError
@@ -189,17 +190,26 @@ def _get_antialias_stage_2_combine_func(combination: AntialiasCombination, zero:
                 return nansum_in_place
 
 
-def make_antialias_stage_2_functions(antialias_stage_2):
+def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned):
     aa_combinations, aa_zeroes, aa_n_reductions, aa_categorical = antialias_stage_2
 
     # Accumulate functions.
     funcs = [_get_antialias_stage_2_combine_func(comb, zero, n_red, cat) for comb, zero, n_red, cat
              in zip(aa_combinations, aa_zeroes, aa_n_reductions, aa_categorical)]
 
+    base_is_where = [b.is_where() for b in bases]
+    next_base_is_where = base_is_where[1:] + [False]
+
     namespace = {}
     namespace["literal_unroll"] = literal_unroll
     for func in set(funcs):
         namespace[func.__name__] = func
+
+    print("==> BASES", bases)
+    #import pdb; pdb.set_trace()
+
+    # Generator of unique names for combine functions
+    names = (f"combine{i}" for i in count())
 
     # aa_stage_2_accumulate
     lines = [
@@ -210,9 +220,25 @@ def make_antialias_stage_2_functions(antialias_stage_2):
         "            a[1][:] = a[0][:]",
         "    else:",
     ]
-    for i, func in enumerate(funcs):
-        lines.append(f"        {func.__name__}(aggs_and_copies[{i}][1], aggs_and_copies[{i}][0])")
+    for i, (func, is_where, next_is_where) in enumerate(zip(funcs, base_is_where, next_base_is_where)):
+        if is_where:
+            where_reduction = bases[i]
+            if isinstance(where_reduction, by):
+                where_reduction = where_reduction.reduction
+
+            combine = where_reduction._combine_callback(cuda, partitioned, aa_categorical[i])
+            name = next(names)  # Unique name
+            namespace[name] = combine
+
+            lines.append(f"        {name}(aggs_and_copies[{i}][::-1], aggs_and_copies[{i-1}][::-1])")
+        elif next_is_where:
+            # This is dealt with as part of the following base which is a where reduction.
+            pass
+        else:
+            lines.append(f"        {func.__name__}(aggs_and_copies[{i}][1], aggs_and_copies[{i}][0])")
     code = "\n".join(lines)
+    print("==> aa_stage_2_accumulate")
+    print(code)
     exec(code, namespace)
     aa_stage_2_accumulate = ngjit(namespace["aa_stage_2_accumulate"])
 
@@ -224,6 +250,8 @@ def make_antialias_stage_2_functions(antialias_stage_2):
     for i, aa_zero in enumerate(aa_zeroes):
         lines.append(f"    aggs_and_copies[{i}][0].fill({aa_zero})")
     code = "\n".join(lines)
+    print("==> aa_stage_2_clear")
+    print(code)
     exec(code, namespace)
     aa_stage_2_clear = ngjit(namespace["aa_stage_2_clear"])
 
@@ -416,6 +444,8 @@ def make_append(bases, cols, calls, glyph, antialias):
         code = ('def append({0}, x, y, {1}):\n'
                 '    {2}'
                 ).format(subscript, ', '.join(signature), '\n    '.join(body))
+    print("==> append")
+    print(code)
     exec(code, namespace)
     return ngjit(namespace['append']), any_uses_cuda_mutex
 

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -146,7 +146,6 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False, parti
 
 def _get_antialias_stage_2_combine_func(combination: AntialiasCombination, zero: float,
                                         n_reduction: bool, categorical: bool):
-    print("==> CHECK", combination, zero, n_reduction, categorical)
     if n_reduction:
         if zero == -1:
             if combination in (AntialiasCombination.MAX, AntialiasCombination.LAST):
@@ -205,9 +204,6 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
     for func in set(funcs):
         namespace[func.__name__] = func
 
-    print("==> BASES", bases)
-    #import pdb; pdb.set_trace()
-
     # Generator of unique names for combine functions
     names = (f"combine{i}" for i in count())
 
@@ -237,8 +233,6 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
         else:
             lines.append(f"        {func.__name__}(aggs_and_copies[{i}][1], aggs_and_copies[{i}][0])")
     code = "\n".join(lines)
-    print("==> aa_stage_2_accumulate")
-    print(code)
     exec(code, namespace)
     aa_stage_2_accumulate = ngjit(namespace["aa_stage_2_accumulate"])
 
@@ -250,8 +244,6 @@ def make_antialias_stage_2_functions(antialias_stage_2, bases, cuda, partitioned
     for i, aa_zero in enumerate(aa_zeroes):
         lines.append(f"    aggs_and_copies[{i}][0].fill({aa_zero})")
     code = "\n".join(lines)
-    print("==> aa_stage_2_clear")
-    print(code)
     exec(code, namespace)
     aa_stage_2_clear = ngjit(namespace["aa_stage_2_clear"])
 
@@ -444,8 +436,6 @@ def make_append(bases, cols, calls, glyph, antialias):
         code = ('def append({0}, x, y, {1}):\n'
                 '    {2}'
                 ).format(subscript, ', '.join(signature), '\n    '.join(body))
-    print("==> append")
-    print(code)
     exec(code, namespace)
     return ngjit(namespace['append']), any_uses_cuda_mutex
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -441,7 +441,7 @@ The axis argument to Canvas.line must be 0 or 1
             if not isinstance(non_cat_agg, (
                 rd.any, rd.count, rd.max, rd.min, rd.sum, rd.summary, rd._sum_zero,
                 rd._first_or_last, rd.mean, rd.max_n, rd.min_n, rd._first_n_or_last_n,
-                rd._max_or_min_row_index, rd._max_n_or_min_n_row_index
+                rd._max_or_min_row_index, rd._max_n_or_min_n_row_index,
             )):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -441,7 +441,7 @@ The axis argument to Canvas.line must be 0 or 1
             if not isinstance(non_cat_agg, (
                 rd.any, rd.count, rd.max, rd.min, rd.sum, rd.summary, rd._sum_zero,
                 rd._first_or_last, rd.mean, rd.max_n, rd.min_n, rd._first_n_or_last_n,
-                rd._max_or_min_row_index, rd._max_n_or_min_n_row_index,
+                rd._max_or_min_row_index, rd._max_n_or_min_n_row_index, rd.where,
             )):
                 raise NotImplementedError(
                     f"{type(non_cat_agg)} reduction not implemented for antialiased lines")

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -878,14 +878,6 @@ def nansum_in_place(ret, other):
             ret[i] += other[i]
 
 
-@ngjit_parallel
-def parallel_fill(array, value):
-    """Parallel version of np.fill()"""
-    array = array.ravel()
-    for i in nb.prange(len(array)):
-        array[i] = value
-
-
 @ngjit
 def row_max_in_place(ret, other):
     """Maximum of 2 arrays of row indexes.

--- a/doc/reduction.csv
+++ b/doc/reduction.csv
@@ -3,14 +3,14 @@
 :class:`~datashader.reductions.by`,      yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.count`,   yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.first`,   yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.first_n`, yes, yes,        yes, yes,        ,             yes
+:class:`~datashader.reductions.first_n`, yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.last`,    yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.last_n`,  yes, yes,        yes, yes,        ,             yes
+:class:`~datashader.reductions.last_n`,  yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.max`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.max_n`,   yes, yes,        yes, yes,        ,             yes
+:class:`~datashader.reductions.max_n`,   yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.mean`,    yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.min`,     yes, yes,        yes, yes,        yes,          yes
-:class:`~datashader.reductions.min_n`,   yes, yes,        yes, yes,        ,             yes
+:class:`~datashader.reductions.min_n`,   yes, yes,        yes, yes,        yes,          yes
 :class:`~datashader.reductions.std`,     yes, yes,        yes, yes,        ,
 :class:`~datashader.reductions.sum`,     yes, yes,        yes, yes,        yes,
 :class:`~datashader.reductions.var`,     yes, yes,        yes, yes,        ,


### PR DESCRIPTION
This PR adds antialiased line support for `where` reductions on CPU, with and without dask, of the following:

```python
ds.where(ds.min("value"), "other")
ds.where(ds.max("value"), "other")
ds.where(ds.first("value"), "other")
ds.where(ds.last("value"), "other")
ds.where(ds.min_n("value", n=n), "other")
ds.where(ds.max_n("value", n=n), "other")
ds.where(ds.first_n("value", n=n), "other")
ds.where(ds.last_n("value", n=n), "other")
```
all of which return values from the `"other"` column, and the same calls but without `"other"` which return row indexes.

Also, all of the above within a categorical `by` reduction such as
```python
ds.by("cat", ds.where(ds.first_n("value", n=n)))
```
Example code:
```python
import datashader as ds
import datashader.transfer_functions as tf
import numpy as np
import pandas as pd

df = pd.DataFrame(dict(y0=[0.5, 1.0, 0.0 ], y1=[1.0, 0.0, 0.5], y2=[0.0, 0.5, 1.0], value=[2, 3, 1], other=[33, 22, 11],))
cvs = ds.Canvas(plot_width=200, plot_height=150, x_range=(-0.1, 1.1), y_range=(-0.1, 1.1))
kwargs = dict(source=df, x=np.asarray([0, 0.5, 1]), y=["y0", "y1", "y2"], axis=1, line_width=15)

reductions = dict(
    where_max_i=ds.where(ds.max("value")),
    where_max_other=ds.where(ds.max("value"), "other"),
    where_min_i=ds.where(ds.min("value")),
    where_min_other=ds.where(ds.min("value"), "other"),
    where_first_i=ds.where(ds.first("value")),
    where_first_other=ds.where(ds.first("value"), "other"),
    where_last_i=ds.where(ds.last("value")),
    where_last_other=ds.where(ds.last("value"), "other"),
)

for name, reduction in reductions.items():
    agg = cvs.line(agg=reduction, **kwargs)
    limits = (np.nanmin(agg), np.nanmax(agg))
    im = tf.shade(agg, how="linear", span=limits)
    filename = f"temp_{name}"
    print("Writing file", filename, "limits", limits)
    ds.utils.export_image(im, filename, background="white")
```
Example outputs returning row indexes for `max`, `min`, `first` and `last` respectively (integers in the range -1 to 2 inclusive):
![temp_where_max_i](https://github.com/holoviz/datashader/assets/580326/1bfe164a-d520-4d62-98ef-76c0a538d359) ![temp_where_min_i](https://github.com/holoviz/datashader/assets/580326/74d6f2a0-96a3-4dd8-8919-ef834249dae8) ![temp_where_first_i](https://github.com/holoviz/datashader/assets/580326/4c0299d1-cbb6-471c-9b3d-0e137caa969d) ![temp_where_last_i](https://github.com/holoviz/datashader/assets/580326/69de98e5-a437-4a2d-8b39-32cfc40a2761)

If you don't want to work out the maths yourself, just note that these are examples are setup such that the outputs should all have different overlaps.

Example outputs when returning values from the `"other"` column (floats which are either 11, 22 or 33, or `np.nan`):
![temp_where_max_other](https://github.com/holoviz/datashader/assets/580326/7ce62ca9-d9ac-4f81-9c45-b1a1990d8102) ![temp_where_min_other](https://github.com/holoviz/datashader/assets/580326/2399e4b2-4126-419e-9593-b2b3088719f5) ![temp_where_first_other](https://github.com/holoviz/datashader/assets/580326/2e028935-39c1-49ee-9c79-9773dc9b088d) ![temp_where_last_other](https://github.com/holoviz/datashader/assets/580326/f29dbd42-fa46-4949-9a6d-0086f27be3b3)

The colors here are in the opposite orders to the equivalent row index examples above, but the overlaps are the same.

The edges are hard (not antialiased) when returning row indexes because there is no such thing as a fractional row index. The edges are also hard when returning values from the `"other"` column as these values are derived from the row indexes. Returning antialiased edges for the latter is currently not possible given how the antialiased lines are implemented, but is a possible area for improvement in the future.

In terms of implementation, the second stage antialiased accumulation here reuses the `where` `combine()` functions to keep code duplication to a minimum.