### PR TITLE
Parallelize the test suite and fix a test polluted bug

### DIFF
--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
+from contextlib import suppress
 from datashader.data_libraries.pandas import default
 from datashader.core import bypixel
-import cudf
 
 
-@bypixel.pipeline.register(cudf.DataFrame)
 def cudf_pipeline(df, schema, canvas, glyph, summary, *, antialias=False):
     return default(glyph, df, schema, canvas, summary, antialias=antialias, cuda=True)
+
+
+with suppress(ImportError):
+    import cudf
+
+    cudf_pipeline = bypixel.pipeline.register(cudf.DataFrame)(cudf_pipeline)

--- a/datashader/data_libraries/dask_cudf.py
+++ b/datashader/data_libraries/dask_cudf.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
+from contextlib import suppress
 from datashader.data_libraries.dask import dask_pipeline
 from datashader.core import bypixel
-import dask_cudf
 
 
-@bypixel.pipeline.register(dask_cudf.DataFrame)
 def dask_cudf_pipeline(df, schema, canvas, glyph, summary, *, antialias=False):
     return dask_pipeline(df, schema, canvas, glyph, summary, antialias=antialias, cuda=True)
+
+
+with suppress(ImportError):
+    import dask_cudf
+
+    dask_cudf_pipeline = bypixel.pipeline.register(dask_cudf.DataFrame)(dask_cudf_pipeline)

--- a/datashader/data_libraries/dask_xarray.py
+++ b/datashader/data_libraries/dask_xarray.py
@@ -173,8 +173,8 @@ def dask_raster(glyph, xr_ds, schema, canvas, summary, *, antialias=False, cuda=
     src_y0, src_y1 = glyph._compute_bounds_from_1d_centers(
         xr_ds, y_name, maybe_expand=False, orient=False
     )
-    xbinsize = float(xr_ds[x_name][1] - xr_ds[x_name][0])
-    ybinsize = float(xr_ds[y_name][1] - xr_ds[y_name][0])
+    xbinsize = abs(float(xr_ds[x_name][1] - xr_ds[x_name][0]))
+    ybinsize = abs(float(xr_ds[y_name][1] - xr_ds[y_name][0]))
 
     # Compute scale/translate
     out_h, out_w = shape

--- a/datashader/datashape/coretypes.py
+++ b/datashader/datashape/coretypes.py
@@ -254,7 +254,7 @@ class DateTime(Unit):
         return np.dtype('datetime64[us]')
 
 
-_units = set(['ns', 'us', 'ms', 's', 'm', 'h', 'D', 'W', 'M', 'Y'])
+_units = ('ns', 'us', 'ms', 's', 'm', 'h', 'D', 'W', 'M', 'Y')
 
 
 _unit_aliases = {

--- a/datashader/tests/benchmarks/__init__.py
+++ b/datashader/tests/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.benchmark

--- a/datashader/tests/conftest.py
+++ b/datashader/tests/conftest.py
@@ -1,0 +1,34 @@
+CUSTOM_MARKS = ("benchmark",)
+
+
+def pytest_addoption(parser):
+    for marker in CUSTOM_MARKS:
+        parser.addoption(
+            f"--{marker}",
+            action="store_true",
+            default=False,
+            help=f"Run {marker} related tests",
+        )
+
+
+def pytest_configure(config):
+    for marker in CUSTOM_MARKS:
+        config.addinivalue_line("markers", f"{marker}: {marker} test marker")
+
+
+def pytest_collection_modifyitems(config, items):
+    skipped, selected = [], []
+    markers = [m for m in CUSTOM_MARKS if config.getoption(f"--{m}")]
+    empty = not markers
+    for item in items:
+        if empty and any(m in item.keywords for m in CUSTOM_MARKS):
+            skipped.append(item)
+        elif empty:
+            selected.append(item)
+        elif not empty and any(m in item.keywords for m in markers):
+            selected.append(item)
+        else:
+            skipped.append(item)
+
+    config.hook.pytest_deselected(items=skipped)
+    items[:] = selected

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -188,8 +188,7 @@ def test_raster_quadmesh_upsamplex_and_downsampley(array_module):
     assert_eq_xr(res, out)
 
 
-# FIXME: dask.array does not work for this test
-@pytest.mark.parametrize('array_module', [array_modules[0], *array_modules[2:]])
+@pytest.mark.parametrize('array_module', array_modules)
 def test_raster_quadmesh_autorange_reversed(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4)
     da = xr.DataArray(

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -188,7 +188,8 @@ def test_raster_quadmesh_upsamplex_and_downsampley(array_module):
     assert_eq_xr(res, out)
 
 
-@pytest.mark.parametrize('array_module', array_modules)
+# FIXME: dask.array does not work for this test
+@pytest.mark.parametrize('array_module', [array_modules[0], *array_modules[2:]])
 def test_raster_quadmesh_autorange_reversed(array_module):
     c = ds.Canvas(plot_width=8, plot_height=4)
     da = xr.DataArray(

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from io import BytesIO
 
 import numpy as np
@@ -12,6 +13,8 @@ from datashader.tests.test_pandas import assert_eq_ndarray, assert_eq_xr, assert
 
 coords = dict([('x_axis', [3, 4, 5]), ('y_axis', [0, 1, 2])])
 dims = ['y_axis', 'x_axis']
+
+test_gpu = bool(int(os.getenv("DATASHADER_TEST_GPU", 0)))
 
 # CPU
 def build_agg(array_module=np):
@@ -42,12 +45,12 @@ def create_dask_array_np(*args, **kwargs):
     return da.from_array(np.array(*args, **kwargs))
 
 
-try:
+if test_gpu:
     import cupy
     aggs = [build_agg(np), build_agg(cupy), build_agg_dask()]
     arrays = [np.array, cupy.array, create_dask_array_np]
     array_modules = [np, cupy]
-except ImportError:
+else:
     cupy = None
     aggs = [build_agg(np), build_agg_dask()]
     arrays = [np.array, create_dask_array_np]

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,6 +1,8 @@
 import platform
 
-collect_ignore_glob = []
+collect_ignore_glob = [
+    "tiling.ipynb",
+]
 
 # 2023-07-21 with following error:
 # nbclient.exceptions.CellTimeoutError: A cell timed out while it was being executed, after 300 seconds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ norecursedirs = 'doc .git dist build _build .ipynb_checkpoints'
 minversion = "7"
 xfail_strict = true
 log_cli_level = "INFO"
-# skipping any notebooks that require extra deps
-nbsmoke_skip_run = ".*tiling.ipynb$\n.*streaming-aggregation.ipynb$\n.*8_Geography.ipynb$"
 filterwarnings = [
     "ignore:Passing a (SingleBlockManager|BlockManager) to (Series|GeoSeries|DataFrame|GeoDataFrame) is deprecated:DeprecationWarning",  # https://github.com/holoviz/spatialpandas/issues/137
     "ignore:Accessing the underlying geometries through the `.data`:DeprecationWarning:dask_geopandas.core",  # https://github.com/geopandas/dask-geopandas/issues/264

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extras_require = {
         'nbconvert',
         'nbformat',
         'nbsmoke[verify] >0.5',
+        'nbval',
         'netcdf4',
         'pyarrow',
         'pytest <8',  # Fails lint with IPynbFile is deprecated

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ extras_require = {
         'pytest <8',  # Fails lint with IPynbFile is deprecated
         'pytest-benchmark',
         'pytest-cov',
+        'psutil',
+        'pytest-xdist',
         'rasterio',
         'rioxarray',
         'scikit-image',

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ numpy2 = [
     'nbformat',
     'nbsmoke[verify] >0.5',
     'netcdf4',
+    'nbval',
+    'psutil',
+    'pytest-xdist',
     # 'pyarrow',
     'pytest <8',  # Fails lint with IPynbFile is deprecated
     'pytest-benchmark',

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = flake8
 [_unit]
 description = Run unit tests
 deps = .[tests]
-commands = pytest datashader -n logical --dist loadgroup --cov=./datashader --cov-append
+commands = pytest datashader -n logical --dist loadgroup --cov=./datashader --cov-append --benchmark-skip
            pytest datashader --benchmark --cov=./datashader --cov-append
 
 [_unit_deploy]
@@ -28,7 +28,7 @@ commands = pytest datashader
 [_unit_nojit]
 description = Run select unit tests with numba jit disabled
 deps = .[tests]
-commands = pytest datashader -k "not benchmarks and not test_tiles" --cov=./datashader --cov-append
+commands = pytest datashader -k "not test_tiles" -n logical --dist loadgroup --cov=./datashader --cov-append --benchmark-skip
 
 [_examples]
 description = Test that default examples run

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ commands = flake8
 [_unit]
 description = Run unit tests
 deps = .[tests]
-commands = pytest datashader --cov=./datashader --cov-append
+commands = pytest datashader -n logical --dist loadgroup --cov=./datashader --cov-append
+           pytest datashader --benchmark --cov=./datashader --cov-append
 
 [_unit_deploy]
 description = Run unit tests without coverage

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = pytest datashader -k "not test_tiles" -n logical --dist loadgroup --c
 description = Test that default examples run
 deps = .[examples, tests]
 commands = datashader fetch-data --path=examples --use-test-data
-           pytest --nbsmoke-run -k ".ipynb"
+           pytest -n logical --dist loadscope --nbval-lax examples
 # could add more, to test types of example other than nbs
 
 [_examples_extra]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = pytest datashader -k "not test_tiles" -n logical --dist loadgroup --c
 description = Test that default examples run
 deps = .[examples, tests]
 commands = datashader fetch-data --path=examples --use-test-data
-           pytest -n logical --dist loadscope --nbval-lax examples
+           pytest -n logical --dist loadscope --nbval-lax examples --benchmark-skip
 # could add more, to test types of example other than nbs
 
 [_examples_extra]


### PR DESCRIPTION
<s>I see this flaky test: `datashader/tests/test_quadmesh.py::test_raster_quadmesh_autorange_reversed[dask.array]` </s> 
Not flaky at all: `pytest 'datashader/tests/test_quadmesh.py::test_raster_quadmesh_autorange_reversed[dask.array]'` as this also fails. It is test pollution from the other array...

Want to merge it after my other prs.