### PR TITLE
Fix bug in QuadMeshRectilinear

### DIFF
--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -218,26 +218,13 @@ class QuadMeshRectilinear(_QuadMeshLike):
                 yscaled = yscaled[::-1]
                 xr_ds = xr_ds.isel({y_name: slice(None, None, -1)})
 
-            xm0 = max(np.searchsorted(xscaled, 0, 'right') - 1, 0)
+            xm0 = max(np.searchsorted(xscaled, 0, "right") - 1, 0)
             xm1 = np.searchsorted(xscaled, 1, "left")
-            ym0 = max(np.searchsorted(yscaled, 0, 'right') - 1, 0)
+            ym0 = max(np.searchsorted(yscaled, 0, "right") - 1, 0)
             ym1 = np.searchsorted(yscaled, 1, "left")
 
-            if xm0 == xm1:
-                xm1 += 1
-            if ym0 == ym1:
-                ym1 += 1
-
-            # xin0, xin1 = xscaled >= 0, xscaled <= 1
-            # yin0, yin1 = yscaled >= 0, yscaled <= 1
-            # xinds, = np.where((xin0[:-1] | xin0[1:]) & (xin1[:-1] | xin1[1:]))
-            # yinds, = np.where((yin0[:-1] | yin0[1:]) & (yin1[:-1] | yin1[1:]))
-            # if len(xinds) == 0 or len(yinds) == 0:
-            #     # Nothing to do
-            #     return
-
-            # xm0, xm1 = xinds.min(), xinds.max() + 2
-            # ym0, ym1 = yinds.min(), yinds.max() + 2
+            if xm0 == xm1 or ym0 == ym1:
+                return
 
             plot_height, plot_width = aggs[0].shape[:2]
 

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -942,16 +942,22 @@ def test_rectilinear_extra_padding():
 
     # make sure canvas lines up with cell edges
     cvs = ds.Canvas(256, 256, x_range=(-70, -53.5), y_range=(17.5, 43))
+
     # insert nans along the border and a value in the center so the data
     # that is valid for the canvas is
-    # [
-    #    np.nan, np.nan, np.nan
-    #    np.nan,   10  , np.nan
-    #    np.nan, np.nan, np.nan
-    # ]
     da.data[:, [3, 5]] = np.nan
     da.data[[2, 5], :] = np.nan
     da.data[3, 4] = 10
+    expected_data = np.array([
+           [np.nan, np.nan, np.nan],
+           [np.nan,   10  , np.nan],
+           [np.nan, np.nan, np.nan],
+    ])
+    np.testing.assert_array_equal(
+        da.sel(x=slice(-70, -53.5), y=slice(17.5, 43)).data,
+        expected_data,
+    )
+
     actual = cvs.quadmesh(da, x="x", y="y")
     assert actual.isel(x=0).isnull().all().item()
     assert actual.isel(x=-1).isnull().all().item()


### PR DESCRIPTION
Fixes a rendering bug in QuadmeshRectilinear.  I think this was introduced in https://github.com/holoviz/datashader/pull/1442

### before (notice the thin lines)

<img width="1489" height="827" alt="image" src="https://github.com/user-attachments/assets/ff8bb5e6-9b56-44a6-b49c-2d92fb35cd97" />


### after
<img width="1489" height="827" alt="image" src="https://github.com/user-attachments/assets/ca5814e0-1aac-4203-96c5-e04282fb571c" />
