### PR TITLE
Fix rendering viewport fully contained in one cell

### DIFF
--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -193,10 +193,10 @@ class QuadMeshRectilinear(_QuadMeshLike):
             # An interval [xscaled[i], xscaled[i+1]] overlaps [0,1] if:
             # max(xscaled[i], xscaled[i+1]) >= 0 and min(xscaled[i], xscaled[i+1]) <= 1
             # This handles both ascending and descending coordinate orders
-            xinds = np.where((np.maximum(xscaled[1:], xscaled[:-1]) >= 0) &
-                           (np.minimum(xscaled[1:], xscaled[:-1]) <= 1))[0]
-            yinds = np.where((np.maximum(yscaled[1:], yscaled[:-1]) >= 0) &
-                           (np.minimum(yscaled[1:], yscaled[:-1]) <= 1))[0]
+            xin0, xin1 = xscaled >= 0, xscaled <= 1
+            yin0, yin1 = yscaled >= 0, yscaled <= 1
+            xinds = np.where((xin0[:-1] | xin0[1:]) & (xin1[:-1] | xin1[1:]))[0]
+            yinds = np.where((yin0[:-1] | yin0[1:]) & (yin1[:-1] | yin1[1:]))[0]
 
 
             if len(xinds) == 0 or len(yinds) == 0:

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -190,14 +190,11 @@ class QuadMeshRectilinear(_QuadMeshLike):
                 yscaled = (y_mapper2(y_breaks) - y0) / yspan
 
             # Find intervals that overlap the canvas bounds [0,1]
-            # An interval [xscaled[i], xscaled[i+1]] overlaps [0,1] if:
-            # max(xscaled[i], xscaled[i+1]) >= 0 and min(xscaled[i], xscaled[i+1]) <= 1
             # This handles both ascending and descending coordinate orders
             xin0, xin1 = xscaled >= 0, xscaled <= 1
             yin0, yin1 = yscaled >= 0, yscaled <= 1
-            xinds = np.where((xin0[:-1] | xin0[1:]) & (xin1[:-1] | xin1[1:]))[0]
-            yinds = np.where((yin0[:-1] | yin0[1:]) & (yin1[:-1] | yin1[1:]))[0]
-
+            xinds, = np.where((xin0[:-1] | xin0[1:]) & (xin1[:-1] | xin1[1:]))
+            yinds, = np.where((yin0[:-1] | yin0[1:]) & (yin1[:-1] | yin1[1:]))
 
             if len(xinds) == 0 or len(yinds) == 0:
                 # Nothing to do

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -189,8 +189,16 @@ class QuadMeshRectilinear(_QuadMeshLike):
             else:
                 yscaled = (y_mapper2(y_breaks) - y0) / yspan
 
-            xinds = np.where((xscaled >= 0) & (xscaled <= 1))[0]
-            yinds = np.where((yscaled >= 0) & (yscaled <= 1))[0]
+            # Find intervals that overlap the canvas bounds [0,1]
+            # An interval [xscaled[i], xscaled[i+1]] overlaps [0,1] if:
+            # max(xscaled[i], xscaled[i+1]) >= 0 and min(xscaled[i], xscaled[i+1]) <= 1
+            # This handles both ascending and descending coordinate orders
+            xinds = np.where((np.maximum(xscaled[1:], xscaled[:-1]) >= 0) &
+                           (np.minimum(xscaled[1:], xscaled[:-1]) <= 1))[0]
+            yinds = np.where((np.maximum(yscaled[1:], yscaled[:-1]) >= 0) &
+                           (np.minimum(yscaled[1:], yscaled[:-1]) <= 1))[0]
+
+
             if len(xinds) == 0 or len(yinds) == 0:
                 # Nothing to do
                 return


### PR DESCRIPTION
Disclaimer: generated by Claude, and this one I haven't spent the time to really wrap my head around it

-----

Closes #1438

The QuadMeshRectilinear glyph was incorrectly checking if coordinate break points were within canvas bounds, instead of checking if coordinate intervals overlap the canvas bounds. This caused quadmesh to return all NaN values when coordinate centers were outside the canvas but intervals still overlapped.

🤖 Generated with [Claude Code](https://claude.ai/code)