### PR TITLE
Fixup registration of Dask DataFrame

### DIFF
--- a/datashader/data_libraries/dask.py
+++ b/datashader/data_libraries/dask.py
@@ -51,13 +51,7 @@ def dask_pipeline(df, schema, canvas, glyph, summary, *, antialias=False, cuda=F
     return scheduler(dsk, name)
 
 
-# Classic Dask.DataFrame
-bypixel.pipeline.register(dd.core.DataFrame)(dask_pipeline)
-
-with suppress(ImportError):
-    import dask_expr
-
-    bypixel.pipeline.register(dask_expr.DataFrame)(dask_pipeline)
+bypixel.pipeline.register(dd.DataFrame)(dask_pipeline)
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):


### PR DESCRIPTION
- closes #1388 

This will automatically pull the correct DataFrame Class, even on older version. The backend can only be set before dask.dataframe is imported for the first time in a python session, i.e. it can't be changed afterwards. Setting whatever you get with dd.DataFrame is thus sufficient