### PR TITLE
enh!: Respect input order of collection in summary

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -2128,9 +2128,15 @@ class summary(Expr):
     performed in two stages.
     """
     def __init__(self, **kwargs):
-        ks, vs = zip(*sorted(kwargs.items()))
-        self.keys = ks
-        self.values = vs
+        self._collection = kwargs
+
+    @property
+    def keys(self):
+        return list(self._collection)
+
+    @property
+    def values(self):
+        return list(self._collection.values())
 
     def __hash__(self):
         return hash((type(self), tuple(self.keys), tuple(self.values)))


### PR DESCRIPTION
A breaking change because as the resulting array values keyword arguments are no longer sorted.

This would give a different result before: `ds.summary(val=ds.min("s"), a=ds.where(ds.min("s")))` and `ds.summary(val=ds.min("s"), z=ds.where(ds.min("s")))`. 

|a | z |
| -- | -- |
|![image](https://github.com/user-attachments/assets/e3b7e6da-0235-49a3-a9a5-26b56cc249fc) | ![image](https://github.com/user-attachments/assets/22a7fd4e-6d47-4e75-9b05-0a8e3cd01fd0) | 

``` python
import datashader as ds
import numpy as np
import pandas as pd

import holoviews as hv
from holoviews.operation.datashader import rasterize

hv.extension("bokeh")

num = 10000
np.random.seed(1)

dists = {
    cat: pd.DataFrame(
        {
            "x": np.random.normal(x, s, num),
            "y": np.random.normal(y, s, num),
            "s": s,
            "val": val,
            "cat": cat,
        }
    )
    for x, y, s, val, cat in [
        (2, 2, 0.03, 0, "d1"),
        (2, -2, 0.10, 1, "d2"),
        (-2, -2, 0.50, 2, "d3"),
        (-2, 2, 1.00, 3, "d4"),
        (0, 0, 3.00, 4, "d5"),
    ]
}

df = pd.concat(dists, ignore_index=True)
points = hv.Points(df)
agg = ds.summary(val=ds.min("s"), a=ds.where(ds.min("s")))
# agg = ds.summary(val=ds.min("s"), z=ds.where(ds.min("s")))
plot = rasterize(points, aggregator=agg)#.opts(tools=["hover"])
plot
```

I need to think if there are some consequences that I currently don't see. One thing could be `__hash__` is right now sensitive to input order, even though the data could be the same


 