### PR TITLE
Fix links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -554,7 +554,7 @@ New features:
 * Replaced outdated 536-line Bokeh `dashboard.py <https://github.com/holoviz/datashader/blob/ae72d237d574cbd7103a912fc84094ce10d55344/examples/dashboard/dashboard.py>`_ with 71-line Panel+HoloViews `dashboard <https://github.com/holoviz/datashader/blob/main/examples/dashboard.ipynb>`_ (`#676 <https://github.com/holoviz/datashader/pull/676>`_)
 * Allow aggregating xarray objects (in addition to Pandas and Dask DataFrames) (`#675 <https://github.com/holoviz/datashader/pull/675>`_)
 * Create WMTS tiles from Datashader data (`#636 <https://github.com/holoviz/datashader/pull/636>`_)
-* Added various `geographic utility functions <http://datashader.org/user_guide/8_Geography.html>`_ (ndvi, slope, aspect, hillshade, mean, bump map, Perlin noise) (`#661 <https://github.com/holoviz/datashader/pull/661>`_)
+* Added various `geographic utility functions <https://datashader.org/user_guide/8_Geography.html>`_ (ndvi, slope, aspect, hillshade, mean, bump map, Perlin noise) (`#661 <https://github.com/holoviz/datashader/pull/661>`_)
 * Made OpenSky data public (`#691 <https://github.com/holoviz/datashader/pull/691>`_)
 
 Bugfixes and compatibility:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Otherwise create a new environment:
 
 1.  Install Python 3
     [miniconda](https://docs.conda.io/en/latest/miniconda.html) or
-    [anaconda](https://www.anaconda.com/distribution/), if you don't
+    [anaconda](https://www.anaconda.com/download/success), if you don't
     already have it on your system.
 
 2.  Clone the datashader git repository if you do not already have it:

--- a/datashader/datashape/util/__init__.py
+++ b/datashader/datashape/util/__init__.py
@@ -29,7 +29,7 @@ def dshapes(*args):
 def dshape(o):
     """
     Parse a datashape. For a thorough description see
-    http://blaze.pydata.org/docs/datashape.html
+    https://datashape.readthedocs.io/en/latest/
 
     >>> ds = dshape('2 * int32')
     >>> ds[1]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,11 @@
 # Datashader Examples
 
 The best way to understand how Datashader works is to try out our
-extensive set of examples. [Datashader.org](http://datashader.org)
+extensive set of examples. [Datashader.org](https://datashader.org)
 includes static versions of the
-[getting started guide](http://datashader.org/getting_started),
-[user manual](http://datashader.org/user_guide), and
-[topic examples](http://datashader.org/topics), but for the full
+[getting started guide](https://datashader.org/getting_started),
+[user manual](https://datashader.org/user_guide), and
+[topic examples](https://datashader.org/topics), but for the full
 experience with dynamic updating you will need to install them on a
 live server.
 
@@ -55,7 +55,7 @@ you are welcome to edit that file or to download the individual files
 specified therein manually if you prefer, as long as you put them into
 a subdirectory `data/` so the examples can find them.  Once these
 steps have completed, you will be ready to run any of the examples
-listed on [datashader.org](http://datashader.org).
+listed on [datashader.org](https://datashader.org).
 
 
 ## Notebooks

--- a/examples/user_guide/10_Performance.ipynb
+++ b/examples/user_guide/10_Performance.ipynb
@@ -142,7 +142,7 @@
     "  <td class=\"sM\">-</td>\n",
     "</tr>\n",
     "<tr>\n",
-    "  <td class=\"sL\"><a href=\"https://docs.rapids.ai/api/cudf/stable/10min.html\">DaskDF + cuDF</a></td>\n",
+    "  <td class=\"sL\"><a href=\"https://docs.rapids.ai/api/cudf/stable/user_guide/10min/\">DaskDF + cuDF</a></td>\n",
     "  <td>columnar</td>\n",
     "  <td>distributed GPU</td>\n",
     "  <td>out-of-core</td>\n",


### PR DESCRIPTION
Two things done in this PR;

1) Convert http://datashader.org to https://datashader.org.
2) Try to update failing links. 


Commands used for 1: `rg -l 'http://datashader.org' | xargs sed -i 's/http:\/\/datashader.org/https:\/\/datashader.org/g'`

The commands used for 2:
``` sh
rg --no-filename --no-line-number --no-ignore --glob '!*.svg' --glob '!CHANGELOG.rst' -o 'https?:\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])' | sort | uniq | tee inputs.txt
parallel 'curl --output /dev/null --silent --fail {} -w "%{http_code} %{url}\n" --connect-timeout 10' :::: inputs.txt | tee outputs.txt
cat outputs.txt | grep '^40' 
```
Output:
```
404 http://blaze.pydata.org/docs/datashape.html
404 https://docs.rapids.ai/api/cudf/stable/10min.html
404 https://datashader-tiles-testing.s3.amazonaws.com/wald_tiles/
403 https://storage.googleapis.com/tlc-trip-data/2015/
404 https://www.anaconda.com/distribution/
```