### PR TITLE
test(benchmark): Add seed and make dask single-threaded

### DIFF
--- a/datashader/tests/benchmarks/test_layout.py
+++ b/datashader/tests/benchmarks/test_layout.py
@@ -29,4 +29,4 @@ def edges():
 @pytest.mark.parametrize('layout', [random_layout, circular_layout, forceatlas2_layout])
 @pytest.mark.benchmark(group="layout")
 def test_layout(benchmark, nodes, edges, layout):
-    benchmark(layout, nodes, edges)
+    benchmark(layout, nodes, edges, seed=1)

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,7 +96,7 @@ pytest-xdist = "*"
 [feature.test-unit-task.tasks] # So it is not showing up in the test-gpu environment
 test-unit = 'pytest datashader -n logical --dist loadgroup'
 test-unit-nojit = { cmd = 'pytest datashader -k "not test_tiles" -n logical --dist loadgroup', env = { NUMBA_DISABLE_JIT = '1' } }
-test-benchmark = 'pytest datashader/tests --benchmark --codspeed'
+test-benchmark = { cmd = 'pytest datashader/tests --benchmark --codspeed', env = { DASK_SCHEDULER = "single-threaded" } }
 
 [feature.test.dependencies]
 bokeh_sampledata = "*"
@@ -138,7 +138,7 @@ rmm = { version = "*", channel = "rapidsai" }
 
 [feature.test-gpu.tasks]
 test-gpu = "python -m pytest datashader/tests -n logical --dist loadgroup --gpu"
-test-benchmark = 'pytest datashader/tests --benchmark --gpu --codspeed'
+test-benchmark = { cmd = 'pytest datashader/tests --gpu --benchmark --codspeed', env = { DASK_SCHEDULER = "single-threaded" } }
 
 # =============================================
 # =================== DOCS ====================


### PR DESCRIPTION
It could be the cause of this flakiness. 