### PR TITLE
test: Move to actions/cache/{restore,save}

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,11 +122,10 @@ jobs:
         with:
           environments: ${{ matrix.environment }}
       - name: Restore cached hypothesis directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: .hypothesis/
           key: cache-hypothesis
-          enableCrossOsArchive: true
       - name: Test Unit
         run: |
           pixi run -e ${{ matrix.environment }} test-unit $COV
@@ -139,6 +138,12 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Save hypothesis directory
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .hypothesis/
+          key: cache-hypothesis
 
   core_test_suite:
     name: core:${{ matrix.environment }}:${{ matrix.os }}


### PR DESCRIPTION
I removed the save-always feature yesterday due to this warning, but I only removed it; this adds the functionality back. 

<img width="1800" height="138" alt="image" src="https://github.com/user-attachments/assets/23fc940e-5f01-44e6-85cf-eb5b201fc8f7" />

https://github.com/actions/cache/tree/main/save#always-save-cache