### PR TITLE
fix: Improve `compute_chunksize` for 

### DIFF
--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -179,13 +179,19 @@ def compute_chunksize(src, w, h, chunksize=None, max_mem=None):
     chunksize : tuple(int, int)
         Size of the output chunks.
     """
+    sh, sw = src.shape
+    height_fraction, width_fraction = sh / h, sw / w
+    # For downsampling, use smaller chunks to reduce memory usage
+    if chunksize is None and (w < sw or h < sh):
+        src_chunks = src.chunksize
+        new_chunk_h = max(32, int(src_chunks[0] / height_fraction))
+        new_chunk_w = max(32, int(src_chunks[1] / width_fraction))
+        chunksize = (new_chunk_h, new_chunk_w)
+
     start_chunksize = src.chunksize if chunksize is None else chunksize
     if max_mem is None:
         return start_chunksize
 
-    sh, sw = src.shape
-    height_fraction = float(sh)/h
-    width_fraction = float(sw)/w
     ch, cw = start_chunksize
     dim = True
     nbytes = src.dtype.itemsize


### PR DESCRIPTION
Previously, the following code would, depending on the dask version, either kill the process or kill my computer. 

I haven't done any profiling to see if this affects performance, but at least it doesn't crash my computer anymore. If it does, we can maybe move the functionality into `resample_2d_distributed`.

``` python
import numpy as np
import dask.array as da
import datashader as ds
import xarray as xr
import dask

print(dask.__version__)

# create large dask array
N = 100_000
dask_array = da.random.random((N, N), chunks=(1000, 1000))  # .compute()
# convert to dasked xarray
dask_xarray = xr.DataArray(
    dask_array,
    dims=["x", "y"],
    coords={"x": np.arange(N), "y": np.arange(N)},
    name="example_data",  # Name of the data variable
)
# create plot using Datashader
arr = ds.Canvas(plot_height=300, plot_width=300).raster(dask_xarray)
arr.compute()
```