### PR TITLE
Ignore shapely deprecation warning emitted from geopandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,4 +115,6 @@ filterwarnings = [
     "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning", # https://github.com/pydata/xarray/issues/7259
     "ignore:\\s*Dask dataframe query planning is disabled because dask-expr is not installed:FutureWarning", # https://github.com/holoviz/spatialpandas/issues/146
     "ignore:The legacy Dask DataFrame implementation is deprecated:FutureWarning", # https://github.com/holoviz/spatialpandas/issues/146
+    # 2025-04
+    "ignore:The 'shapely.geos' module is deprecated, and will be removed in a future version:DeprecationWarning",
 ]


### PR DESCRIPTION
The test suite failed this week-end with:

```
Run pixi run -e test-311 test-unit $COV
✨ Pixi task (test-unit in test-311): pytest datashader -n logical --dist loadgroup --benchmark-skip --cov=./datashader --cov-report=xml
ImportError while loading conftest '/home/runner/work/datashader/datashader/datashader/tests/conftest.py'.
datashader/__init__.py:7: in <module>
    from .core import Canvas                                 # noqa (API import)
datashader/core.py:13: in <module>
    from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, \
datashader/utils.py:33: in <module>
    from geopandas.array import GeometryDtype as gpd_GeometryDtype
.pixi/envs/test-311/lib/python3.11/site-packages/geopandas/__init__.py:3: in <module>
    from geopandas.geoseries import GeoSeries
.pixi/envs/test-311/lib/python3.11/site-packages/geopandas/geoseries.py:18: in <module>
    from geopandas.base import GeoPandasBase, _delegate_property
.pixi/envs/test-311/lib/python3.11/site-packages/geopandas/base.py:12: in <module>
    from . import _compat as compat
.pixi/envs/test-311/lib/python3.11/site-packages/geopandas/_compat.py:7: in <module>
    import shapely.geos
.pixi/envs/test-311/lib/python3.11/site-packages/shapely/geos.py:7: in <module>
    warnings.warn(
E   DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
```