### PR TITLE
ci: Move numba to top of dependencies

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -22,10 +22,10 @@ build = ["py311", "build"]
 lint = ["py311", "lint"]
 
 [dependencies]
+numba = "*"  # At top as this dictates Python version
 colorcet = "*"
 dask-core = "*"
 multipledispatch = "*"
-numba = "*"
 numpy = "*"
 pandas = "*"
 param = "*"


### PR DESCRIPTION
Will not solve on `osx-64` because it is in a weird state between `numba` and `python 3.13`

![image](https://github.com/user-attachments/assets/87a77436-5a08-4e0b-b586-489b47ef085c)
