### PR TITLE
Speed up edge bundling

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -194,7 +194,6 @@ def smooth_segment(segments, tension, idx, idy):
                             (tension*(previous[idx] + next_point[idx]) / 2))
             current[idy] = (((1-tension)*current[idy]) +
                             (tension*(previous[idy] + next_point[idy]) / 2))
-     
 
 def smooth(edge_segments, tension, idx, idy):
     for segments in edge_segments:

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -520,7 +520,7 @@ class hammer_bundle(connect_edges):
     tension = param.Number(default=0.3,bounds=(0,None),precedence=-0.5,doc="""
         Exponential smoothing factor to use when smoothing""")
 
-    accuracy = param.Integer(default=500,bounds=(1,None),precedence=-0.5,doc="""
+    accuracy = param.Integer(default=500,bounds=(1,65535),precedence=-0.5,doc="""
         Number of entries in table for...""")
 
     advect_iterations = param.Integer(default=50,bounds=(0,None),precedence=-0.5,doc="""

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -108,8 +108,8 @@ def resample_segment(segments, new_segments, n_points_to_add, ndims):
 
 @nb.jit(
     nb.types.Tuple((nb.boolean, nb.uint64, nb.uint16[::1]))(nb.float32[:,::1], segment_length_type),
-    nopython=True, 
-    nogil=True, 
+    nopython=True,
+    nogil=True,
     fastmath=True,
     locals={
         'next_point': nb.float32[::1],
@@ -158,7 +158,7 @@ def calculate_resampling(segments, squared_segment_length):
     nogil=True,
 )
 def resample_edge(segments, squared_segment_length, ndims):
-    change, total_resamples, n_points_to_add = calculate_resampling(segments, 
+    change, total_resamples, n_points_to_add = calculate_resampling(segments,
                                                                     squared_segment_length)
     if not change:
         return segments
@@ -190,9 +190,9 @@ def smooth_segment(segments, tension, idx, idy):
         seg_length = len(segments) - 2
         for i in range(1, seg_length):
             previous, current, next_point = segments[i - 1], segments[i], segments[i + 1]
-            current[idx] = (((1-tension)*current[idx]) + 
+            current[idx] = (((1-tension)*current[idx]) +
                             (tension*(previous[idx] + next_point[idx]) / 2))
-            current[idy] = (((1-tension)*current[idy]) + 
+            current[idy] = (((1-tension)*current[idy]) +
                             (tension*(previous[idy] + next_point[idy]) / 2))
      
 
@@ -208,7 +208,7 @@ def smooth(edge_segments, tension, idx, idy):
     fastmath=True,
     locals={'it': nb.uint8, "i": nb.uint16, "x": nb.uint16, "y": nb.uint16}
 )
-def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_segment_length, 
+def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_segment_length,
                         idx, idy, ndims):
     for it in range(iterations):
         for i in range(1, len(segments) - 1):
@@ -223,7 +223,7 @@ def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_seg
             segments = resample_edge(segments, squared_segment_length, ndims)
     return segments
 
-def advect_resample_all(gradients, edge_segments, iterations, accuracy, squared_segment_length, 
+def advect_resample_all(gradients, edge_segments, iterations, accuracy, squared_segment_length,
                         idx, idy, ndims):
     vert, horiz = gradients
     return [advect_and_resample(vert, horiz, edges, iterations, accuracy, squared_segment_length,
@@ -286,7 +286,7 @@ class UnweightedSegment(BaseSegment):
     @staticmethod
     @ngjit
     def create_segment(edge):
-        return np.array([[edge[0], edge[1], edge[2]], [edge[0], edge[3], edge[4]]], 
+        return np.array([[edge[0], edge[1], edge[2]], [edge[0], edge[3], edge[4]]],
                         dtype=np.float32)
 
     @staticmethod
@@ -360,7 +360,7 @@ class EdgelessWeightedSegment(BaseSegment):
     @staticmethod
     @ngjit
     def create_segment(edge):
-        return np.array([[edge[0], edge[1], edge[4]], [edge[2], edge[3], edge[4]]], 
+        return np.array([[edge[0], edge[1], edge[4]], [edge[2], edge[3], edge[4]]],
                         dtype=np.float32)
 
     @staticmethod
@@ -599,8 +599,8 @@ class hammer_bundle(connect_edges):
             # Move edges along the gradients and resample when necessary
             # This could include smoothing to adjust the amount a graph can change
             edge_segments = [advect_resample_all_fn(gradients, segment, p.advect_iterations,
-                                                 p.accuracy, squared_segment_length, 
-                                                 segment_class.idx, segment_class.idy, 
+                                                 p.accuracy, squared_segment_length,
+                                                 segment_class.idx, segment_class.idy,
                                                  segment_class.ndims)
                              for segment in edge_segments]
 

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -520,7 +520,7 @@ class hammer_bundle(connect_edges):
             get_gradients_fn = delayed(get_gradients)
             advect_resample_all_fn = delayed(advect_resample_all)
         else:
-            result_edges_fn = resample_edges
+            resample_edges_fn = resample_edges
             draw_to_surface_fn = draw_to_surface
             get_gradients_fn = get_gradients
             advect_resample_all_fn = advect_resample_all

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -600,7 +600,7 @@ class hammer_bundle(connect_edges):
 
         if p.use_dask:
             # Finally things can be sent for computation
-            edge_segments = compute(edge_segments)
+            edge_segments = compute(edge_segments)[0]
 
         # Flatten things
         new_segs = []

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -185,7 +185,7 @@ def smooth(edge_segments, tension, idx, idy):
 
 
 @nb.jit(
-    'void(f4[:,::1],f8[:,::1],f8[:,::1],f8,u1,u1)',
+    nb.void(nb.float32[:,::1], nb.float32[:,::1], nb.float32[:,::1], nb.float64, nb.int64, nb.int64),
     nopython=True,
     nogil=True,
     fastmath=True,
@@ -195,14 +195,14 @@ def advect_segments(segments, vert, horiz, accuracy, idx, idy):
     for i in range(1, len(segments) - 1):
         x = np.uint16(segments[i, idx] * accuracy)
         y = np.uint16(segments[i, idy] * accuracy)
-        segments[i, idx] = segments[i, idx] + horiz[x, y] / accuracy
-        segments[i, idy] = segments[i, idy] + vert[x, y] / accuracy
+        segments[i, idx] += horiz[x, y] / accuracy
+        segments[i, idy] += vert[x, y] / accuracy
         segments[i, idx] = max(0, min(segments[i, idx], 1))
         segments[i, idy] = max(0, min(segments[i, idy], 1))
 
 
 @nb.jit(
-    nb.float32[:,::1](nb.float64[:,::1], nb.float64[:,::1], nb.float32[:,::1], nb.int64, nb.float64, segment_length_type, nb.int64, nb.int64, nb.int64),
+    nb.float32[:,::1](nb.float32[:,::1], nb.float32[:,::1], nb.float32[:,::1], nb.int64, nb.float64, segment_length_type, nb.int64, nb.int64, nb.int64),
     nopython=True,
     nogil=True,
     locals={'it': nb.uint8}
@@ -228,7 +228,7 @@ def batches(seq, n):
 
 
 def draw_to_surface(edge_segments, bandwidth, accuracy, accumulator):
-    img = np.zeros((accuracy + 1, accuracy + 1))
+    img = np.zeros((accuracy + 1, accuracy + 1), dtype=np.float32)
     for segments in edge_segments:
         for point in segments:
             accumulator(img, point, accuracy)

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -158,7 +158,8 @@ def calculate_resampling(segments, squared_segment_length):
     nogil=True,
 )
 def resample_edge(segments, squared_segment_length, ndims):
-    change, total_resamples, n_points_to_add = calculate_resampling(segments, squared_segment_length)
+    change, total_resamples, n_points_to_add = calculate_resampling(segments, 
+                                                                    squared_segment_length)
     if not change:
         return segments
     resampled = np.empty((total_resamples, ndims), dtype=np.float32)
@@ -189,8 +190,10 @@ def smooth_segment(segments, tension, idx, idy):
         seg_length = len(segments) - 2
         for i in range(1, seg_length):
             previous, current, next_point = segments[i - 1], segments[i], segments[i + 1]
-            current[idx] = ((1-tension)*current[idx]) + (tension*(previous[idx] + next_point[idx]) / 2)
-            current[idy] = ((1-tension)*current[idy]) + (tension*(previous[idy] + next_point[idy]) / 2)
+            current[idx] = (((1-tension)*current[idx]) + 
+                            (tension*(previous[idx] + next_point[idx]) / 2))
+            current[idy] = (((1-tension)*current[idy]) + 
+                            (tension*(previous[idy] + next_point[idy]) / 2))
      
 
 def smooth(edge_segments, tension, idx, idy):
@@ -205,7 +208,8 @@ def smooth(edge_segments, tension, idx, idy):
     fastmath=True,
     locals={'it': nb.uint8, "i": nb.uint16, "x": nb.uint16, "y": nb.uint16}
 )
-def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_segment_length, idx, idy, ndims):
+def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_segment_length, 
+                        idx, idy, ndims):
     for it in range(iterations):
         for i in range(1, len(segments) - 1):
             x = np.uint16(segments[i, idx] * accuracy)
@@ -281,7 +285,8 @@ class UnweightedSegment(BaseSegment):
     @staticmethod
     @ngjit
     def create_segment(edge):
-        return np.array([[edge[0], edge[1], edge[2]], [edge[0], edge[3], edge[4]]], dtype=np.float32)
+        return np.array([[edge[0], edge[1], edge[2]], [edge[0], edge[3], edge[4]]], 
+                        dtype=np.float32)
 
     @staticmethod
     @ngjit
@@ -354,7 +359,8 @@ class EdgelessWeightedSegment(BaseSegment):
     @staticmethod
     @ngjit
     def create_segment(edge):
-        return np.array([[edge[0], edge[1], edge[4]], [edge[2], edge[3], edge[4]]], dtype=np.float32)
+        return np.array([[edge[0], edge[1], edge[4]], [edge[2], edge[3], edge[4]]], 
+                        dtype=np.float32)
 
     @staticmethod
     @ngjit
@@ -564,8 +570,10 @@ class hammer_bundle(connect_edges):
         # This is simply to let the work split out over multiple cores
         edge_batches = list(batches(edges, p.batch_size))
 
-        squared_segment_length = SegmentLength(p.min_segment_length**2, p.max_segment_length**2,
-                                                        ((p.min_segment_length + p.max_segment_length) / 2)**2)
+        squared_segment_length = SegmentLength(
+            p.min_segment_length**2, p.max_segment_length**2,
+            ((p.min_segment_length + p.max_segment_length) / 2)**2
+        )
 
         # This gets the edges split into lots of small segments
         # Doing this inside a delayed function lowers the transmission overhead
@@ -590,8 +598,9 @@ class hammer_bundle(connect_edges):
             # Move edges along the gradients and resample when necessary
             # This could include smoothing to adjust the amount a graph can change
             edge_segments = [advect_resample_all_fn(gradients, segment, p.advect_iterations,
-                                                 p.accuracy, squared_segment_length, segment_class.idx,
-                                                 segment_class.idy, segment_class.ndims)
+                                                 p.accuracy, squared_segment_length, 
+                                                 segment_class.idx, segment_class.idy, 
+                                                 segment_class.ndims)
                              for segment in edge_segments]
 
         # Do a final resample to a smaller size for nicer rendering

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -153,7 +153,7 @@ def calculate_resampling(segments, squared_segment_length):
     return any_change, total, n_points_to_add
 
 @nb.jit(
-    nb.float32[:,::1](nb.float32[:,::1], segment_length_type, nb.int64),
+    nb.float32[:, ::1](nb.float32[:, ::1], segment_length_type, nb.int64),
     nopython=True,
     nogil=True,
 )

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -62,16 +62,16 @@ def distance_between(a, b):
 
 @nb.jit(
     nb.float32[:,::1](nb.float32[:,::1], nb.float32[:,::1], nb.uint16[::1], nb.int64),
-    nopython=True, 
-    nogil=True, 
+    nopython=True,
+    nogil=True,
     fastmath=True,
     locals={
-        'next_point': nb.float32[::1], 
+        'next_point': nb.float32[::1],
         'current_point': nb.float32[::1],
         'step_vector': nb.float32[::1],
         'i': nb.uint16,
-        'pos': nb.uint64, 
-        'index': nb.uint64, 
+        'pos': nb.uint64,
+        'index': nb.uint64,
         'distance': nb.float32
     }
 )
@@ -112,10 +112,10 @@ def resample_segment(segments, new_segments, n_points_to_add, ndims):
     nogil=True, 
     fastmath=True,
     locals={
-        'next_point': nb.float32[::1], 
-        'current_point': nb.float32[::1], 
-        'pos': nb.uint64, 
-        'index': nb.uint64, 
+        'next_point': nb.float32[::1],
+        'current_point': nb.float32[::1],
+        'pos': nb.uint64,
+        'index': nb.uint64,
         'distance': nb.float32
     }
 )
@@ -178,7 +178,7 @@ def resample_edges(edge_segments, squared_segment_length, ndims):
     nogil=True,
     fastmath=True,
     locals={
-        "i": nb.uint16, 
+        "i": nb.uint16,
         "segments": nb.float32[:,::1],
         "previous": nb.float32[::1],
         "current": nb.float32[::1],
@@ -201,7 +201,7 @@ def smooth(edge_segments, tension, idx, idy):
         smooth_segment(segments, tension, idx, idy)
 
 @nb.jit(
-    nb.float32[:,::1](nb.float32[:,::1], nb.float32[:,::1], nb.float32[:,::1], nb.int64, nb.float64, 
+    nb.float32[:,::1](nb.float32[:,::1], nb.float32[:,::1], nb.float32[:,::1], nb.int64, nb.float64,
                       segment_length_type, nb.uint64, nb.uint64, nb.int64),
     nopython=True,
     nogil=True,
@@ -223,9 +223,10 @@ def advect_and_resample(vert, horiz, segments, iterations, accuracy, squared_seg
             segments = resample_edge(segments, squared_segment_length, ndims)
     return segments
 
-def advect_resample_all(gradients, edge_segments, iterations, accuracy, squared_segment_length, idx, idy, ndims):
+def advect_resample_all(gradients, edge_segments, iterations, accuracy, squared_segment_length, 
+                        idx, idy, ndims):
     vert, horiz = gradients
-    return [advect_and_resample(vert, horiz, edges, iterations, accuracy, squared_segment_length, 
+    return [advect_and_resample(vert, horiz, edges, iterations, accuracy, squared_segment_length,
                                 idx, idy, ndims)
             for edges in edge_segments]
 


### PR DESCRIPTION
The hammer edge bundling is fantastic, but can be quite time consuming for large graphs (100,000+ edges and upward). I spent some time  benchmarking the code, and then doing some profiling to determine how the time was being spent, and then attempted to make some minor improvements. I quickly discovered that, at least on the machines and setups I tried, the dask usage actually made it significantly *slower*. I have therefore made dask optional, with a param ``use_dask`` which defaults to ``False``. I also spent a while trying to wring the most I could out of numba for many of the core or frequently called functions. Primarily this involved adding more annotations to the decorators, and a careful rewrite of the distance function which is called extremely often. The remainder of the work was re-juggling when and where various computations were done to avoid duplicate work, or move more loops inside numba where possible. Lastly I rewrote ``_convert_edge_segments_to_dataframe`` to use a single large numpy allocation followed by ``zip`` and ``chain`` rather than a generator with many many small allocations (the code is a little less readable, but significantly faster for very large graphs).

After all these changes a typical use case for me (a knn-graph) went from 1h20m to 15s, and scaled up versions of the random graph examples from the docs (with ``n=500`` and  ``m=100000``) went from 1h 13min for circular layout and 1h 39min for force-directed layout to 1min 38s and 60s respectively. This would make edge-bundling and graph drawing with datashader (which I love!) far more practical for a much wider range of datasets.

I'll be happy to discuss the changes as required -- some are more important than others, but I went down the optimization rabbit hole and did all the things I could.