### PR TITLE
docs: update the supported python versions on Getting Started page

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -5,7 +5,7 @@ Getting Started
 Installation
 ------------
 
-Datashader supports Python 3.7, 3.8, 3.9 and 3.10 on Linux, Windows, or Mac
+Datashader supports Python 3.9, 3.10, 3.11 and 3.12 on Linux, Windows, or Mac
 and can be installed with conda::
 
     conda install datashader


### PR DESCRIPTION
The supported python versions on https://datashader.org/getting_started/index.html are outdated and shows that 3.7-3.10 is supported, this updates to the currently supported versions 3.9-3.12.