### PR TITLE
Update to latest holoviz_tasks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
     env:
       DESC: "Documentation build"
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a17
         with:
           name: Documentation
           python-version: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       NUMEXPR_NUM_THREADS: 1
       PYDEVD_DISABLE_FILE_VALIDATION: 1
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a17
         with:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
The changes in the install task are caching when a test fails. Beforehand, it will only do so if the test passed. 

The other change is saving the environment files from the different runs, making debugging easier. 

You can get the environment files here: https://github.com/holoviz/datashader/actions/runs/6309708107?pr=1281 under artifacts.