### PR TITLE
compat: Dask-expr 2

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -96,7 +96,7 @@ test-benchmark = 'pytest datashader/tests --benchmark'
 
 [feature.test.dependencies]
 dask-core = "*"
-dask-expr = "*"
+dask-expr = "<2"
 dask-geopandas = "*"
 geodatasets = "*"
 geopandas-base = "*"


### PR DESCRIPTION
For now, add an upper pin that removes the warning, so the CI is not failing.


![image](https://github.com/user-attachments/assets/be180be2-947b-49b9-af87-88fc419304ce)


