### PR TITLE
Fix images UX

### DIFF
--- a/examples/getting_started/2_Pipeline.ipynb
+++ b/examples/getting_started/2_Pipeline.ipynb
@@ -106,7 +106,7 @@
     "from holoviews.operation.datashader import datashade\n",
     "hv.extension(\"bokeh\")\n",
     "\n",
-    "datashade(hv.Points(df))"
+    "datashade(hv.Points(df)).opts(width=700, height=700)"
    ]
   },
   {

--- a/examples/getting_started/3_Interactivity.ipynb
+++ b/examples/getting_started/3_Interactivity.ipynb
@@ -127,7 +127,11 @@
    "source": [
     "hv.output(backend=\"matplotlib\")\n",
     "agg = ds.Canvas().points(df,'x','y')\n",
-    "hd.datashade(points)  +  hd.shade(hv.Image(agg)) + hv.RGB(np.array(tf.shade(agg).to_pil()), bounds=(-10,-10,10,10))"
+    "(\n",
+    "hd.datashade(points) +\n",
+    "hd.shade(hv.Image(agg)) +\n",
+    "hv.RGB(np.array(tf.shade(agg).to_pil()), bounds=(-10,-10,10,10))\n",
+    ").opts(fig_size=40)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #1395 

This PR fixes the remaining two issues in #1395 

- [x] from a UI perspective, make the holoviews image the same size as the first one, and center the first one

![image](https://github.com/user-attachments/assets/22a23b2e-c57d-4b8c-ac10-75288c91de5b)

Note that centering the first image was not possible from my end as it is centered in the local notebooks but moved to the left in the built HTML files.

- [x] fix scroll of images UX
![image](https://github.com/user-attachments/assets/bfc690ce-130d-4d84-9fd7-dbc8d6115aa0)
