### PR TITLE
Implement lines using 2D xarray with common x coordinates

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -140,7 +140,7 @@ def compile_components(agg, schema, glyph, *, antialias=False, cuda=False, parti
 
     create = make_create(bases, dshapes, cuda)
     append, any_uses_cuda_mutex = make_append(bases, cols, calls, glyph, antialias)
-    info = make_info(cols, any_uses_cuda_mutex)
+    info = make_info(cols, cuda, any_uses_cuda_mutex)
     combine = make_combine(bases, dshapes, temps, combine_temps, antialias, cuda, partitioned)
     finalize = make_finalize(bases, agg, schema, cuda, partitioned)
 
@@ -302,9 +302,9 @@ def make_create(bases, dshapes, cuda):
     return lambda shape: tuple(c(shape, array_module) for c in creators)
 
 
-def make_info(cols, uses_cuda_mutex: bool):
+def make_info(cols, cuda, uses_cuda_mutex: bool):
     def info(df, canvas_shape):
-        ret = tuple(c.apply(df) for c in cols)
+        ret = tuple(c.apply(df, cuda) for c in cols)
         if uses_cuda_mutex:
             import cupy  # Guaranteed to be available if uses_cuda_mutex is True
             import numba

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -383,7 +383,6 @@ class Canvas:
                     "dask_geopandas.GeoDataFrame. Received objects of type {typ}".format(
                         typ=type(source)))
 
-            glyph = LineAxis1Geometry(geometry)
         elif isinstance(source, Dataset) and isinstance(x, str) and isinstance(y, str):
             x_arr = source[x]
             y_arr = source[y]

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -345,7 +345,7 @@ class Canvas:
         """
         from .glyphs import (LineAxis0, LinesAxis1, LinesAxis1XConstant,
                              LinesAxis1YConstant, LineAxis0Multi,
-                             LinesAxis1Ragged, LineAxis1Geometry)
+                             LinesAxis1Ragged, LineAxis1Geometry, LinesXarrayCommonX)
 
         validate_xy_or_geometry('Line', x, y, geometry)
 
@@ -383,6 +383,21 @@ class Canvas:
                     "dask_geopandas.GeoDataFrame. Received objects of type {typ}".format(
                         typ=type(source)))
 
+            glyph = LineAxis1Geometry(geometry)
+        elif isinstance(source, Dataset) and isinstance(x, str) and isinstance(y, str):
+            x_arr = source[x]
+            y_arr = source[y]
+            if x_arr.ndim != 1:
+                raise ValueError(f"x array must have 1 dimension not {x_arr.ndim}")
+
+            if y_arr.ndim != 2:
+                raise ValueError(f"y array must have 2 dimensions not {y_arr.ndim}")
+            if x not in y_arr.dims:
+                raise ValueError("x must be one of the coordinate dimensions of y")
+
+            y_coord_dims = list(y_arr.coords.dims)
+            x_dim_index = y_coord_dims.index(x)
+            glyph = LinesXarrayCommonX(x, y, x_dim_index)
         else:
             # Broadcast column specifications to handle cases where
             # x is a list and y is a string or vice versa

--- a/datashader/data_libraries/xarray.py
+++ b/datashader/data_libraries/xarray.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datashader.glyphs.line import LinesXarrayCommonX
 from datashader.glyphs.quadmesh import _QuadMeshLike
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel
@@ -16,7 +17,13 @@ glyph_dispatch = Dispatcher()
 
 @bypixel.pipeline.register(xr.Dataset)
 def xarray_pipeline(xr_ds, schema, canvas, glyph, summary, *, antialias=False):
-    cuda = cupy and isinstance(xr_ds[glyph.name].data, cupy.ndarray)
+    cuda = False
+    if cupy:
+        if isinstance(glyph, LinesXarrayCommonX):
+            cuda = isinstance(xr_ds[glyph.y].data, cupy.ndarray)
+        else:
+            cuda = isinstance(xr_ds[glyph.name].data, cupy.ndarray)
+
     if not xr_ds.chunks:
         return glyph_dispatch(
             glyph, xr_ds, schema, canvas, summary, antialias=antialias, cuda=cuda)
@@ -28,3 +35,4 @@ def xarray_pipeline(xr_ds, schema, canvas, glyph, summary, *, antialias=False):
 
 # Default to default pandas implementation
 glyph_dispatch.register(_QuadMeshLike)(default)
+glyph_dispatch.register(LinesXarrayCommonX)(default)

--- a/datashader/glyphs/__init__.py
+++ b/datashader/glyphs/__init__.py
@@ -9,6 +9,7 @@ from .line import (  # noqa (API import)
     LinesAxis1Ragged,
     LineAxis1Geometry,
     LineAxis1GeoPandas,
+    LinesXarrayCommonX,
 )
 from .area import (  # noqa (API import)
     AreaToZeroAxis0,

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -7,6 +7,7 @@ from math import isnan
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from datashader.utils import Expr, ngjit
 from datashader.macros import expand_varargs
@@ -54,6 +55,11 @@ class Glyph(Expr):
             return (s.min(), s.max())
         elif isinstance(s, pd.Series):
             return Glyph._compute_bounds_numba(s.values)
+        elif isinstance(s, xr.DataArray):
+            if cp and isinstance(s.data, cp.ndarray):
+                return (s.min().item(), s.max().item())
+            else:
+                return Glyph._compute_bounds_numba(s.values.ravel())
         else:
             return Glyph._compute_bounds_numba(s)
 

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -16,6 +16,7 @@ try:
     from ..transfer_functions._cuda_utils import cuda_args
 except ImportError:
     cudf = None
+    cp = None
     cuda_args = None
 
 try:

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -112,7 +112,7 @@ class extract(Preprocess):
             else:
                 return np.arange(row_offset, row_offset + row_length, dtype=np.int64)
         elif isinstance(df, xr.Dataset):
-            if cuda:
+            if cuda and not isinstance(df[self.column].data, cp.ndarray):
                 return cp.asarray(df[self.column])
             else:
                 return df[self.column].data

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -84,14 +84,20 @@ class Preprocess(Expr):
 
 class extract(Preprocess):
     """Extract a column from a dataframe as a numpy array of values."""
-    def apply(self, df):
+    def apply(self, df, cuda):
         if self.column is SpecialColumn.RowIndex:
-            attrs = getattr(df, "attrs", None)
-            row_offset = getattr(attrs or df, "_datashader_row_offset", 0)
+            attr_name = "_datashader_row_offset"
+            if isinstance(df, xr.Dataset):
+                row_offset = df.attrs[attr_name]
+                row_length = df.attrs["_datashader_row_length"]
+            else:
+                attrs = getattr(df, "attrs", None)
+                row_offset = getattr(attrs or df, attr_name, 0)
+                row_length = len(df)
 
         if cudf and isinstance(df, cudf.DataFrame):
             if self.column is SpecialColumn.RowIndex:
-                return cp.arange(row_offset, row_offset+len(df), dtype=np.int64)
+                return cp.arange(row_offset, row_offset + row_length, dtype=np.int64)
 
             if df[self.column].dtype.kind == 'f':
                 nullval = np.nan
@@ -100,11 +106,16 @@ class extract(Preprocess):
             if Version(cudf.__version__) >= Version("22.02"):
                 return df[self.column].to_cupy(na_value=nullval)
             return cp.array(df[self.column].to_gpu_array(fillna=nullval))
-        elif isinstance(df, xr.Dataset):
-            # DataArray could be backed by numpy or cupy array
-            return df[self.column].data
         elif self.column is SpecialColumn.RowIndex:
-            return np.arange(row_offset, row_offset+len(df), dtype=np.int64)
+            if cuda:
+                return cp.arange(row_offset, row_offset + row_length, dtype=np.int64)
+            else:
+                return np.arange(row_offset, row_offset + row_length, dtype=np.int64)
+        elif isinstance(df, xr.Dataset):
+            if cuda:
+                return cp.asarray(df[self.column])
+            else:
+                return df[self.column].data
         else:
             return df[self.column].values
 
@@ -124,7 +135,7 @@ class CategoryPreprocess(Preprocess):
         """Validates input shape"""
         raise NotImplementedError("validate not implemented")
 
-    def apply(self, df):
+    def apply(self, df, cuda):
         """Applies preprocessor to DataFrame and returns array"""
         raise NotImplementedError("apply not implemented")
 
@@ -149,7 +160,7 @@ class category_codes(CategoryPreprocess):
         if not isinstance(in_dshape.measure[self.column], ct.Categorical):
             raise ValueError("input must be categorical")
 
-    def apply(self, df):
+    def apply(self, df, cuda):
         if cudf and isinstance(df, cudf.DataFrame):
             if Version(cudf.__version__) >= Version("22.02"):
                 return df[self.column].cat.codes.to_cupy()
@@ -185,7 +196,7 @@ class category_modulo(category_codes):
         if in_dshape.measure[self.column] not in self.IntegerTypes:
             raise ValueError("input must be an integer column")
 
-    def apply(self, df):
+    def apply(self, df, cuda):
         result = (df[self.column] - self.offset) % self.modulo
         if cudf and isinstance(df, cudf.Series):
             if Version(cudf.__version__) >= Version("22.02"):
@@ -226,7 +237,7 @@ class category_binning(category_modulo):
         if self.column not in in_dshape.dict:
             raise ValueError("specified column not found")
 
-    def apply(self, df):
+    def apply(self, df, cuda):
         if cudf and isinstance(df, cudf.DataFrame):
             if Version(cudf.__version__) >= Version("22.02"):
                 values = df[self.column].to_cupy(na_value=cp.nan)
@@ -269,8 +280,8 @@ class category_values(CategoryPreprocess):
     def validate(self, in_dshape):
         return self.categorizer.validate(in_dshape)
 
-    def apply(self, df):
-        a = self.categorizer.apply(df)
+    def apply(self, df, cuda):
+        a = self.categorizer.apply(df, cuda)
         if cudf and isinstance(df, cudf.DataFrame):
             import cupy
             if self.column == SpecialColumn.RowIndex:
@@ -281,7 +292,7 @@ class category_values(CategoryPreprocess):
                 nullval = 0
             a = cupy.asarray(a)
             if self.column == SpecialColumn.RowIndex:
-                b = extract(SpecialColumn.RowIndex).apply(df)
+                b = extract(SpecialColumn.RowIndex).apply(df, cuda)
             elif Version(cudf.__version__) >= Version("22.02"):
                 b = df[self.column].to_cupy(na_value=nullval)
             else:
@@ -289,7 +300,7 @@ class category_values(CategoryPreprocess):
             return cupy.stack((a, b), axis=-1)
         else:
             if self.column == SpecialColumn.RowIndex:
-                b = extract(SpecialColumn.RowIndex).apply(df)
+                b = extract(SpecialColumn.RowIndex).apply(df, cuda)
             else:
                 b = df[self.column].values
             return np.stack((a, b), axis=-1)
@@ -2023,11 +2034,13 @@ class where(FloatingReduction):
             if len(aggs) == 1:
                 pass
             elif cuda:
+                assert len(aggs) == 2
                 is_n_reduction = isinstance(self.selector, FloatingNReduction)
                 shape = aggs[0].shape[:-1] if is_n_reduction else aggs[0].shape
                 combine[cuda_args(shape)](aggs, selector_aggs)
             else:
-                combine(aggs, selector_aggs)
+                for i in range(1, len(aggs)):
+                    combine((aggs[0], aggs[i]), (selector_aggs[0], selector_aggs[i]))
 
             return aggs[0], selector_aggs[0]
 
@@ -2182,10 +2195,11 @@ class _max_row_index(_max_or_min_row_index):
     def _combine(aggs):
         # Maximum ignoring -1 values
         # Works for CPU and GPU
-        if len(aggs) > 1:
+        ret = aggs[0]
+        for i in range(1, len(aggs)):
             # Works with numpy or cupy arrays
-            np.maximum(aggs[0], aggs[1], out=aggs[0])
-        return aggs[0]
+            np.maximum(ret, aggs[i], out=ret)
+        return ret
 
 
 class _min_row_index(_max_or_min_row_index):
@@ -2245,9 +2259,9 @@ class _min_row_index(_max_or_min_row_index):
     def _combine(aggs):
         # Minimum ignoring -1 values
         ret = aggs[0]
-        if len(aggs) > 1:
+        for i in range(1, len(aggs)):
             # Can take 2d (ny, nx) or 3d (ny, nx, ncat) arrays.
-            row_min_in_place(aggs[0], aggs[1])
+            row_min_in_place(ret, aggs[i])
         return ret
 
     @staticmethod

--- a/datashader/tests/test_xarray.py
+++ b/datashader/tests/test_xarray.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 import numpy as np
+from numpy import nan
+import os
 import xarray as xr
 
 import datashader as ds
+from datashader.tests.test_pandas import assert_eq_ndarray
 
 import pytest
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+test_gpu = bool(int(os.getenv("DATASHADER_TEST_GPU", 0)))
 
 
 xda = xr.DataArray(data=np.array(([1.] * 10 + [10] * 10)),
@@ -54,3 +64,150 @@ def test_count(source):
     assert_eq(agg, out)
     np.testing.assert_array_almost_equal(agg.x_range, (0, 1))
     np.testing.assert_array_almost_equal(agg.y_range, (0, 1))
+
+
+x = np.arange(5)
+channel = np.arange(2)
+value = [-33, -55]
+other = [2.2, 1.1]
+data = np.array([[2, 1, 0, 1, 2], [1, 1, 1, 1, 1]], dtype=np.float64)
+ds2d_x0 = xr.Dataset(
+    data_vars=dict(
+        name=(("x", "channel"), data.T.copy()),
+        value=("channel", value),
+        other=("channel", other),
+    ),
+    coords=dict(
+        channel=("channel", channel),
+        x=("x", x),
+    ),
+)
+ds2d_x1 = xr.Dataset(
+    data_vars=dict(
+        name=(("channel", "x"), data),
+        value=("channel", value),
+        other=("channel", other),
+    ),
+    coords=dict(
+        channel=("channel", channel),
+        x=("x", x),
+    ),
+)
+ds2ds = [ds2d_x0, ds2d_x1]
+
+
+@pytest.mark.parametrize("ds2d", ds2ds)
+@pytest.mark.parametrize("cuda", [False, True])
+@pytest.mark.parametrize("chunksizes", [
+    None,
+    dict(x=10, channel=10),
+    dict(x=10, channel=1),
+    dict(x=3, channel=10),
+    dict(x=3, channel=1),
+])
+def test_lines_xarray_common_x(ds2d, cuda, chunksizes):
+    source = ds2d.copy()
+    if cuda:
+        if not (cupy and test_gpu):
+            pytest.skip("CUDA tests not requested")
+        elif chunksizes is not None:
+            pytest.skip("CUDA-dask for LinesXarrayCommonX not implemented")
+
+        # CPU -> GPU
+        source.name.data = cupy.asarray(source.name.data)
+
+    if chunksizes is not None:
+        source = source.chunk(chunksizes)
+
+    canvas = ds.Canvas(plot_height=3, plot_width=7)
+
+    # Expected solutions
+    sol_count = np.array(
+        [[0, 0, 1, 1, 0, 0, 0], [1, 2, 1, 1, 2, 2, 1], [1, 0, 0, 0, 0, 0, 1]],
+        dtype=np.uint32)
+    sol_max = np.array(
+        [[nan, nan, -33, -33, nan, nan, nan], [-55, -33, -55, -55, -33, -33, -55], [-33, nan, nan, nan, nan, nan, -33]],  # noqa: E501
+        dtype=np.float64)
+    sol_min = np.array(
+        [[nan, nan, -33, -33, nan, nan, nan], [-55, -55, -55, -55, -55, -55, -55], [-33, nan, nan, nan, nan, nan, -33]],  # noqa: E501
+        dtype=np.float64)
+    sol_sum = np.array(
+        [[nan, nan, -33, -33, nan, nan, nan], [-55, -88, -55, -55, -88, -88, -55], [-33, nan, nan, nan, nan, nan, -33]],  # noqa: E501
+        dtype=np.float64)
+    sol_max_row_index = np.array(
+        [[-1, -1, 0, 0, -1, -1, -1], [1, 1, 1, 1, 1, 1, 1], [0, -1, -1, -1, -1, -1, 0]],
+        dtype=np.int64)
+    sol_min_row_index = np.array(
+        [[-1, -1, 0, 0, -1, -1, -1], [1, 0, 1, 1, 0, 0, 1], [0, -1, -1, -1, -1, -1, 0]],
+        dtype=np.int64)
+
+    if chunksizes is not None and chunksizes["x"] == 3:
+        # Dask chunking in x-direction gives different (incorrect) results.
+        sol_count[:, 4] = 0
+        sol_max[:, 4] = nan
+        sol_min[:, 4] = nan
+        sol_sum[:, 4] = nan
+        sol_max_row_index[:, 4] = -1
+        sol_min_row_index[:, 4] = -1
+
+    sol_first = np.select([sol_min_row_index==0, sol_min_row_index==1], value, np.nan)
+    sol_last = np.select([sol_max_row_index==0, sol_max_row_index==1], value, np.nan)
+    sol_where_max_other = np.select([sol_max==-33, sol_max==-55], other, np.nan)
+    sol_where_max_row = np.select([sol_max==-33, sol_max==-55], [0, 1], -1)
+    sol_where_min_other = np.select([sol_min==-33, sol_min==-55], other, np.nan)
+    sol_where_min_row = np.select([sol_min==-33, sol_min==-55], [0, 1], -1)
+
+    # count
+    agg = canvas.line(source, x="x", y="name", agg=ds.count())
+    assert_eq_ndarray(agg.x_range, (0, 4), close=True)
+    assert_eq_ndarray(agg.y_range, (0, 2), close=True)
+    assert_eq_ndarray(agg.data, sol_count)
+    assert isinstance(agg.data, cupy.ndarray if cuda else np.ndarray)
+
+    # any
+    agg = canvas.line(source, x="x", y="name", agg=ds.any())
+    assert_eq_ndarray(agg.data, sol_count > 0)
+
+    # max
+    agg = canvas.line(source, x="x", y="name", agg=ds.max("value"))
+    assert_eq_ndarray(agg.data, sol_max)
+
+    # min
+    agg = canvas.line(source, x="x", y="name", agg=ds.min("value"))
+    assert_eq_ndarray(agg.data, sol_min)
+
+    # sum
+    agg = canvas.line(source, x="x", y="name", agg=ds.sum("value"))
+    assert_eq_ndarray(agg.data, sol_sum)
+
+    # _max_row_index
+    agg = canvas.line(source, x="x", y="name", agg=ds._max_row_index())
+    assert_eq_ndarray(agg.data, sol_max_row_index)
+
+    # _min_row_index
+    agg = canvas.line(source, x="x", y="name", agg=ds._min_row_index())
+    assert_eq_ndarray(agg.data, sol_min_row_index)
+
+    # first
+    agg = canvas.line(source, x="x", y="name", agg=ds.first("value"))
+    assert_eq_ndarray(agg.data, sol_first)
+
+    # last
+    agg = canvas.line(source, x="x", y="name", agg=ds.last("value"))
+    assert_eq_ndarray(agg.data, sol_last)
+
+    # where(max) returning other row
+    agg = canvas.line(source, x="x", y="name", agg=ds.where(ds.max("value"), "other"))
+    assert_eq_ndarray(agg.data, sol_where_max_other)
+
+    # where(max) returning row index
+    agg = canvas.line(source, x="x", y="name", agg=ds.where(ds.max("value")))
+    assert_eq_ndarray(agg.data, sol_where_max_row)
+
+    # where(min) returning other row
+    agg = canvas.line(source, x="x", y="name", agg=ds.where(ds.min("value"), "other"))
+    assert_eq_ndarray(agg.data, sol_where_min_other)
+
+    # where(min) returning row index
+    agg = canvas.line(source, x="x", y="name", agg=ds.where(ds.min("value")))
+    assert_eq_ndarray(agg.data, sol_where_min_row)


### PR DESCRIPTION
This is a work in progress to implement datashading lines from a 2D xarray that has common `x` coordinates, as described in issue #1278.

So far it only works for `count` and `any` reductions, with and without Dask but only on the CPU not GPU. Further work is underway to support other simple reductions, categorical  and `where` reductions, antialiasing, CUDA, etc.

There is a limitation when using dask chunking of the 2D array in the `x` direction in that the line segments between chunks are not rendered. This is the same limitation that occurs in other datashader line glyphs that similarly chunk along arrays, and no attempt will be made to address the limitation in this PR.

This work is part of a CZI Round 5 grant.