### PR TITLE
enh: Add `__repr__` to reductions

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1274,6 +1274,8 @@ class count_cat(by):
     def __init__(self, column):
         super().__init__(column, count())
 
+    def __repr__(self):
+        return f"count_cat(column={self.column!r})"
 
 class mean(Reduction):
     """Mean of all elements in ``column``.

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -471,6 +471,9 @@ class Reduction(Expr):
     def _create_uint32(shape, array_module):
         return array_module.zeros(shape, dtype='u4')
 
+    def __repr__(self):
+        return f"{type(self).__name__}({self.column!r})"
+
 
 class OptionalFieldReduction(Reduction):
     """Base class for things like ``count`` or ``any`` for which the field is optional"""
@@ -657,6 +660,9 @@ class count(SelfIntersectingOptionalFieldReduction):
             nansum_in_place(ret, aggs[i])
         return ret
 
+    def __repr__(self):
+        return "count()"
+
 
 class _count_ignore_antialiasing(count):
     """Count reduction but ignores antialiasing. Used by mean reduction.
@@ -812,6 +818,9 @@ class by(Reduction):
             return self.reduction._build_finalize(dshape)(bases, cuda=cuda, **kwargs)
 
         return finalize
+
+    def __repr__(self):
+        return f"{type(self).__name__}(column={self.column!r}, reduction={self.reduction!r})"
 
 class any(OptionalFieldReduction):
     """Whether any elements in ``column`` map to each bin.
@@ -1477,6 +1486,9 @@ class FloatingNReduction(OptionalFieldReduction):
     def _hashable_inputs(self):
         return super()._hashable_inputs() + (self.n,)
 
+    def __repr__(self):
+        return f"{type(self).__name__}(column={self.column!r}, n={self.n!r})"
+
 
 class _first_n_or_last_n(FloatingNReduction):
     """Abstract base class of first_n and last_n reductions.
@@ -2103,6 +2115,9 @@ class where(FloatingReduction):
 
         return finalize
 
+    def __repr__(self):
+        return f"where(selector={self.selector!r}, lookup_column={self.column!r})"
+
 
 class summary(Expr):
     """A collection of named reductions.
@@ -2165,6 +2180,10 @@ class summary(Expr):
     @property
     def inputs(self):
         return tuple(unique(concat(v.inputs for v in self.values)))
+
+    def __repr__(self):
+        pairs = ", ".join([f"{k}={v!r}" for k, v in zip(self.keys, self.values, strict=True)])
+        return f"summary({pairs})"
 
 
 class _max_or_min_row_index(OptionalFieldReduction):

--- a/datashader/tests/test_reductions.py
+++ b/datashader/tests/test_reductions.py
@@ -12,7 +12,7 @@ def test_string_output():
         "any": "any('col')",
         "by": "by(column='col', reduction=count())",
         "count": "count()",
-        "count_cat": "count_cat(column='col', reduction=count())",
+        "count_cat": "count_cat(column='col')",
         "first": "first('col')",
         "first_n": "first_n(column='col', n=1)",
         "last": "last('col')",

--- a/datashader/tests/test_reductions.py
+++ b/datashader/tests/test_reductions.py
@@ -1,0 +1,49 @@
+import datashader as ds
+
+
+def all_subclasses(cls):
+    items1 = {cls, *cls.__subclasses__()}
+    items2 = {s for c in cls.__subclasses__() for s in all_subclasses(c)}
+    return items1 | items2
+
+
+def test_string_output():
+    expected = {
+        "any": "any('col')",
+        "by": "by(column='col', reduction=count())",
+        "count": "count()",
+        "count_cat": "count_cat(column='col', reduction=count())",
+        "first": "first('col')",
+        "first_n": "first_n(column='col', n=1)",
+        "last": "last('col')",
+        "last_n": "last_n(column='col', n=1)",
+        "m2": "m2('col')",
+        "max": "max('col')",
+        "max_n": "max_n(column='col', n=1)",
+        "mean": "mean('col')",
+        "min": "min('col')",
+        "min_n": "min_n(column='col', n=1)",
+        "mode": "mode('col')",
+        "std": "std('col')",
+        "sum": "sum('col')",
+        "summary": "summary(a=1)",
+        "var": "var('col')",
+        "where": "where(selector=min('col'), lookup_column='col')",
+    }
+
+    count = 0
+    for red in all_subclasses(ds.reductions.Reduction) | all_subclasses(ds.reductions.summary):
+        red_name = red.__name__
+        if red_name.startswith("_") or "Reduction" in red_name:
+            continue
+        elif red_name in ("by", "count_cat"):
+            assert str(red("col")) == expected[red_name]
+        elif red_name == "where":
+            assert str(red(ds.min("col"), "col")) == expected[red_name]
+        elif red_name == "summary":
+            assert str(red(a=1)) == expected[red_name]
+        else:
+            assert str(red("col")) == expected[red_name]
+        count += 1
+
+    assert count == 20  # Update if more subclasses are added


### PR DESCRIPTION
This is a tiny improvement, making it easier for underlying libraries to get this information. I'm not sure I have gotten all of them, and I'm also unsure if multiple inputs should have keywords. 

Before:
![image](https://github.com/user-attachments/assets/ac50e15c-07de-4248-be8e-39e3e26bfa71)


After:
![image](https://github.com/user-attachments/assets/29cec14e-3789-4362-b920-213c65f76956)
