### PR TITLE
Improved antialiased mean reduction

### DIFF
--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -392,7 +392,7 @@ def make_append(bases, cols, calls, glyph, antialias):
 
         args.extend([local_lk[i] for i in temps])
         if antialias:
-            args.append("aa_factor")
+            args += ["aa_factor", "prev_aa_factor"]
 
         if local_cuda_mutex and prev_local_cuda_mutex:
             # Avoid unnecessary mutex unlock and lock cycle
@@ -458,7 +458,7 @@ def make_append(bases, cols, calls, glyph, antialias):
         body = [get_cuda_mutex_call(True)] + body + [get_cuda_mutex_call(False)]
 
     if antialias:
-        signature.insert(0, "aa_factor")
+        signature = ["aa_factor", "prev_aa_factor"] + signature
 
     if ndims is None:
         code = ('def append(x, y, {0}):\n'

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -174,6 +174,6 @@ class Glyph(Expr):
 
         # Antialiased append() calls also take aa_factor argument
         if antialiased:
-            aggs_and_cols_len -= 1
+            aggs_and_cols_len -= 2
 
         return expand_varargs(aggs_and_cols_len)

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -967,15 +967,18 @@ def _build_full_antialias(expand_aggs_and_cols):
                         prev_correction = True
                 value = 1.0 - _linearstep(0.5*(line_width - aa), halfwidth, distance)
                 value *= scale
+                prev_value = 0.0
                 if prev_correction:
                     # Already set pixel from previous segment, need to correct it
                     prev_distance = abs((x-x0)*prev_rightx + (y-y0)*prev_righty)
                     prev_value = 1.0 - _linearstep(0.5*(line_width - aa), halfwidth, prev_distance)
                     prev_value *= scale
-                    value = value - prev_value  # Correction from previous segment.
+                    if value <= prev_value:
+                        # Have already used a larger value (alpha) for this pixel.
+                        value = 0.0
                 if value > 0.0:
                     xx, yy = (y, x) if flip_xy else (x, y)
-                    append(i, xx, yy, value, *aggs_and_cols)
+                    append(i, xx, yy, value, prev_value, *aggs_and_cols)
 
     return _full_antialias
 


### PR DESCRIPTION
This improves the output of `Canvas.line` using an antialiased `mean` reduction.

Example code:
```python
import datashader as ds
import numpy as np
import pandas as pd

x = np.asarray([0, 0.5, 1])
df = pd.DataFrame(dict(
    y0    = [0.0, 0.5, 1.0],
    y1    = [1.0, 0.0, 0.5],
    y2    = [0.0, 1.0, 0.2],
    value = [1.1, 2.2, 3.3],
))

canvas = ds.Canvas(plot_height=100, plot_width=150, x_range=(-0.1, 1.1), y_range=(-0.1, 1.1))
agg = canvas.line(source=df, x=x, y=["y0", "y1", "y2"], line_width=10, agg=ds.mean("value"), axis=1)
ds.transfer_functions.shade(agg, how="linear")
```
Image produced, before and after this PR:
![temp_old](https://github.com/holoviz/datashader/assets/580326/59527abb-50f2-4577-92a2-91ef37ee8686) ![temp_new](https://github.com/holoviz/datashader/assets/580326/1e92df4d-dd4d-4a6f-be56-ea25fa8933c9)

and zoomed in by a factor of 3 (before and after):
<img width="448" alt="Screenshot 2023-10-27 at 15 52 42" src="https://github.com/holoviz/datashader/assets/580326/b560d758-006e-4f1d-8783-b4958a930a1b"> <img width="447" alt="Screenshot 2023-10-27 at 15 52 57" src="https://github.com/holoviz/datashader/assets/580326/ae9ab828-9435-4441-bd2c-99af4d8be288">

Before this PR a `mean` reduction was implemented by dividing a `sum` reduction by a `count` reduction. If you imagine `sum("value")` where all the value are 1 then the `sum` and `count` produce identical results with larger values at the middle of lines and smaller antialiased values at the edges. Dividing one by the other therefore loses the antialiasing.

This PR changes the `mean` to be a `sum` divided by a new reduction `_count_ignore_antialiasing` and the latter, as the name suggests, ignores the antialiasing factor. Hence the result produced is antialiased.

It isn't actually quite that simple as at the edges of joins artifacts were produced where the line goes over itself. Pixels where this occurred are visited twice, the second time with a larger antialiasing factor. Now when this occurs both of the antialiasing factors are passed to `Reduction.append` functions so that the reduction can better deal with it. There is no change to the low-level antialiasing code which has always calculated both values, but now both values are used rather than just one.