### PR TITLE
fix: Support `dask.array` without `dask.dataframe`

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -19,9 +19,13 @@ from . import reductions as rd
 
 try:
     import dask.dataframe as dd
+except ImportError:
+    dd = None
+
+try:
     import dask.array as da
 except ImportError:
-    dd, da = None, None
+    da = None
 
 try:
     import cudf


### PR DESCRIPTION
Superseeds https://github.com/holoviz/datashader/pull/1452, much simpler fix, we just need to separate the `dask.dataframe` and `dask.array` imports. 

``` python
import numpy as np
import dask.array as da
import datashader as ds
import xarray as xr
import dask

print(dask.__version__)

# create large dask array
N = 10_000
dask_array = da.random.random((N, N), chunks=(1000, 1000))  # .compute()
# convert to dasked xarray
dask_xarray = xr.DataArray(
    dask_array,
    dims=["x", "y"],
    coords={"x": np.arange(N), "y": np.arange(N)},
    name="example_data",  # Name of the data variable
)
# create plot using Datashader
arr = ds.Canvas(plot_height=300, plot_width=300).raster(dask_xarray)
```

``` bash
❯ uv pip list
Package            Version
------------------ ----------------------------
certifi            2025.8.3
charset-normalizer 3.4.3
click              8.2.1
cloudpickle        3.1.1
colorcet           3.1.0
dask               2025.7.0
datashader         0.18.2.post1.dev8+g9a6015524
fsspec             2025.9.0
idna               3.10
llvmlite           0.44.0
locket             1.0.0
multipledispatch   1.0.0
numba              0.61.2
numpy              2.2.6
packaging          25.0
pandas             2.3.2
param              2.2.1
partd              1.4.2
pyct               0.5.0
python-dateutil    2.9.0.post0
pytz               2025.2
pyyaml             6.0.2
requests           2.32.5
scipy              1.16.1
six                1.17.0
toolz              1.0.0
tzdata             2025.2
urllib3            2.5.0
xarray             2025.9.0
```

<img width="1458" height="865" alt="image" src="https://github.com/user-attachments/assets/9373b07e-b719-4820-b977-1d55e67f31a6" />
