### PR TITLE
refactor: Add NPY to ruff rules

### DIFF
--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -65,10 +65,10 @@ class random_layout(LayoutAlgorithm):
     def __call__(self, nodes, edges=None, **params):
         p = param.ParamOverrides(self, params)
 
-        np.random.seed(p.seed)
+        rng = np.random.default_rng(p.seed)
 
         df = nodes.copy()
-        points = np.asarray(np.random.random((len(df), 2)))
+        points = np.asarray(rng.random((len(df), 2)))
 
         df[p.x] = points[:, 0]
         df[p.y] = points[:, 1]
@@ -92,7 +92,7 @@ class circular_layout(LayoutAlgorithm):
     def __call__(self, nodes, edges=None, **params):
         p = param.ParamOverrides(self, params)
 
-        np.random.seed(p.seed)
+        rng = np.random.default_rng(p.seed)
 
         r = 0.5  # radius
         x0, y0 = 0.5, 0.5  # center of unit circle
@@ -103,7 +103,7 @@ class circular_layout(LayoutAlgorithm):
         if p.uniform:
             thetas = np.arange(circumference, step=circumference/len(df))
         else:
-            thetas = np.asarray(np.random.random((len(df),))) * circumference
+            thetas = np.asarray(rng.random((len(df),))) * circumference
 
         df[p.x] = x0 + r * np.cos(thetas)
         df[p.y] = y0 + r * np.sin(thetas)
@@ -111,11 +111,14 @@ class circular_layout(LayoutAlgorithm):
         return df
 
 
-def _extract_points_from_nodes(nodes, params, dtype=None):
+def _extract_points_from_nodes(nodes, params, dtype=None, rng=None):
+    if rng is None:
+        rng = np.random.default_rng()
+
     if params.x in nodes.columns and params.y in nodes.columns:
         points = np.asarray(nodes[[params.x, params.y]])
     else:
-        points = np.asarray(np.random.random((len(nodes), params.dim)), dtype=dtype)
+        points = np.asarray(rng.random((len(nodes), params.dim)), dtype=dtype)
     return points
 
 
@@ -243,10 +246,10 @@ class forceatlas2_layout(LayoutAlgorithm):
     def __call__(self, nodes, edges, **params):
         p = param.ParamOverrides(self, params)
 
-        np.random.seed(p.seed)
+        rng = np.random.default_rng(p.seed)
 
         # Convert graph into sparse adjacency matrix and array of points
-        points = _extract_points_from_nodes(nodes, p, dtype='f')
+        points = _extract_points_from_nodes(nodes, p, dtype='f', rng=rng)
         matrix = _convert_graph_to_sparse_matrix(nodes, edges, p, dtype='f')
 
         if p.k is None:

--- a/datashader/tests/benchmarks/test_canvas.py
+++ b/datashader/tests/benchmarks/test_canvas.py
@@ -1,17 +1,15 @@
 import pytest
-import numpy as np
 import pandas as pd
-
 import datashader as ds
 
 
 @pytest.fixture
-def time_series():
+def time_series(rng):
     n = 10**7
-    signal = np.random.normal(0, 0.3, size=n).cumsum() + 50
+    signal = rng.normal(0, 0.3, size=n).cumsum() + 50
     def noise(var, bias, n):
-        return np.random.normal(bias, var, n)
-    ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
+        return rng.normal(bias, var, n)
+    ys = signal + noise(1, 10*(rng.random() - 0.5), n)
 
     df = pd.DataFrame({'y': ys})
     df['x'] = df.index

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -25,13 +25,13 @@ def extend_line():
 @pytest.mark.parametrize('high', [0, 10**5])
 @pytest.mark.parametrize('low', [0, -10**5])
 @pytest.mark.benchmark(group="extend_line")
-def test_extend_line_uniform(benchmark, extend_line, low, high):
+def test_extend_line_uniform(benchmark, extend_line, low, high, rng):
     n = 10**6
     sx, tx, sy, ty = (1, 0, 1, 0)
     xmin, xmax, ymin, ymax = (0, 0, 10**4, 10**4)
 
-    xs = np.random.uniform(xmin + low, ymin + high, n)
-    ys = np.random.uniform(xmax + low, ymax + high, n)
+    xs = rng.uniform(xmin + low, ymin + high, n)
+    ys = rng.uniform(xmax + low, ymax + high, n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
     buffer = np.empty(0)
@@ -41,7 +41,7 @@ def test_extend_line_uniform(benchmark, extend_line, low, high):
 
 
 @pytest.mark.benchmark(group="extend_line")
-def test_extend_line_normal(benchmark, extend_line):
+def test_extend_line_normal(benchmark, extend_line, rng):
     n = 10**6
     sx, tx, sy, ty = (1, 0, 1, 0)
     xmin, xmax, ymin, ymax = (0, 0, 10**4, 10**4)
@@ -50,10 +50,10 @@ def test_extend_line_normal(benchmark, extend_line):
     end = start + 60 * 60 * 24
     xs = np.linspace(start, end, n)
 
-    signal = np.random.normal(0, 0.3, size=n).cumsum() + 50
+    signal = rng.normal(0, 0.3, size=n).cumsum() + 50
     def noise(var, bias, n):
-        return np.random.normal(bias, var, n)
-    ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
+        return rng.normal(bias, var, n)
+    ys = signal + noise(1, 10*(rng.random() - 0.5), n)
 
     agg = np.zeros((ymin, ymax), dtype='i4')
     buffer = np.empty(0)

--- a/datashader/tests/conftest.py
+++ b/datashader/tests/conftest.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 CUSTOM_MARKS = {"benchmark", "gpu"}
 
 
@@ -33,3 +36,8 @@ def pytest_collection_modifyitems(config, items):
 
     config.hook.pytest_deselected(items=skipped)
     items[:] = selected
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)

--- a/datashader/tests/test_layout.py
+++ b/datashader/tests/test_layout.py
@@ -87,9 +87,8 @@ def test_forceatlas2_unpositioned_nodes_with_weighted_edges(nodes_without_positi
 
 
 def test_random_layout(nodes_without_positions, edges):
-    expected_x = [0.417022004703, 0.000114374817, 0.146755890817, 0.186260211378, 0.396767474231]
-    expected_y = [0.720324493442, 0.302332572632, 0.092338594769, 0.345560727043, 0.538816734003]
-
+    expected_x = [0.511821624, 0.144159612, 0.311831452, 0.827702593, 0.549593687]
+    expected_y = [0.950463696, 0.948649447, 0.423326448, 0.409199136, 0.027559113]
     df = random_layout(nodes_without_positions, edges, seed=1)
 
     assert np.allclose(df['x'], expected_x)
@@ -107,9 +106,8 @@ def test_uniform_circular_layout(nodes_without_positions, edges):
 
 
 def test_random_circular_layout(nodes_without_positions, edges):
-    expected_x = [0.066430214119, 0.407310906119, 0.999999870890, 0.338539010529, 0.802076237875]
-    expected_y = [0.749032609855, 0.008666374166, 0.500359319055, 0.973212794501, 0.898434369139]
-
+    expected_x = [0.00137865, 0.97597639, 0.80853537, 0.97420002, 0.31060039]
+    expected_y = [0.46289541, 0.34687760, 0.89345383, 0.34146188, 0.96273944]
     df = circular_layout(nodes_without_positions, edges, uniform=False, seed=1)
 
     assert np.allclose(df['x'], expected_x)

--- a/datashader/tests/test_tiles.py
+++ b/datashader/tests/test_tiles.py
@@ -21,8 +21,9 @@ df = None
 def mock_load_data_func(x_range, y_range):
     global df
     if df is None:
-        xs = np.random.normal(loc=0, scale=500000, size=10000000)
-        ys = np.random.normal(loc=0, scale=500000, size=10000000)
+        rng = np.random.default_rng()
+        xs = rng.normal(loc=0, scale=500000, size=10000000)
+        ys = rng.normal(loc=0, scale=500000, size=10000000)
         df = pd.DataFrame(dict(x=xs, y=ys))
 
     return df.loc[df['x'].between(*x_range) & df['y'].between(*y_range)]

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -1106,17 +1106,17 @@ def check_eq_hist_cdf_slope(eq):
     assert 0.9 < slope < 1.1
 
 
-def test_eq_hist():
+def test_eq_hist(rng):
     # Float
-    data = np.random.normal(size=300**2)
-    data[np.random.randint(300**2, size=100)] = np.nan
+    data = rng.normal(size=300**2)
+    data[rng.integers(300**2, size=100)] = np.nan
     data = (data - np.nanmin(data)).reshape((300, 300))
     mask = np.isnan(data)
     eq, _ = tf.eq_hist(data, mask)
     check_eq_hist_cdf_slope(eq)
     assert (np.isnan(eq) == mask).all()
     # Integer
-    data = np.random.normal(scale=100, size=(300, 300)).astype('i8')
+    data = rng.normal(scale=100, size=(300, 300)).astype('i8')
     data = data - data.min()
     eq, _ = tf.eq_hist(data)
     check_eq_hist_cdf_slope(eq)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ fix = true
 select = [
     "E",
     "F",
+    "NPY",
     "UP",
     "W",
 ]


### PR DESCRIPTION
Enable Numpy rules: https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy

The changes are related to NPY002: https://docs.astral.sh/ruff/rules/numpy-legacy-random/#numpy-legacy-random-npy002

I'm not sure why `layout.py` is part of datashader.  