### PR TITLE
fix: Warn if dask is installed without pyarrow

### DIFF
--- a/datashader/data_libraries/__init__.py
+++ b/datashader/data_libraries/__init__.py
@@ -1,18 +1,30 @@
-from . import pandas, xarray  # noqa (API import)
+from importlib.util import find_spec
+from warnings import warn
 
-try:
-    import dask as _dask  # noqa (Test dask installed)
-    from . import dask    # noqa (API import)
-except ImportError:
-    pass
+from . import pandas, xarray
 
-try:
-    import cudf as _cudf  # noqa (Test cudf installed)
-    import cupy as _cupy  # noqa (Test cupy installed)
-    from . import cudf    # noqa (API import)
 
-    import dask_cudf as _dask_cudf  # noqa (Test dask_cudf installed)
-    from . import dask_cudf         # noqa (API import)
+if find_spec("dask"):
+    if not find_spec("pyarrow"):
+        warn(
+            "dask requires pyarrow to work with datashader.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    else:
+        from . import dask
 
-except Exception:
-    pass
+if find_spec("cudf") and find_spec("cupy"):
+    from . import cudf
+
+    if find_spec("dask_cudf"):
+        from . import dask_cudf
+
+
+__all__ = (
+    "pandas",
+    "xarray",
+    "dask",
+    "cudf",
+    "dask_cudf",
+)


### PR DESCRIPTION
Fixes https://github.com/holoviz/datashader/pull/1448#issuecomment-3264898482

I'm not sure if this would be too annoying, but I couldn't think of a better way to do it. 

``` python
❯ python -c "import dask.dataframe"
Traceback (most recent call last):
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/dask/_compatibility.py", line 114, in import_optional_dependency
    module = importlib.import_module(name)
  File "/home/shh/.local/conda/envs/holoviz/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pyarrow'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import dask.dataframe
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/dask/dataframe/__init__.py", line 24, in <module>
    from dask.dataframe import backends, dispatch
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/dask/dataframe/backends.py", line 14, in <module>
    from dask.dataframe._compat import PANDAS_GE_220, is_any_real_numeric_dtype
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/dask/dataframe/_compat.py", line 11, in <module>
    import_optional_dependency("pyarrow")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/dask/_compatibility.py", line 117, in import_optional_dependency
    raise ImportError(msg) from err
ImportError: Missing optional dependency 'pyarrow'.  Use pip or conda to install pyarrow.
```



``` python
❯ python example_dask_crash.py
/home/shh/projects/holoviz/repos/datashader/example_dask_crash.py:3: RuntimeWarning: dask requires pyarrow to work with datashader.
  import datashader as ds
Traceback (most recent call last):
  File "/home/shh/projects/holoviz/repos/datashader/example_dask_crash.py", line 20, in <module>
    arr = ds.Canvas(plot_height=300, plot_width=300).raster(dask_xarray)
  File "/home/shh/projects/holoviz/repos/datashader/datashader/core.py", line 1155, in raster
    data = resample_2d(source_window, **kwargs)
  File "/home/shh/projects/holoviz/repos/datashader/datashader/resampling.py", line 347, in resample_2d
    resampled = _resample_2d(src, mask, use_mask, ds_method, us_method,
                             fill_value, mode_rank, x_offset, y_offset, out)
  File "/home/shh/projects/holoviz/repos/datashader/datashader/resampling.py", line 499, in _resample_2d
    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
                                 ~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/numba/core/dispatcher.py", line 424, in _compile_for_args
    error_rewrite(e, 'typing')
    ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/datashader/.venv/lib/python3.13/site-packages/numba/core/dispatcher.py", line 365, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
non-precise type pyobject
During: typing of argument at /home/shh/projects/holoviz/repos/datashader/datashader/resampling.py (488)

File "datashader/resampling.py", line 488:
def _get_fill_value(fill_value, src, out):
    <source elided>

@ngjit
^

During: Pass nopython_type_inference

This error may have been caused by the following argument(s):
- argument 0: Cannot determine Numba type of <class 'dask.array.core.Array'>

```