### PR TITLE
Docs: ignore numpydoc validation checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ doc/*.ipynb
 doc/*/*.ipynb
 doc/*.rst
 doc/*/*.rst
+builtdocs/
+jupyter_execute/
 
 # PyBuilder
 target/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,5 +66,10 @@ nbsite_analytics = {
 
 nbbuild_cell_timeout = 2000
 
+# Turning off all numpydoc checks, not great but a good workaround
+# for https://github.com/pydata/xarray/issues/8596
+# To be removed some day to re-enable the validation checks.
+numpydoc_validation_checks = set()
+
 # Override the Sphinx default title that appends `documentation`
 html_title = f'{project} v{version}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,10 +66,26 @@ nbsite_analytics = {
 
 nbbuild_cell_timeout = 2000
 
-# Turning off all numpydoc checks, not great but a good workaround
-# for https://github.com/pydata/xarray/issues/8596
-# To be removed some day to re-enable the validation checks.
-numpydoc_validation_checks = set()
+# Datashader uses sphinx.ext.autodoc (e.g. automodule) for its API reference
+# and automatically include a module that contains Image. Image inherits
+# from xr.DataArray. Datashader uses numpydoc to parse the docstrings.
+# It turns out xarray broke numpydoc https://github.com/pydata/xarray/issues/8596
+# This is a bad hack to work around this issue.
+
+import numpydoc.docscrape  # noqa
+
+original_error_location = numpydoc.docscrape.NumpyDocString._error_location
+
+def patch_error_location(self, msg, error=True):
+    try:
+        original_error_location(self, msg, error)
+    except ValueError as e:
+        if "See Also entry ':doc:`xarray-tutorial" in str(e):
+            return
+        else:
+            raise e
+
+numpydoc.docscrape.NumpyDocString._error_location = patch_error_location
 
 # Override the Sphinx default title that appends `documentation`
 html_title = f'{project} v{version}'


### PR DESCRIPTION
The doc build was broken with:

```
Extension error (numpydoc.numpydoc):
Handler <function mangle_signature at 0x7f27ca70fe20> for event 'autodoc-process-signature' threw an exception (exception: Error parsing See Also entry ':doc:`xarray-tutorial:fundamentals/03.3_windowed`' in the docstring of coarsen in /usr/share/miniconda3/envs/test-environment/lib/python3.10/site-packages/xarray/core/dataarray.py.)
```

It turns out Datashader doesn't use the `sphinx.ext.napoleon` extension to process its docstrings but [numpydoc](https://numpydoc.readthedocs.io/en/latest/index.html), which does more validation (than I would have expected at least) and wasn't happy with some recent changes made in xarray (see https://github.com/pydata/xarray/issues/8596). I tried:

- to configure numpydoc to ignore xarray's docstrings and failed, maybe I did it wrong
- to switch to `sphinx.ext.napoleon` but the API page didn't look the same and I didn't want to find what changed exactly and if it was better or worse.

So I ended up figuring out how to disable all the validations numpydoc performs. We probably need to revert that some day.

---

EDIT: Meh I must have done something wrong in my testing, this doesn't work yet.

---

EDIT2:

Datashader uses `sphinx.ext.autodoc` (e.g. the `automodule` directive) for its API reference and automatically includes a module that contains the `Image` class. `Image` inherits from `xr.DataArray`. Datashader uses numpydoc to parse the docstrings. It turns out xarray affected numpydoc in some way (see https://github.com/pydata/xarray/issues/8596). I found a (bad) hacky way to work around that.