### PR TITLE
Support pandas 2.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,6 +96,9 @@ jobs:
       - name: doit develop_install
         run: |
           doit ecosystem=pip develop_install -o tests -o examples
+      - name: install spatialpandas RC
+        run: |
+          python -m pip install "spatialpandas==0.4.9rc1"
       - name: doit env_capture
         run: |
           doit ecosystem=pip env_capture

--- a/datashader/tests/test_datatypes.py
+++ b/datashader/tests/test_datatypes.py
@@ -648,11 +648,11 @@ class TestRaggedGetitem(eb.BaseGetitemTests):
 
         result = s.get([4, 6])
         expected = s.iloc[[2, 3]]
-        self.assert_series_equal(result, expected)
+        pd.testing.assert_series_equal(result, expected)
 
         result = s.get(slice(2))
         expected = s.iloc[[0, 1]]
-        self.assert_series_equal(result, expected)
+        pd.testing.assert_series_equal(result, expected)
 
         assert s.get(-1) is None
         assert s.get(s.index.max() + 1) is None
@@ -662,7 +662,7 @@ class TestRaggedGetitem(eb.BaseGetitemTests):
 
         result = s.get(slice('b', 'd'))
         expected = s.iloc[[1, 2, 3]]
-        self.assert_series_equal(result, expected)
+        pd.testing.assert_series_equal(result, expected)
 
         result = s.get('Z')
         assert result is None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'datashape',
     'numba',
     'numpy',
-    'pandas <2.1',
+    'pandas',
     'param',
     'pillow',
     'pyct',

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ extras_require = {
         'pytest-cov',
         'rasterio',
         'rioxarray',
+        'scikit-image',
         'spatialpandas',
     ],
     'examples': examples,


### PR DESCRIPTION
Now that there is a SpatialPandas RC the supports Pandas 2.1 (https://pypi.org/project/spatialpandas/0.4.9rc1/#files and https://anaconda.org/pyviz/spatialpandas/files), we can remove the temporary pin of #1275.