### PR TITLE
fix: Propagate NotImplementedError for mode

### DIFF
--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1782,14 +1782,17 @@ class mode(Reduction):
         return dshape(Option(ct.float64))
 
     @staticmethod
-    def _append(x, y, agg):
+    @ngjit
+    def _append(x, y, agg, field):
         raise NotImplementedError("mode is currently implemented only for rasters")
 
     @staticmethod
+    @ngjit
     def _combine(aggs):
         raise NotImplementedError("mode is currently implemented only for rasters")
 
     @staticmethod
+    @ngjit
     def _finalize(bases, **kwargs):
         raise NotImplementedError("mode is currently implemented only for rasters")
 


### PR DESCRIPTION
Propagate the NotImplementedError as discussed in https://github.com/holoviz/datashader/issues/1435. 

``` python-traceback
❯ python example.py
Traceback (most recent call last):
  File "/home/shh/projects/holoviz/repos/datashader/example.py", line 16, in <module>
    mesh = cvs.quadmesh(ds, x="x", y="y", agg=dsh.reductions.mode("foo"))
  File "/home/shh/projects/holoviz/repos/datashader/datashader/core.py", line 885, in quadmesh
    return bypixel(source, self, glyph, agg)
  File "/home/shh/projects/holoviz/repos/datashader/datashader/core.py", line 1351, in bypixel
    return bypixel.pipeline(source, schema, canvas, glyph, agg, antialias=antialias)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/datashader/utils.py", line 118, in __call__
    return lk[typ](head, *rest, **kwargs)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/datashader/data_libraries/xarray.py", line 28, in xarray_pipeline
    return glyph_dispatch(
        glyph, xr_ds, schema, canvas, summary, antialias=antialias, cuda=cuda)
  File "/home/shh/projects/holoviz/repos/datashader/datashader/utils.py", line 121, in __call__
    return lk[cls](head, *rest, **kwargs)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/datashader/data_libraries/pandas.py", line 59, in default
    extend(bases, source, x_st + y_st, x_range + y_range)
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/datashader/glyphs/quadmesh.py", line 672, in extend
    do_extend(
    ~~~~~~~~~^
        plot_height, plot_width, xs, ys, *aggs_and_cols
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/shh/projects/holoviz/repos/datashader/datashader/reductions.py", line 1787, in _append
    raise NotImplementedError("mode is currently implemented only for rasters")
NotImplementedError: mode is currently implemented only for rasters
```