### PR TITLE
Temporarily pin pandas < 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'datashape',
     'numba',
     'numpy',
-    'pandas',
+    'pandas <2.1',
     'param',
     'pillow',
     'pyct',


### PR DESCRIPTION
CI is failing due to a problem in SpatialPandas using Pandas 2.1.0 (holoviz/spatialpandas#124). Here temporarily pinning pandas < 2.1 so that CI is not failing all the time. When the SpatialPandas issue is fixed and a new version is released, we can remove this pin.