### PR TITLE
CI: guard dask-geopandas expr import to avoid a TypeError on Python 3.10

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1285,9 +1285,12 @@ x- and y-coordinate arrays must have 1 or 2 dimensions.
             import dask_geopandas
             if Version(dask_geopandas.__version__) >= Version("0.4.0"):
                 from dask_geopandas.core import GeoDataFrame as gdf1
-                from dask_geopandas.expr import GeoDataFrame as gdf2
+                dfs.append(gdf1)
 
-                dfs.extend([gdf1, gdf2])
+                # See https://github.com/geopandas/dask-geopandas/issues/311
+                with contextlib.suppress(TypeError):
+                    from dask_geopandas.expr import GeoDataFrame as gdf2
+                    dfs.append(gdf2)
             else:
                 dfs.append(dask_geopandas.GeoDataFrame)
 


### PR DESCRIPTION
The CI has been broken the last couple of weeks, failing when running the example tests on Python 3.10. This can be narrowed down to:

```python
import dask
dask.config.set({'dataframe.query-planning': False})  # This is set via an env var on the CI where running pytest

import dask_geopandas.expr  # This happens internally in datashader
```

This has just been reported (https://github.com/geopandas/dask-geopandas/issues/311) but because it looks like it's a bit of a corner case it seems worth just working around it at the datashader level.