### PR TITLE
Install numba from numba conda channel in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}
           channel-priority: strict
-          channels: pyviz/label/dev,conda-forge,nodefaults
+          channels: pyviz/label/dev,numba,conda-forge,nodefaults
           envs: "-o tests -o examples"
           cache: true
           conda-update: true


### PR DESCRIPTION
Install numba from numba conda channel in CI, to test latest available packages. Note that the pip-based tests were already doing this.

Thanks to @Hoxbro for the suggestion.